### PR TITLE
Add a HOST environment variable to configure production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,4 +86,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.hosts = [ENV['HOST']]
 end


### PR DESCRIPTION
Rails has a feature that prevents DNS rebinding and `Host` header
attacks. It is disabled by default on production.

This change enables feature when the environment variable `HOST` is
present.
