### PR TITLE
Use new GOV.UK Design System link styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,4 @@
+$govuk-global-styles: true;
+$govuk-new-link-styles: true;
+
 @use 'govuk-frontend/govuk/all';


### PR DESCRIPTION
Source:

https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-new-link-styles

Also make GOV.UK styles global (for all `p` and basic elements).