### PR TITLE
Add a confirmation page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  def start; end
+  def helpdesk_request_submitted
+    @trn_request = TrnRequest.find_by(id: session[:trn_request_id])
+    redirect_to root_url unless @trn_request
+  end
+
+  def start
+    @trn_request = TrnRequest.new
+  end
 end

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class TrnRequestsController < ApplicationController
+  def create
+    @trn_request = TrnRequest.create
+    session[:trn_request_id] = @trn_request.id
+    redirect_to helpdesk_request_submitted_url
+  end
+end

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class TrnRequest < ApplicationRecord
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title>Find a lost teacher reference number (TRN)</title>
+    <title><%= [yield(:page_title).presence, 'Find a lost teacher reference number (TRN)'].compact.join(' - ') %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/pages/helpdesk_request_submitted.html.erb
+++ b/app/views/pages/helpdesk_request_submitted.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title, 'Information Received' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(
+      title_text: 'Information received',
+      text: 'We’ll send your TRN by email or get in touch to ask for more information',
+      classes: %w[govuk-!-margin-bottom-6]
+    ) %>
+    <h2 class="govuk-heading-m">What happens next?</h2>
+    <p class='govuk-body'>
+      You’ll get an email with your TRN if we find a match. Otherwise, we’ll be in touch to ask for more information.
+    </p>
+    <p class='govuk-body'>
+      We aim to respond in 5 working days.
+    </p>
+    <h2 class="govuk-heading-m">For urgent requests, call the Teaching Regulation Agency</h2>
+    <p class="govuk-body">
+      Give the helpdesk your request number: <%= @trn_request.id %>
+    </p>
+    <ul class="govuk-list">
+      <li>Telephone: 020 7593 5394</li>
+      <li>Monday to Friday, 9am to 5pm (except public holidays)</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -43,10 +43,14 @@
       Have your National Insurance number ready, as we’ll ask for this.
     </p>
 
-    <%= govuk_start_button(
-      text: "Start now",
-      href: "#",
-      classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
+    <%= form_with model: @trn_request do %>
+      <button class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-9 govuk-button--start" data-module="govuk-button">
+        Start now
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        </svg>
+      </button>
+    <% end %>
 
     <h2 class="govuk-heading-m">Other ways to find your TRN</h2>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,10 @@
 Rails.application.routes.draw do
   root to: redirect('/start')
 
-  get '/health', to: proc { [200, {}, ['success']] }
+  resources :trn_requests, only: [:create]
 
+  get '/health', to: proc { [200, {}, ['success']] }
+  get '/helpdesk-request-submitted', to: 'pages#helpdesk_request_submitted'
   get '/start', to: 'pages#start'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20220215085120_create_trn_requests.rb
+++ b/db/migrate/20220215085120_create_trn_requests.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class CreateTrnRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :trn_requests, &:timestamps
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2022_02_15_085120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
+
+  create_table 'trn_requests', force: :cascade do |t|
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+  end
 end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'TRN requests', type: :system do
+  it 'completing a request' do
+    given_i_am_on_the_home_page
+    when_i_try_to_go_straight_to_the_confirmation_page
+    then_i_am_redirected_to_home
+    when_i_press_the_start_button
+    then_i_see_the_confirmation_page
+  end
+
+  private
+
+  def given_i_am_on_the_home_page
+    visit root_path
+  end
+
+  def then_i_am_redirected_to_home
+    expect(page).to have_current_path(start_path)
+    expect(page).to have_content('Find a lost teacher reference number (TRN)')
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page.driver.browser.current_title).to start_with('Information Received')
+    expect(page).to have_content('Information received')
+  end
+
+  def when_i_press_the_start_button
+    click_on 'Start now'
+  end
+
+  def when_i_try_to_go_straight_to_the_confirmation_page
+    visit helpdesk_request_submitted_path
+  end
+end


### PR DESCRIPTION
When a person has completed a request for a TRN, we want to display a
confirmation screen that provides details of what to expect next.

The reference design is [here](https://find-a-lost-trn.herokuapp.com/helpdesk-request-submitted).

`TrnRequest` is intended to be a record of the request. Currently, we
have no details to store on it. This can be iterated on as we progress.

For now, we simply use the ID of the record as a reference number for
person who made the request.

I opted to store this ID in the session so that the confirmation screen
has access to it.

This also introduces a way to add a prefix to the page title from a
view.

Simply use the `content_for` method using `:page_title` as the target
and it will get injected into the page title in the <head> of the
document.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
