### PR TITLE
Add the Check your answers page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,5 +22,13 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Metrics/AbcSize:
+  Exclude:
+    - spec/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
 Metrics/MethodLength:
   Enabled: false

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -1,8 +1,35 @@
 # frozen_string_literal: true
 class TrnRequestsController < ApplicationController
   def create
-    @trn_request = TrnRequest.create
+    @trn_request =
+      TrnRequest.create(
+        date_of_birth: '1955-11-12',
+        email: 'email@example.com',
+        name: 'Jane Doe',
+        ni_number: 'QQ123456C',
+      )
     session[:trn_request_id] = @trn_request.id
+    redirect_to check_answers_url
+  end
+
+  def show
+    redirect_to root_url unless trn_request
+  end
+
+  def update
+    redirect_to root_url unless trn_request
+
+    trn_request.update(trn_request_params)
     redirect_to helpdesk_request_submitted_url
+  end
+
+  private
+
+  def trn_request
+    @trn_request ||= TrnRequest.find_by(id: session[:trn_request_id])
+  end
+
+  def trn_request_params
+    params.require(:trn_request).permit(:answers_checked)
   end
 end

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -1,3 +1,8 @@
 # frozen_string_literal: true
 class TrnRequest < ApplicationRecord
+  def answers_checked=(value)
+    return unless value
+
+    self.checked_at = Time.current
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,7 @@
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }, text: "This is a new service – your feedback will help us to improve it. ") %>
+      <%= govuk_back_link(href: yield(:back_link_url)) unless yield(:back_link_url).blank? %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= yield %>
       </main>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -43,7 +43,7 @@
       Have your National Insurance number ready, as we’ll ask for this.
     </p>
 
-    <%= form_with model: @trn_request do %>
+    <%= form_with model: @trn_request, url: trn_request_path do %>
       <button class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-9 govuk-button--start" data-module="govuk-button">
         Start now
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -1,0 +1,36 @@
+<% content_for :page_title, 'Check your answers' %>
+<%= content_for :back_link_url, start_url %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Check your answers</h1>
+    <p class="govuk-body">We will send your TRN to <%= @trn_request.email %> if we find one matching your details.</p>
+
+    <%= govuk_summary_list(actions: false) do |summary_list|
+          summary_list.row do |row|
+            row.key { 'Email address' }
+            row.value { @trn_request.email }
+          end
+
+          summary_list.row do |row|
+            row.key { 'Name' }
+            row.value { @trn_request.name }
+          end
+
+          summary_list.row do |row|
+            row.key { 'Date of birth' }
+            row.value { @trn_request.date_of_birth.to_fs(:long_ordinal_uk) }
+          end
+
+          summary_list.row do |row|
+            row.key { 'National Insurance number' }
+            row.value { @trn_request.ni_number }
+          end
+        end
+    %>
+
+    <%= form_with model: @trn_request, method: :put do |f| %>
+      <%= f.hidden_field :answers_checked, value: true %>
+      <%= f.govuk_submit 'Submit', prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+Date::DATE_FORMATS[:long_ordinal_uk] = '%d %B %Y'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@
 Rails.application.routes.draw do
   root to: redirect('/start')
 
-  resources :trn_requests, only: [:create]
+  resource :trn_request, only: %i[create show update]
 
+  get '/check-answers', to: 'trn_requests#show'
   get '/health', to: proc { [200, {}, ['success']] }
   get '/helpdesk-request-submitted', to: 'pages#helpdesk_request_submitted'
   get '/start', to: 'pages#start'

--- a/db/migrate/20220216125137_add_details_to_trn_request.rb
+++ b/db/migrate/20220216125137_add_details_to_trn_request.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class AddDetailsToTrnRequest < ActiveRecord::Migration[7.0]
+  def change
+    change_table :trn_requests, bulk: true do |t|
+      t.datetime :checked_at
+      t.date :date_of_birth
+      t.string :email
+      t.string :name
+      t.string :ni_number
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_15_085120) do
+ActiveRecord::Schema[7.0].define(version: 2022_02_16_125137) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
   create_table 'trn_requests', force: :cascade do |t|
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.datetime 'checked_at', precision: nil
+    t.date 'date_of_birth'
+    t.string 'email'
+    t.string 'name'
+    t.string 'ni_number'
   end
 end

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe TrnRequest, type: :model do
+  describe '#answers_checked=' do
+    before { trn_request.answers_checked = value }
+
+    let(:trn_request) { described_class.new }
+
+    context 'when true' do
+      let(:value) { true }
+
+      it 'stores the current timestamp on checked_at' do
+        expect(trn_request.checked_at).to be_present
+      end
+    end
+
+    context 'when false' do
+      let(:value) { false }
+
+      it 'does not set checked_at' do
+        expect(trn_request.checked_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -4,10 +4,18 @@ require 'rails_helper'
 RSpec.describe 'TRN requests', type: :system do
   it 'completing a request' do
     given_i_am_on_the_home_page
+    when_i_press_the_start_button
+    then_i_see_the_check_answers_page
+    when_i_press_the_submit_button
+    then_i_see_the_confirmation_page
+  end
+
+  it 'trying to skip steps' do
+    given_i_am_on_the_home_page
     when_i_try_to_go_straight_to_the_confirmation_page
     then_i_am_redirected_to_home
-    when_i_press_the_start_button
-    then_i_see_the_confirmation_page
+    when_i_try_to_go_to_the_check_answers_page
+    then_i_am_redirected_to_home
   end
 
   private
@@ -26,11 +34,29 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('Information received')
   end
 
+  def then_i_see_the_check_answers_page
+    expect(page).to have_current_path('/check-answers')
+    expect(page.driver.browser.current_title).to start_with('Check your answers')
+    expect(page).to have_content('Check your answers')
+    expect(page).to have_content('email@example.com')
+    expect(page).to have_content('Jane Doe')
+    expect(page).to have_content('QQ123456C')
+    expect(page).to have_content('12 November 1955')
+  end
+
   def when_i_press_the_start_button
     click_on 'Start now'
   end
 
+  def when_i_press_the_submit_button
+    click_on 'Submit'
+  end
+
   def when_i_try_to_go_straight_to_the_confirmation_page
     visit helpdesk_request_submitted_path
+  end
+
+  def when_i_try_to_go_to_the_check_answers_page
+    visit trn_request_path
   end
 end


### PR DESCRIPTION
After providing all the details required to find a lost TRN, there is a
screen that displays the answers given and presents an opportunity to
modify them before submitting the request.

The reference design for this screen is [here](https://find-a-lost-trn.herokuapp.com/check-answers) and the
Trello ticket is [here](https://trello.com/c/cVaeihfv).

Assumptions:
* the column types for the fields have been set to what appears to be
  the correct type. This could change as we implement the relevant
  screens.
* the `checked_at` field is a placeholder to represent the submit action
  by the user. This could be replaced by a finite state machine in
  future to better represent the state of the TRN request.
* the back link goes to /start as that also happens to be the previous
  screen. Once we add more of the flow, this will change.
* the TRN request values are hard-coded until we implement the screens
  to capture them.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
