### PR TITLE
Add migrate rake task for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ ENV RAILS_ENV=production \
 RUN yarn build && yarn build:css
 RUN bundle exec rails assets:precompile
 
-CMD bundle exec rails server -b 0.0.0.0
+CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions \
+    bundle exec rails server -b 0.0.0.0

--- a/lib/tasks/ignore_concurrent_migration_exceptions.rake
+++ b/lib/tasks/ignore_concurrent_migration_exceptions.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+namespace :db do
+  namespace :migrate do
+    desc 'db:migrate but ignores ActiveRecord::ConcurrentMigrationError errors'
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task['db:migrate'].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end


### PR DESCRIPTION
### Context


[This is stolen from Apply](https://github.com/DFE-Digital/apply-for-teacher-training/blob/1ae993f586ecb81278296a99adf56953e7086c40/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake).

It's a migrate script that is meant to be run in production when multiple machines are deployed to concurrently. To stop the deploy from failing due to `ConcurrentMigrationError`, it swallows these errors.

### Changes proposed in this pull request

Add `db:migrate:ignore_concurrent_migration_exceptions`.

### Guidance to review

:ship:

### Checklist

- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally