### PR TITLE
Add NI number to the request flow

### DIFF
--- a/app/controllers/ni_number_controller.rb
+++ b/app/controllers/ni_number_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+class NiNumberController < ApplicationController
+  def new; end
+
+  def create
+    trn_request.update(has_ni_number: trn_request_params[:has_ni_number])
+    redirect_to trn_request.has_ni_number? ? ni_number_url : itt_provider_url
+  end
+
+  def edit; end
+
+  def update
+    if ni_number.update(ni_number_params)
+      redirect_to ni_number.email? ? check_answers_url : itt_provider_url
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def ni_number
+    @ni_number ||= NiNumber.new(trn_request_id: session[:trn_request_id])
+  end
+  helper_method :ni_number
+
+  def ni_number_params
+    params.require(:ni_number).permit(:ni_number)
+  end
+
+  def trn_request
+    @trn_request ||= TrnRequest.find_by(id: session[:trn_request_id]) || TrnRequest.new
+  end
+  helper_method :trn_request
+
+  def trn_request_params
+    params.require(:trn_request).permit(:has_ni_number, :ni_number)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def back_link_url(trn_request)
+    referer = controller.request.env['HTTP_REFERER']
+    return check_answers_path if referer&.include?('check-answers') || trn_request&.email?
+
+    start_path
+  end
+
+  def pretty_ni_number(ni_number)
+    ni_number.scan(/..?/).join(' ').upcase
+  end
 end

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-module EmailHelper
-  def back_link_url(trn_request)
-    referer = controller.request.env['HTTP_REFERER']
-    return check_answers_path if referer&.include?('check-answers') || trn_request&.email?
-
-    start_path
-  end
-end

--- a/app/models/ni_number.rb
+++ b/app/models/ni_number.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class NiNumber
+  include ActiveModel::Model
+
+  attr_accessor :trn_request_id
+
+  validates :ni_number, format: { with: /\A[a-z]{2}[0-9]{6}[a-d]{1}\Z/i }, presence: true
+
+  delegate :email?, :ni_number, to: :trn_request
+
+  def ni_number=(value)
+    trn_request.ni_number = value&.gsub(/\s/, '')
+  end
+
+  def update(params = {})
+    self.ni_number = params[:ni_number]
+    return false if invalid?
+
+    trn_request.update(params)
+  end
+
+  private
+
+  def trn_request
+    @trn_request ||= TrnRequest.find_by(id: trn_request_id) || TrnRequest.new
+  end
+end

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class TrnRequest < ApplicationRecord
-  validates :email, valid_for_notify: true, if: %i[itt_provider_answered? email]
-  validates :itt_provider_enrolled, presence: true, inclusion: { in: [true, false] }
+  validates :email, valid_for_notify: true, if: %i[itt_provider_answered? ni_number_answered?]
+  validates :itt_provider_enrolled, presence: true, inclusion: { in: [true, false] }, if: %i[ni_number_answered?]
   validates :itt_provider_name, allow_blank: true, length: { maximum: 255 }
 
   def answers_checked=(value)
@@ -12,5 +12,11 @@ class TrnRequest < ApplicationRecord
 
   def itt_provider_answered?
     !itt_provider_enrolled.nil? && !itt_provider_enrolled_was.nil?
+  end
+
+  def ni_number_answered?
+    return ni_number.present? if has_ni_number
+
+    !has_ni_number.nil? && !has_ni_number_was.nil?
   end
 end

--- a/app/views/ni_number/edit.html.erb
+++ b/app/views/ni_number/edit.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title, "#{'Error: ' if ni_number.errors.any?}What is your National Insurance number?" %>
+<% content_for :back_link_url, back_link_url(ni_number) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: ni_number, url: ni_number_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field(:ni_number, 
+            label: { size: 'xl', text: 'What is your National Insurance number?' },
+            hint: { text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.' },
+            class: 'govuk-input--width-10',
+            required: true
+          ) %>
+
+      <%= govuk_details(summary_text: "I don’t know my National Insurance number") do %>
+        <p class="govuk-body">
+          You can <a href='https://www.gov.uk/lost-national-insurance-number'>find a lost National Insurance number</a>.
+        </p>
+
+        <p class="govuk-body">
+          Or you can continue without it, but we are less likely to find your TRN.
+        </p>
+
+        <%= govuk_button_link_to 'Continue without it', itt_provider_path, secondary: true %>
+      <% end %>
+
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/ni_number/new.html.erb
+++ b/app/views/ni_number/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title, "Do you have a National Insurance number?" %>
+<% content_for :back_link_url, back_link_url(trn_request) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: trn_request, url: have_ni_number_path, method: :post do |f| %>
+      <% options = [OpenStruct.new(label: 'Yes', value: 1), OpenStruct.new(label: 'No', value: 0)] %>
+      <%= f.govuk_collection_radio_buttons(:has_ni_number, 
+            options, 
+            :value, 
+            :label, 
+            legend: { size: 'xl', text: 'Do you have a National Insurance number?' }
+          ) %>
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -43,7 +43,7 @@
       Have your National Insurance number ready, as we’ll ask for this.
     </p>
 
-    <%= govuk_start_button(text: 'Start now', href: itt_provider_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
+    <%= govuk_start_button(text: 'Start now', href: have_ni_number_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
 
     <h2 class="govuk-heading-m">Other ways to find your TRN</h2>
 

--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -12,6 +12,11 @@
           key: { text: 'Teacher training provider' }, 
           value: { text: @trn_request.itt_provider_name.presence || 'Not provided' }, 
           actions: [{ href: itt_provider_path, visually_hidden_text: 'itt_provider' }]
+        },
+        { 
+          key: { text: 'National Insurance number' }, 
+          value: { text: @trn_request.has_ni_number? ? pretty_ni_number(@trn_request.ni_number) : 'Not provided' }, 
+          actions: [{ href: have_ni_number_path, visually_hidden_text: 'ni_number' }]
         }
     ] %>
     <%= govuk_summary_list(rows: rows) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,3 +33,12 @@ en:
   hello: 'Hello world'
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com
+
+  activemodel:
+    errors:
+      models:
+        ni_number:
+          attributes:
+            ni_number:
+              blank: Enter a National Insurance number in the correct format
+              invalid: Enter a National Insurance number in the correct format

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,14 @@ Rails.application.routes.draw do
   get '/check-answers', to: 'trn_requests#show'
   get '/email', to: 'email#edit'
   patch '/email', to: 'email#update'
+  get '/have-ni-number', to: 'ni_number#new'
+  post '/have-ni-number', to: 'ni_number#create'
   get '/health', to: proc { [200, {}, ['success']] }
   get '/helpdesk-request-submitted', to: 'pages#helpdesk_request_submitted'
   get '/itt-provider', to: 'itt_providers#edit'
   patch '/itt-provider', to: 'itt_providers#update'
+  get '/ni-number', to: 'ni_number#edit'
+  patch '/ni-number', to: 'ni_number#update'
   get '/start', to: 'pages#start'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20220223110719_add_ni_number_to_trn_request.rb
+++ b/db/migrate/20220223110719_add_ni_number_to_trn_request.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class AddNiNumberToTrnRequest < ActiveRecord::Migration[7.0]
+  def change
+    change_table :trn_requests, bulk: true do |t|
+      t.boolean :has_ni_number
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_21_101530) do
+ActiveRecord::Schema[7.0].define(version: 2022_02_23_110719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -24,5 +24,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_21_101530) do
     t.string 'ni_number'
     t.boolean 'itt_provider_enrolled'
     t.string 'itt_provider_name'
+    t.boolean 'has_ni_number'
   end
 end

--- a/spec/models/ni_number_spec.rb
+++ b/spec/models/ni_number_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe NiNumber, type: :model do
+  subject(:ni_number_form) { described_class.new }
+
+  specify do
+    expect(ni_number_form).to validate_presence_of(:ni_number).with_message(
+      'Enter a National Insurance number in the correct format',
+    )
+  end
+
+  shared_examples 'an invalid ni_number' do
+    it { is_expected.to be_invalid }
+
+    it 'adds an incorrect format error message' do
+      ni_number_form.validate
+      expect(ni_number_form.errors[:ni_number]).to include('Enter a National Insurance number in the correct format')
+    end
+  end
+
+  context 'when the ni_number is too short' do
+    before { ni_number_form.ni_number = 'QQ12345C' }
+
+    it_behaves_like 'an invalid ni_number'
+  end
+
+  context 'when the ni_number is missing 2 letters at the start' do
+    before { ni_number_form.ni_number = 'Q1234567C' }
+
+    it_behaves_like 'an invalid ni_number'
+  end
+
+  context 'when the ni_number is missing a letter at the end' do
+    before { ni_number_form.ni_number = 'QQ1234567' }
+
+    it_behaves_like 'an invalid ni_number'
+  end
+
+  context 'when the ni_number has a letter at the end out of the range' do
+    before { ni_number_form.ni_number = 'QQ123456E' }
+
+    it_behaves_like 'an invalid ni_number'
+  end
+
+  context 'when the ni_number is too long' do
+    before { ni_number_form.ni_number = 'QQ1234567C' }
+
+    it_behaves_like 'an invalid ni_number'
+  end
+
+  context 'when the ni_number is blank' do
+    before { ni_number_form.ni_number = '' }
+
+    it_behaves_like 'an invalid ni_number'
+  end
+
+  context 'when the ni_number has the correct characters but in a strange format' do
+    valid_numbers_in_strange_formats = [
+      'QQ 12 34 56 C',
+      ' QQ 12 34 56 C',
+      'QQ12 34 56 C ',
+      'QQ 1234 56 C',
+      'QQ 12 3456 C',
+      'QQ 12 34 56C',
+      'QQ1234 56 C',
+      'QQ 123456 C',
+      'QQ 12 3456C',
+      'QQ123456C',
+      'QQ 1 2 3 4 5 6 C',
+      'qq123456c',
+    ]
+
+    valid_numbers_in_strange_formats.each do |ni_number|
+      specify do
+        ni_number_form.ni_number = ni_number
+        expect(ni_number_form).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -2,7 +2,11 @@
 require 'rails_helper'
 
 RSpec.describe TrnRequest, type: :model do
-  subject(:trn_request) { described_class.new }
+  subject(:trn_request) do
+    described_class.new(email: 'test@example.com', has_ni_number: false, itt_provider_enrolled: 'no')
+  end
+
+  it { is_expected.to be_valid }
 
   describe '#answers_checked=' do
     before { trn_request.answers_checked = value }
@@ -24,28 +28,19 @@ RSpec.describe TrnRequest, type: :model do
     end
   end
 
-  context 'when the ITT provider enrollment question has been asked' do
-    subject(:trn_request) { described_class.create(itt_provider_enrolled: true) }
+  context 'when the ITT provider enrollment and NI number questions have been asked' do
+    subject(:trn_request) { described_class.create(has_ni_number: false, itt_provider_enrolled: true) }
 
-    context 'when the email is blank' do
-      before { trn_request.email = '' }
-
-      it { is_expected.to be_invalid }
-
-      it 'displays a blank email error' do
-        trn_request.validate
-        expect(trn_request.errors.messages[:email]).to include(
-          'Enter an email address in the correct format, like name@example.com',
-        )
-      end
-    end
-
-    context 'when the email is not blank' do
-      before { trn_request.email = 'test@example.com' }
-
-      it { is_expected.to be_valid }
+    it 'validates the presence of the email address' do
+      expect(trn_request).to validate_presence_of(:email).with_message(
+        'Enter an email address in the correct format, like name@example.com',
+      )
     end
   end
 
-  it { is_expected.to validate_length_of(:itt_provider_name).is_at_most(255) }
+  context 'when the NI number question has been asked' do
+    before { trn_request.has_ni_number = false }
+
+    it { is_expected.to validate_length_of(:itt_provider_name).is_at_most(255) }
+  end
 end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'TRN requests', type: :system do
   it 'completing a request' do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    then_i_see_the_ni_page
+    when_i_choose_no_ni_number
     then_i_see_the_itt_provider_page
     when_i_choose_no_itt_provider
     then_i_see_the_email_page
@@ -20,6 +22,12 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_home_page
     when_i_try_to_go_to_the_check_answers_page
     then_i_see_the_home_page
+  end
+
+  it 'changing my NI number' do
+    given_i_have_completed_a_trn_request
+    when_i_change_my_ni_number
+    then_i_see_the_updated_ni_number
   end
 
   it 'changing my email address' do
@@ -52,6 +60,10 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_itt_provider_page
     when_i_press_back
     then_i_see_the_check_answers_page
+    when_i_press_change_ni_number
+    then_i_see_the_ni_page
+    when_i_press_back
+    then_i_see_the_check_answers_page
   end
 
   it 'refreshing the page and pressing back' do
@@ -77,6 +89,8 @@ RSpec.describe 'TRN requests', type: :system do
   def given_i_have_completed_a_trn_request
     visit root_path
     click_on 'Start'
+    choose 'No', visible: false
+    click_on 'Continue'
     choose 'No', visible: false
     click_on 'Continue'
     fill_in 'Your email address', with: 'email@example.com'
@@ -120,8 +134,18 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('Have you ever been enrolled in initial teacher training in England or Wales?')
   end
 
+  def then_i_see_the_ni_page
+    expect(page).to have_current_path('/have-ni-number')
+    expect(page.driver.browser.current_title).to start_with('Do you have a National Insurance number?')
+    expect(page).to have_content('Do you have a National Insurance number?')
+  end
+
   def then_i_see_the_updated_email_address
     expect(page).to have_content('new@example.com')
+  end
+
+  def then_i_see_the_updated_ni_number
+    expect(page).to have_content('QQ 12 34 56 C')
   end
 
   def when_i_am_on_the_check_answers_page
@@ -148,7 +172,20 @@ RSpec.describe 'TRN requests', type: :system do
     click_on 'Continue'
   end
 
+  def when_i_change_my_ni_number
+    click_on 'Change ni_number'
+    choose 'Yes', visible: false
+    click_on 'Continue'
+    fill_in 'What is your National Insurance number?', with: 'QQ123456C'
+    click_on 'Continue'
+  end
+
   def when_i_choose_no_itt_provider
+    choose 'No', visible: false
+    click_on 'Continue'
+  end
+
+  def when_i_choose_no_ni_number
     choose 'No', visible: false
     click_on 'Continue'
   end
@@ -164,6 +201,10 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_press_change_itt_provider
     click_on 'Change itt_provider'
+  end
+
+  def when_i_press_change_ni_number
+    click_on 'Change ni_number'
   end
 
   def when_i_press_the_start_button


### PR DESCRIPTION
The designs for the TRN request flow have steps to collect an NI number.

This is an optional step and split into 2 screens. The first to
determine if the person knows their NI number and the second to allow
them to enter it.

I tried a different approach to validating the TrnRequest. Rather than
adding a conditional validation to the `TrnRequest` class, I created a
form object, `NiNumber` that gets used to specifically add the
`ni_number` value and makes it easier to conditionally validate that
value.

It means the object representing the record doesn't need to know about
rules related to the flow.

This makes this particular object easier to understand. It comes at the
cost of spreading validation rules across multiple other objects.

At this stage, I think the trade-off is appropriate.

Assumptions:
* we validate the format of the number but have no way of checking if it
  is a real national insurance number.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
