### PR TITLE
Add a date of birth question

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - config/routes.rb
 
 Metrics/MethodLength:
   Enabled: false

--- a/app/controllers/date_of_birth_controller.rb
+++ b/app/controllers/date_of_birth_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class DateOfBirthController < ApplicationController
+  def edit; end
+
+  def update
+    if date_of_birth_form.update(date_of_birth_params)
+      session[:trn_request_id] = date_of_birth_form.trn_request.id
+      redirect_to date_of_birth_form.email? ? check_answers_url : have_ni_number_url
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def date_of_birth_form
+    @date_of_birth_form ||= DateOfBirthForm.new(trn_request: trn_request)
+  end
+  helper_method :date_of_birth_form
+
+  def date_of_birth_params
+    params.require(:date_of_birth_form).permit('date_of_birth(3i)', 'date_of_birth(2i)', 'date_of_birth(1i)')
+  end
+
+  def trn_request
+    @trn_request ||= TrnRequest.find_or_initialize_by(id: session[:trn_request_id])
+  end
+end

--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -7,7 +7,6 @@ class EmailController < ApplicationController
   def update
     @trn_request = TrnRequest.find_by(id: session[:trn_request_id]) || TrnRequest.new
     if @trn_request.update(email: email_params[:email])
-      session[:trn_request_id] = @trn_request.id
       redirect_to check_answers_url
     else
       render :edit

--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+class DateOfBirthForm
+  include ActiveModel::Model
+
+  attr_accessor :trn_request
+  attr_writer :date_of_birth
+
+  validates :date_of_birth,
+            presence: true,
+            inclusion: {
+              in: Date.new(1900, 1, 1)..16.years.ago.to_date,
+              if: :date_of_birth,
+            }
+
+  delegate :email?, to: :trn_request, allow_nil: true
+
+  def date_of_birth
+    @date_of_birth ||= trn_request&.date_of_birth
+  end
+
+  def update(params = {})
+    date_fields = [params['date_of_birth(1i)'], params['date_of_birth(2i)'], params['date_of_birth(3i)']]
+    begin
+      self.date_of_birth = Date.new(*date_fields.map(&:to_i)) unless date_fields.any?(&:blank?)
+    rescue Date::Error
+      errors.add(:date_of_birth, I18n.t('activemodel.errors.models.date_of_birth_form.attributes.date_of_birth.blank'))
+      return false
+    end
+
+    return false if invalid?
+
+    trn_request.update!(date_of_birth: date_of_birth)
+  end
+end

--- a/app/views/date_of_birth/edit.html.erb
+++ b/app/views/date_of_birth/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "#{'Error: ' if date_of_birth_form.errors.any?}Your date of birth" %>
+<% content_for :back_link_url, back_link_url(date_of_birth_form) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: date_of_birth_form, url: date_of_birth_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_date_field(
+            :date_of_birth, 
+            date_of_birth: true, 
+            legend: { size: 'xl', text: 'Your date of birth' }, 
+            hint: { text: 'For example, 27 3 1987' } 
+          )
+      %>
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -43,7 +43,7 @@
       Have your National Insurance number ready, as we’ll ask for this.
     </p>
 
-    <%= govuk_start_button(text: 'Start now', href: have_ni_number_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
+    <%= govuk_start_button(text: 'Start now', href: date_of_birth_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
 
     <h2 class="govuk-heading-m">Other ways to find your TRN</h2>
 

--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -7,6 +7,11 @@
     <p class="govuk-body">We will send your TRN to <%= @trn_request.email %> if we find one matching your details.</p>
 
     <% rows = [
+        { 
+          key: { text: 'Date of birth' }, 
+          value: { text: @trn_request.date_of_birth? ? @trn_request.date_of_birth.to_fs(:long_ordinal_uk) : 'Not given' }, 
+          actions: [{ href: date_of_birth_path, visually_hidden_text: 'date of birth' }]
+        },
         { key: { text: 'Email address '},
           value: { text: @trn_request.email },
           actions: [{ href: email_path, visually_hidden_text: 'email address' }]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,11 @@ en:
   activemodel:
     errors:
       models:
+        date_of_birth_form:
+          attributes:
+            date_of_birth:
+              blank: Enter your date of birth
+              inclusion: You must be 16 or over to use this service
         has_ni_number_form:
           attributes:
             has_ni_number:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   end
 
   get '/check-answers', to: 'trn_requests#show'
+  get '/date-of-birth', to: 'date_of_birth#edit'
+  patch '/date-of-birth', to: 'date_of_birth#update'
   get '/email', to: 'email#edit'
   patch '/email', to: 'email#update'
   get '/have-ni-number', to: 'ni_number#new'

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DateOfBirthForm, type: :model do
+  it { is_expected.to validate_presence_of(:date_of_birth).with_message('Enter your date of birth') }
+
+  describe '#update' do
+    subject(:update) { date_of_birth_form.update(params) }
+
+    let(:date_of_birth_form) { described_class.new(trn_request: trn_request) }
+    let(:params) { { 'date_of_birth(1i)' => '2000', 'date_of_birth(2i)' => '01', 'date_of_birth(3i)' => '01' } }
+    let(:trn_request) { TrnRequest.new }
+
+    it 'updates the date of birth' do
+      update
+      expect(date_of_birth_form.date_of_birth).to eq(Date.new(2000, 1, 1))
+    end
+
+    context 'without a valid date' do
+      let(:params) { { 'date_of_birth(1i)' => '2000', 'date_of_birth(2i)' => '02', 'date_of_birth(3i)' => '30' } }
+
+      it 'does not update the date of birth' do
+        update
+        expect(date_of_birth_form.date_of_birth).to be_nil
+      end
+    end
+
+    context 'with a blank date' do
+      let(:params) { { 'date_of_birth(1i)' => '', 'date_of_birth(2i)' => '', 'date_of_birth(3i)' => '' } }
+
+      it { is_expected.to be_falsy }
+
+      it 'adds an error' do
+        update
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Enter your date of birth'])
+      end
+    end
+
+    context 'when the date is in the future' do
+      let(:params) do
+        { 'date_of_birth(1i)' => 1.year.from_now.year, 'date_of_birth(2i)' => '01', 'date_of_birth(3i)' => '01' }
+      end
+
+      it { is_expected.to be_falsy }
+
+      it 'adds an error' do
+        update
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['You must be 16 or over to use this service'])
+      end
+    end
+
+    context 'with an invalid date' do
+      let(:params) { { 'date_of_birth(1i)' => '', 'date_of_birth(2i)' => '1', 'date_of_birth(3i)' => '1' } }
+
+      it { is_expected.to be_falsy }
+
+      it 'adds an error' do
+        update
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Enter your date of birth'])
+      end
+    end
+
+    context 'with a date less than 16 years ago' do
+      let(:params) do
+        {
+          'date_of_birth(1i)' => 15.years.ago.year,
+          'date_of_birth(2i)' => Time.zone.today.month,
+          'date_of_birth(3i)' => Time.zone.today.day,
+        }
+      end
+
+      it { is_expected.to be_falsy }
+
+      it 'adds an error' do
+        update
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['You must be 16 or over to use this service'])
+      end
+    end
+
+    context 'with a date before 1900' do
+      let(:params) { { 'date_of_birth(1i)' => '1899', 'date_of_birth(2i)' => '1', 'date_of_birth(3i)' => '1' } }
+
+      it { is_expected.to be_falsy }
+
+      it 'adds an error' do
+        update
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['You must be 16 or over to use this service'])
+      end
+    end
+  end
+end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe 'TRN requests', type: :system do
   it 'completing a request' do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    then_i_see_the_date_of_birth_page
+
+    when_i_complete_my_date_of_birth
     then_i_see_the_have_ni_page
 
     when_i_choose_no
@@ -38,13 +41,20 @@ RSpec.describe 'TRN requests', type: :system do
   it 'entering the NI number' do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    then_i_see_the_date_of_birth_page
+
+    when_i_complete_my_date_of_birth
     then_i_see_the_have_ni_page
+
     when_i_press_continue
     then_i_see_the_ni_missing_error
+
     when_i_choose_yes_to_ni_number
     then_i_see_the_ni_number_page
+
     when_i_press_continue
     then_i_see_the_ni_number_missing_error
+
     when_i_enter_a_valid_ni_number
     then_i_see_the_itt_provider_page
   end
@@ -80,6 +90,13 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_updated_itt_provider
   end
 
+  it 'changing my date of birth' do
+    given_i_have_completed_a_trn_request
+    when_i_press_change_date_of_birth
+    then_i_see_the_date_of_birth_page
+    and_the_date_of_birth_is_prepopulated
+  end
+
   it 'pressing back' do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
@@ -87,10 +104,23 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_home_page
   end
 
+  context 'when the user has reached the have NI question' do
+    it 'pressing back' do
+      given_i_am_on_the_home_page
+      when_i_press_the_start_button
+      when_i_complete_my_date_of_birth
+      then_i_see_the_have_ni_page
+
+      when_i_press_back
+      then_i_see_the_date_of_birth_page
+    end
+  end
+
   context 'when the user has reached the email question' do
     it 'pressing back' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
+      when_i_complete_my_date_of_birth
       and_i_choose_no
       and_i_press_continue
       then_i_see_the_itt_provider_page
@@ -108,6 +138,7 @@ RSpec.describe 'TRN requests', type: :system do
     it 'pressing back' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
+      when_i_complete_my_date_of_birth
       and_i_choose_no
       and_i_press_continue
       then_i_see_the_itt_provider_page
@@ -147,6 +178,7 @@ RSpec.describe 'TRN requests', type: :system do
   it 'ITT provider validations' do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    when_i_complete_my_date_of_birth
     then_i_see_the_ni_page
 
     when_i_choose_no
@@ -163,6 +195,12 @@ RSpec.describe 'TRN requests', type: :system do
 
   private
 
+  def and_the_date_of_birth_is_prepopulated
+    expect(page).to have_field('Day', with: '1')
+    expect(page).to have_field('Month', with: '1')
+    expect(page).to have_field('Year', with: '1980')
+  end
+
   def given_i_am_on_the_home_page
     visit root_path
   end
@@ -170,6 +208,7 @@ RSpec.describe 'TRN requests', type: :system do
   def given_i_have_completed_a_trn_request
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    when_i_complete_my_date_of_birth
     when_i_choose_no
     and_i_press_continue
     then_i_see_the_itt_provider_page
@@ -187,6 +226,8 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page.driver.browser.current_title).to start_with('Check your answers')
     expect(page).to have_content('Check your answers')
     expect(page).to have_content('email@example.com')
+    expect(page).to have_content('Date of birth')
+    expect(page).to have_content('01 January 1980')
   end
 
   def then_i_see_the_ni_missing_error
@@ -202,6 +243,12 @@ RSpec.describe 'TRN requests', type: :system do
   def then_i_see_the_confirmation_page
     expect(page.driver.browser.current_title).to start_with('Information Received')
     expect(page).to have_content('Information received')
+  end
+
+  def then_i_see_the_date_of_birth_page
+    expect(page).to have_current_path('/date-of-birth')
+    expect(page.driver.browser.current_title).to start_with('Your date of birth')
+    expect(page).to have_content('Your date of birth')
   end
 
   def then_i_see_the_email_page
@@ -268,6 +315,7 @@ RSpec.describe 'TRN requests', type: :system do
   def when_i_am_on_the_email_page
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    when_i_complete_my_date_of_birth
     when_i_choose_no_ni_number
     when_i_choose_no_itt_provider
   end
@@ -307,6 +355,13 @@ RSpec.describe 'TRN requests', type: :system do
     click_on 'Continue'
   end
 
+  def when_i_complete_my_date_of_birth
+    fill_in 'Day', with: '01'
+    fill_in 'Month', with: '01'
+    fill_in 'Year', with: '1980'
+    click_on 'Continue'
+  end
+
   def when_i_press_back
     click_on 'Back'
   end
@@ -321,6 +376,10 @@ RSpec.describe 'TRN requests', type: :system do
     fill_in 'Your email address', with: 'new@example.com'
   end
   alias_method :and_i_fill_in_my_new_email_address, :when_i_fill_in_my_new_email_address
+
+  def when_i_press_change_date_of_birth
+    click_on 'Change date of birth'
+  end
 
   def when_i_press_change_email
     click_on 'Change email address'


### PR DESCRIPTION
We want to collect a person's date of birth to help with finding their
lost TRN.

We're following guidance on dates from [this design system entry](https://design-system.service.gov.uk/patterns/dates/).

[Reference design](https://find-a-lost-trn.herokuapp.com/dob) and [Trello ticket](https://trello.com/c/qTIsoCgM/159-dob-page-date-of-birth-your-date-of-birth).

Validations are handled in a similar fashion to those for the national
insurance number. There is a form object that gets used by the
controller and view. It contains the validation logic and allows the
underlying model, `TrnRequest` to remain free from the complexity of the
order we present the questions in.

Assumptions:
* 16 years old is the lower range for the date of birth.
* people over 120 years old are unlikely to be using this service.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
