### PR TITLE
Add zendesk integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '3.0.3'
 
 gem 'bootsnap', require: false
 gem 'cssbundling-rails'
+gem 'gds_zendesk'
 gem 'govuk-components', '~> 3.0.3'
 gem 'govuk_design_system_formbuilder'
 gem 'govuk_markdown', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,12 +101,38 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    faraday (1.10.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     ferrum (0.11)
       addressable (~> 2.5)
       cliver (~> 0.3)
       concurrent-ruby (~> 1.1)
       websocket-driver (>= 0.6, < 0.8)
     foreman (0.87.2)
+    gds_zendesk (3.2.0)
+      null_logger (~> 0)
+      zendesk_api (~> 1.27)
     globalid (1.0.0)
       activesupport (>= 5.0)
     govuk-components (3.0.3)
@@ -121,11 +147,13 @@ GEM
     govuk_markdown (1.0.0)
       activesupport
       redcarpet
+    hashie (5.0.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.0.3)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
+    inflection (1.0.0)
     io-console (0.5.11)
     io-wait (0.2.1)
     irb (1.4.1)
@@ -144,6 +172,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.4.5)
+    multipart-post (2.1.1)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -164,6 +193,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
+    null_logger (0.0.1)
     parallel (1.21.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
@@ -249,6 +279,7 @@ GEM
     rubocop-rspec (2.9.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
     spring (4.0.0)
@@ -282,6 +313,12 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
+    zendesk_api (1.35.0)
+      faraday (>= 0.9.0, < 2.0.0)
+      hashie (>= 3.5.2, < 6.0.0)
+      inflection
+      mini_mime
+      multipart-post (~> 2.0)
 
 PLATFORMS
   arm64-darwin-21
@@ -295,6 +332,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   foreman (~> 0.87.2)
+  gds_zendesk
   govuk-components (~> 3.0.3)
   govuk_design_system_formbuilder
   govuk_markdown (~> 1.0)

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -8,6 +8,7 @@ class TrnRequestsController < ApplicationController
     redirect_to root_url unless trn_request
 
     trn_request.update(trn_request_params)
+    ZendeskService.create_ticket!(trn_request)
     redirect_to helpdesk_request_submitted_url
   end
 

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+class ZendeskService
+  def self.create_ticket!(trn_request)
+    return unless FeatureFlag.active?(:zendesk_integration)
+
+    begin
+      GDS_ZENDESK_CLIENT.ticket.create!(ticket_template(trn_request))
+    rescue ZendeskAPI::Error::RecordInvalid
+      raise CreateError, 'Could not create Zendesk ticket'
+    end
+  end
+
+  def self.ticket_template(trn_request)
+    {
+      subject: "[Find a lost TRN] Support request from #{trn_request.name}",
+      comment: {
+        value:
+          'A user has submitted a request to find their lost TRN. Their ' \
+            "information is:\n" \
+            "\nName: #{trn_request.name}" \
+            "\nDate of birth: #{trn_request.date_of_birth.strftime('%d %B %Y')}" \
+            "\nNI number: #{trn_request.ni_number || 'Not provided'}" \
+            "\nITT provider: #{trn_request.itt_provider_name || 'Not provided'}\n",
+      },
+    }
+  end
+
+  class CreateError < StandardError
+  end
+end

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -4,7 +4,7 @@ require 'gds_zendesk/dummy_client'
 
 GDS_ZENDESK_CLIENT =
   if Rails.env.development? || Rails.env.test?
-    GDSZendesk::DummyClient.new(logger: Rails.logger)
+    GDSZendesk::DummyClient.new(development_mode: true, logger: Rails.logger)
   else
     GDSZendesk::Client.new(
       token: ENV['ZENDESK_TOKEN'],

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'gds_zendesk/client'
+require 'gds_zendesk/dummy_client'
+
+GDS_ZENDESK_CLIENT =
+  if Rails.env.development? || Rails.env.test?
+    GDSZendesk::DummyClient.new(logger: Rails.logger)
+  else
+    GDSZendesk::Client.new(
+      token: ENV['ZENDESK_TOKEN'],
+      logger: Rails.logger,
+      url: 'https://teachingregulationagency.zendesk.com/api/v2/',
+    )
+  end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   root to: redirect('/start')
 
-  resource :trn_request, only: %i[show update] do
+  resource :trn_request, path: 'trn-request', only: %i[show update] do
     resource :email, controller: :email, only: %i[edit update]
   end
 

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ZendeskService do
+  let(:ticket_client) { GDS_ZENDESK_CLIENT.ticket }
+
+  describe '.ticket_template' do
+    it 'correctly formats a TRN request with no NI number' do
+      trn_request = TrnRequest.new(date_of_birth: 20.years.ago)
+
+      expect(described_class.ticket_template(trn_request)[:comment][:value]).to include('NI number: Not provided')
+    end
+
+    it 'correctly formats a TRN request with no ITT provider' do
+      trn_request = TrnRequest.new(date_of_birth: 20.years.ago)
+
+      expect(described_class.ticket_template(trn_request)[:comment][:value]).to include('ITT provider: Not provided')
+    end
+  end
+
+  context 'when feature flag is off' do
+    before { FeatureFlag.deactivate(:zendesk_integration) }
+
+    describe '.create_ticket!' do
+      it 'does not create a ticket' do
+        allow(ticket_client).to receive(:create!)
+        trn_request = TrnRequest.new
+
+        described_class.create_ticket!(trn_request)
+
+        expect(ticket_client).not_to have_received(:create!)
+      end
+    end
+  end
+
+  context 'when feature flag is on' do
+    before { FeatureFlag.activate(:zendesk_integration) }
+
+    describe '.create_ticket!' do
+      it 'creates a ticket' do
+        allow(ticket_client).to receive(:create!)
+        trn_request =
+          TrnRequest.new(
+            date_of_birth: 20.years.ago,
+            email: 'test@example.com',
+            has_ni_number: true,
+            itt_provider_enrolled: true,
+            itt_provider_name: 'Big SCITT',
+            name: 'Test User',
+            ni_number: 'QC123456A',
+          )
+
+        described_class.create_ticket!(trn_request)
+
+        expect(ticket_client).to have_received(:create!)
+          .once
+          .with(
+            {
+              subject: '[Find a lost TRN] Support request from Test User',
+              comment: {
+                value:
+                  'A user has submitted a request to find their lost ' \
+                    "TRN. Their information is:\n" \
+                    "\nName: Test User" \
+                    "\nDate of birth: #{20.years.ago.strftime('%d %B %Y')}" \
+                    "\nNI number: QC123456A" \
+                    "\nITT provider: Big SCITT\n",
+              },
+            },
+          )
+      end
+
+      it 'throws an error when it fails to create a ticket' do
+        trn_request =
+          TrnRequest.new(
+            date_of_birth: 20.years.ago,
+            email: 'test@example.com',
+            has_ni_number: true,
+            itt_provider_enrolled: true,
+            itt_provider_name: 'Big SCITT',
+            name: 'break_zendesk',
+            ni_number: 'QC123456A',
+          )
+
+        expect { described_class.create_ticket!(trn_request) }.to raise_error(ZendeskService::CreateError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Add `gds_zendesk` and use it at the end of the journey to create a Zendesk ticket on behalf of the user.

### Changes proposed in this pull request

Add an initializer and a service. If the Zendesk API fails, it currently raises an error which we don't catch in our controller. We have to replace that error with a background job to retry it later.

### Guidance to review

Review commit by commit.

Does the test read well or could it benefit from DRYing up with rspec sugar?

### Checklist

https://trello.com/c/xWruEyTV/204-zendesk-integration

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
