### PR TITLE
Fix link on ni number page

### DIFF
--- a/app/views/ni_number/edit.html.erb
+++ b/app/views/ni_number/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: ni_number, url: ni_number_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_field(:ni_number, 
+      <%= f.govuk_text_field(:ni_number,
             label: { size: 'xl', text: 'What is your National Insurance number?' },
             hint: { text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.' },
             class: 'govuk-input--width-10',
@@ -14,7 +14,7 @@
 
       <%= govuk_details(summary_text: "I don’t know my National Insurance number") do %>
         <p class="govuk-body">
-          You can <a href='https://www.gov.uk/lost-national-insurance-number'>find a lost National Insurance number</a>.
+          You can <a class="govuk-link" href='https://www.gov.uk/lost-national-insurance-number'>find a lost National Insurance number</a>.
         </p>
 
         <p class="govuk-body">


### PR DESCRIPTION
### Changes proposed in this pull request

Make it a correctly styled GOVUK link.

### Guidance to review

#### Before

![image](https://user-images.githubusercontent.com/1650875/156394346-0dd5dc3b-1086-4520-b5c7-dbc37f610a9e.png)

#### After

![image](https://user-images.githubusercontent.com/1650875/156394405-205df041-558c-49a0-a719-2539b26971aa.png)

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
