### PR TITLE
Update wording of NI number invalid error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,4 +41,4 @@ en:
           attributes:
             ni_number:
               blank: Enter a National Insurance number
-              invalid: Enter a National Insurance number
+              invalid: Enter a National Insurance number in the correct format

--- a/spec/models/ni_number_spec.rb
+++ b/spec/models/ni_number_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe NiNumber, type: :model do
 
     it 'adds an incorrect format error message' do
       ni_number_form.validate
-      expect(ni_number_form.errors[:ni_number]).to include('Enter a National Insurance number')
+      expect(ni_number_form.errors[:ni_number]).to include('Enter a National Insurance number in the correct format')
     end
   end
 


### PR DESCRIPTION
Should have left the "invalid" one as before.