### PR TITLE
Rework provider validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,7 @@ Metrics/MethodLength:
 RSpec/ExampleLength:
   Exclude:
     - spec/**/*
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - spec/**/*

--- a/app/controllers/itt_providers_controller.rb
+++ b/app/controllers/itt_providers_controller.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 class IttProvidersController < ApplicationController
   def edit
-    trn_request
+    @itt_provider_form = IttProviderForm.new(trn_request: trn_request).assign_form_values
   end
 
   def update
-    if trn_request.update(itt_provider_params)
+    @itt_provider_form = IttProviderForm.new(itt_provider_params)
+    if @itt_provider_form.save
       redirect_to trn_request.email.blank? ? email_url : check_answers_url
     else
       render :edit
@@ -15,7 +16,10 @@ class IttProvidersController < ApplicationController
   private
 
   def itt_provider_params
-    params.require(:trn_request).permit(:itt_provider_enrolled, :itt_provider_name)
+    params
+      .require(:itt_provider_form)
+      .permit(:itt_provider_enrolled, :itt_provider_name)
+      .merge(trn_request: trn_request)
   end
 
   def trn_request

--- a/app/models/itt_provider_form.rb
+++ b/app/models/itt_provider_form.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class IttProviderForm
+  include ActiveModel::Model
+
+  attr_accessor :trn_request, :itt_provider_enrolled, :itt_provider_name
+
+  validates :itt_provider_enrolled, inclusion: { in: %w[true false] }
+  validates :itt_provider_name, presence: true, length: { maximum: 255 }, if: -> { itt_provider_enrolled == 'true' }
+
+  def save
+    return false if invalid?
+
+    trn_request.update(itt_provider_enrolled: itt_provider_enrolled, itt_provider_name: itt_provider_name)
+  end
+
+  def assign_form_values
+    self.itt_provider_enrolled = trn_request.itt_provider_enrolled
+    self.itt_provider_name = trn_request.itt_provider_name
+    self
+  end
+end

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 class TrnRequest < ApplicationRecord
   validates :email, valid_for_notify: true, if: %i[itt_provider_answered? ni_number_answered?]
-  validates :itt_provider_enrolled,
-            inclusion: {
-              in: [true, false],
-            },
-            if: %i[ni_number_answered? itt_provider_enrolled_changed?]
-  validates :itt_provider_name, allow_blank: true, length: { maximum: 255 }
   validates :has_ni_number, inclusion: { in: [true, false] }
 
   def answers_checked=(value)

--- a/app/views/itt_providers/edit.html.erb
+++ b/app/views/itt_providers/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :page_title, "#{'Error: ' if @trn_request.errors.any?}Have you ever been enrolled in initial teacher training in England or Wales?" %>
+<% content_for :page_title, "#{'Error: ' if @itt_provider_form.errors.any?}Have you ever been enrolled in initial teacher training in England or Wales?" %>
 <%= content_for :back_link_url, back_link_url(@trn_request) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @trn_request, url: itt_provider_path, method: :patch do |f| %>
+    <%= form_with model: @itt_provider_form, url: itt_provider_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset(:itt_provider_enrolled, legend: { size: 'xl', text: 'Have you ever been enrolled in initial teacher training in England or Wales?' }) do %>
         <%= f.govuk_radio_button :itt_provider_enrolled, true, label: { text: 'Yes' } do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,14 @@ en:
             ni_number:
               blank: Enter a National Insurance number
               invalid: Enter a National Insurance number in the correct format
+        itt_provider_form:
+          attributes:
+            itt_provider_enrolled:
+              inclusion: Tell us if you’ve been enrolled in initial teacher
+                training
+            itt_provider_name:
+              blank: Enter your school, university or other training provider
+              too_long: Enter a school that is less than 255 letters long
 
   activerecord:
     errors:

--- a/spec/models/itt_provider_form_spec.rb
+++ b/spec/models/itt_provider_form_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe IttProviderForm, type: :model do
+  describe 'validations' do
+    specify do
+      form = described_class.new
+      expect(form).to validate_presence_of(:itt_provider_enrolled).with_message(
+        'Tell us if you’ve been enrolled in initial teacher training',
+      )
+    end
+
+    specify do
+      form = described_class.new(itt_provider_enrolled: 'true')
+      expect(form).to validate_presence_of(:itt_provider_name).with_message(
+        'Enter your school, university or other training provider',
+      )
+    end
+
+    specify do
+      form = described_class.new(itt_provider_enrolled: 'true')
+      expect(form).to validate_length_of(:itt_provider_name)
+        .is_at_most(255)
+        .with_message('Enter a school that is less than 255 letters long')
+    end
+  end
+
+  describe '#save' do
+    context 'when itt_provider_enrolled is missing' do
+      it 'returns false' do
+        form = described_class.new
+
+        expect(form.save).to eq false
+      end
+    end
+
+    context 'when form data is correct' do
+      it 'saves the model' do
+        form =
+          described_class.new(
+            trn_request: TrnRequest.new,
+            itt_provider_enrolled: 'true',
+            itt_provider_name: 'Big SCITT',
+          )
+
+        form.save
+
+        expect(form.trn_request.itt_provider_enrolled).to eq true
+        expect(form.trn_request.itt_provider_name).to eq 'Big SCITT'
+      end
+    end
+  end
+end

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -37,10 +37,4 @@ RSpec.describe TrnRequest, type: :model do
       )
     end
   end
-
-  context 'when the NI number question has been asked' do
-    before { trn_request.has_ni_number = false }
-
-    it { is_expected.to validate_length_of(:itt_provider_name).is_at_most(255) }
-  end
 end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -6,12 +6,22 @@ RSpec.describe 'TRN requests', type: :system do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
     then_i_see_the_have_ni_page
-    when_i_choose_no_ni_number
+
+    when_i_choose_no
+    then_i_see_the_ni_page
+
+    when_i_choose_no
+    and_i_press_continue
     then_i_see_the_itt_provider_page
-    when_i_choose_no_itt_provider
+
+    when_i_choose_no
+    and_i_press_continue
     then_i_see_the_email_page
-    when_i_submit_my_email_address
+
+    when_i_fill_in_my_email_address
+    and_i_press_continue
     then_i_see_the_check_answers_page
+
     when_i_press_the_submit_button
     then_i_see_the_confirmation_page
   end
@@ -20,6 +30,7 @@ RSpec.describe 'TRN requests', type: :system do
     given_i_am_on_the_home_page
     when_i_try_to_go_straight_to_the_confirmation_page
     then_i_see_the_home_page
+
     when_i_try_to_go_to_the_check_answers_page
     then_i_see_the_home_page
   end
@@ -40,19 +51,28 @@ RSpec.describe 'TRN requests', type: :system do
 
   it 'changing my NI number' do
     given_i_have_completed_a_trn_request
-    when_i_change_my_ni_number
+    when_i_press_change_ni_number
+    and_i_choose_yes
+    and_i_press_continue
+    and_i_fill_in_my_ni_number
+    and_i_press_continue
     then_i_see_the_updated_ni_number
   end
 
   it 'changing my email address' do
     given_i_have_completed_a_trn_request
-    when_i_change_my_email
+    when_i_press_change_email
+    and_i_fill_in_my_new_email_address
+    and_i_press_continue
     then_i_see_the_updated_email_address
   end
 
   it 'changing my ITT provider' do
     given_i_have_completed_a_trn_request
-    when_i_change_my_itt_provider
+    when_i_press_change_itt_provider
+    and_i_choose_yes
+    and_i_fill_in_my_itt_provider
+    and_i_press_continue
     then_i_see_the_updated_itt_provider
   end
 
@@ -67,9 +87,14 @@ RSpec.describe 'TRN requests', type: :system do
     it 'pressing back' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
-      when_i_choose_no_ni_number
-      when_i_choose_no_itt_provider
+      and_i_choose_no
+      and_i_press_continue
+      then_i_see_the_itt_provider_page
+
+      when_i_choose_no
+      and_i_press_continue
       then_i_see_the_email_page
+
       when_i_press_back
       then_i_see_the_itt_provider_page
     end
@@ -79,8 +104,10 @@ RSpec.describe 'TRN requests', type: :system do
     it 'pressing back' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
-      when_i_choose_no_ni_number
+      and_i_choose_no
+      and_i_press_continue
       then_i_see_the_itt_provider_page
+
       when_i_press_back
       then_i_see_the_ni_page
     end
@@ -107,6 +134,7 @@ RSpec.describe 'TRN requests', type: :system do
     given_i_have_completed_a_trn_request
     when_i_press_change_email
     then_i_see_the_email_page
+
     when_i_refresh_the_page
     and_i_press_back
     then_i_see_the_check_answers_page
@@ -121,9 +149,16 @@ RSpec.describe 'TRN requests', type: :system do
   def given_i_have_completed_a_trn_request
     given_i_am_on_the_home_page
     when_i_press_the_start_button
-    when_i_choose_no_ni_number
-    when_i_choose_no_itt_provider
-    when_i_submit_my_email_address
+    when_i_choose_no
+    and_i_press_continue
+    then_i_see_the_itt_provider_page
+
+    when_i_choose_no
+    and_i_press_continue
+    then_i_see_the_email_page
+
+    when_i_fill_in_my_email_address
+    and_i_press_continue
   end
 
   def then_i_see_the_check_answers_page
@@ -173,6 +208,12 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('Do you have a National Insurance number?')
   end
 
+  def then_i_see_the_ni_page
+    expect(page).to have_current_path('/have-ni-number')
+    expect(page.driver.browser.current_title).to start_with('Do you have a National Insurance number?')
+    expect(page).to have_content('Do you have a National Insurance number?')
+  end
+
   def then_i_see_the_ni_number_page
     expect(page).to have_current_path('/ni-number')
     expect(page.driver.browser.current_title).to start_with('What is your National Insurance number?')
@@ -202,38 +243,30 @@ RSpec.describe 'TRN requests', type: :system do
     when_i_choose_no_itt_provider
   end
 
-  def when_i_change_my_email
-    click_on 'Change email'
-    fill_in 'Your email address', with: 'new@example.com'
-    click_on 'Continue'
-  end
-
-  def when_i_change_my_itt_provider
-    click_on 'Change itt_provider'
-    expect(find_field('No', checked: true, visible: false)).to be_truthy
-    choose 'Yes', visible: false
+  def when_i_fill_in_my_itt_provider
     fill_in 'Your school, university or other training provider', with: 'Test ITT Provider', visible: false
-    click_on 'Continue'
   end
+  alias_method :and_i_fill_in_my_itt_provider, :when_i_fill_in_my_itt_provider
 
-  def when_i_change_my_ni_number
-    click_on 'Change ni_number'
-    expect(find_field('No', checked: true, visible: false)).to be_truthy
-    choose 'Yes', visible: false
-    click_on 'Continue'
+  def when_i_fill_in_my_ni_number
     fill_in 'What is your National Insurance number?', with: 'QQ123456C'
-    click_on 'Continue'
   end
+  alias_method :and_i_fill_in_my_ni_number, :when_i_fill_in_my_ni_number
 
-  def when_i_choose_no_itt_provider
+  def when_i_choose_no
     choose 'No', visible: false
-    click_on 'Continue'
   end
+  alias_method :and_i_choose_no, :when_i_choose_no
 
-  def when_i_choose_no_ni_number
-    choose 'No', visible: false
+  def when_i_choose_yes
+    choose 'Yes', visible: false
+  end
+  alias_method :and_i_choose_yes, :when_i_choose_yes
+
+  def when_i_press_continue
     click_on 'Continue'
   end
+  alias_method :and_i_press_continue, :when_i_press_continue
 
   def when_i_choose_yes_to_ni_number
     choose 'Yes', visible: false
@@ -249,6 +282,16 @@ RSpec.describe 'TRN requests', type: :system do
     click_on 'Back'
   end
   alias_method :and_i_press_back, :when_i_press_back
+
+  def when_i_fill_in_my_email_address
+    fill_in 'Your email address', with: 'email@example.com'
+  end
+  alias_method :and_i_fill_in_my_email_address, :when_i_fill_in_my_email_address
+
+  def when_i_fill_in_my_new_email_address
+    fill_in 'Your email address', with: 'new@example.com'
+  end
+  alias_method :and_i_fill_in_my_new_email_address, :when_i_fill_in_my_new_email_address
 
   def when_i_press_change_email
     click_on 'Change email'
@@ -276,11 +319,6 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_refresh_the_page
     page.driver.browser.refresh
-  end
-
-  def when_i_submit_my_email_address
-    fill_in 'Your email address', with: 'email@example.com'
-    click_on 'Continue'
   end
 
   def when_i_try_to_go_straight_to_the_confirmation_page

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe 'TRN requests', type: :system do
   it 'changing my NI number' do
     given_i_have_completed_a_trn_request
     when_i_press_change_ni_number
-    and_i_choose_yes
+    then_no_should_be_checked
+
+    when_i_choose_yes
     and_i_press_continue
     and_i_fill_in_my_ni_number
     and_i_press_continue
@@ -70,7 +72,9 @@ RSpec.describe 'TRN requests', type: :system do
   it 'changing my ITT provider' do
     given_i_have_completed_a_trn_request
     when_i_press_change_itt_provider
-    and_i_choose_yes
+    then_no_should_be_checked
+
+    when_i_choose_yes
     and_i_fill_in_my_itt_provider
     and_i_press_continue
     then_i_see_the_updated_itt_provider
@@ -251,6 +255,10 @@ RSpec.describe 'TRN requests', type: :system do
 
   def then_i_see_a_validation_error
     expect(page).to have_content('There is a problem')
+  end
+
+  def then_no_should_be_checked
+    expect(find_field('No', checked: true, visible: false)).to be_truthy
   end
 
   def when_i_am_on_the_check_answers_page

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -140,6 +140,23 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_check_answers_page
   end
 
+  it 'ITT provider validations' do
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
+    then_i_see_the_ni_page
+
+    when_i_choose_no
+    and_i_press_continue
+    then_i_see_the_itt_provider_page
+
+    when_i_press_continue
+    then_i_see_a_validation_error
+
+    when_i_choose_yes
+    and_i_press_continue
+    then_i_see_a_validation_error
+  end
+
   private
 
   def given_i_am_on_the_home_page
@@ -230,6 +247,10 @@ RSpec.describe 'TRN requests', type: :system do
 
   def then_i_see_the_updated_ni_number
     expect(page).to have_content('QQ 12 34 56 C')
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_content('There is a problem')
   end
 
   def when_i_am_on_the_check_answers_page


### PR DESCRIPTION
### Context

Fix the provider validations.

### Changes proposed in this pull request

Slightly refactor/reorganise the main system spec.

Add `binding.pry` for easier debugging.

The new `IttProviderForm` model introduced in this PR is probably an idiomatic example of how we should do the other form objects; if we agree on this implementation, we should follow-up by going back and refactoring `NiNumber` and Email validation to use a similar model.

### Guidance to review

Review commit by commit.

### Checklist

https://trello.com/c/9jqIgjZq

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
