### PR TITLE
Ensure the session ID is set correctly

### DIFF
--- a/app/controllers/itt_providers_controller.rb
+++ b/app/controllers/itt_providers_controller.rb
@@ -5,8 +5,7 @@ class IttProvidersController < ApplicationController
   end
 
   def update
-    if trn_request.update!(itt_provider_params)
-      session[:trn_request_id] = trn_request.id
+    if trn_request.update(itt_provider_params)
       redirect_to trn_request.email.blank? ? email_url : check_answers_url
     else
       render :edit
@@ -20,6 +19,6 @@ class IttProvidersController < ApplicationController
   end
 
   def trn_request
-    @trn_request ||= TrnRequest.find_by(id: session[:trn_request_id]) || TrnRequest.new
+    @trn_request ||= TrnRequest.find(session[:trn_request_id])
   end
 end

--- a/app/controllers/ni_number_controller.rb
+++ b/app/controllers/ni_number_controller.rb
@@ -3,8 +3,12 @@ class NiNumberController < ApplicationController
   def new; end
 
   def create
-    trn_request.update(has_ni_number: trn_request_params[:has_ni_number])
-    redirect_to trn_request.has_ni_number? ? ni_number_url : itt_provider_url
+    if trn_request.update(has_ni_number: trn_request_params[:has_ni_number])
+      session[:trn_request_id] = trn_request.id
+      redirect_to trn_request.has_ni_number? ? ni_number_url : itt_provider_url
+    else
+      render :new
+    end
   end
 
   def edit; end

--- a/app/models/ni_number.rb
+++ b/app/models/ni_number.rb
@@ -22,6 +22,6 @@ class NiNumber
   private
 
   def trn_request
-    @trn_request ||= TrnRequest.find_by(id: trn_request_id) || TrnRequest.new
+    @trn_request ||= TrnRequest.find(trn_request_id)
   end
 end

--- a/spec/models/ni_number_spec.rb
+++ b/spec/models/ni_number_spec.rb
@@ -2,7 +2,9 @@
 require 'rails_helper'
 
 RSpec.describe NiNumber, type: :model do
-  subject(:ni_number_form) { described_class.new }
+  subject(:ni_number_form) { described_class.new(trn_request_id: trn_request.id) }
+
+  let(:trn_request) { TrnRequest.create(has_ni_number: false) }
 
   specify do
     expect(ni_number_form).to validate_presence_of(:ni_number).with_message('Enter a National Insurance number')

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -43,27 +43,50 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   it 'pressing back' do
-    given_i_am_on_the_itt_provider_page
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
     when_i_press_back
     then_i_see_the_home_page
-    when_i_am_on_the_email_page
-    when_i_press_back
-    then_i_see_the_home_page
-    when_i_am_on_the_check_answers_page
-    when_i_press_back
-    then_i_see_the_home_page
-    when_i_try_to_go_to_the_check_answers_page
-    when_i_press_change_email
-    and_i_press_back
-    then_i_see_the_check_answers_page
-    when_i_press_change_itt_provider
-    then_i_see_the_itt_provider_page
-    when_i_press_back
-    then_i_see_the_check_answers_page
-    when_i_press_change_ni_number
-    then_i_see_the_ni_page
-    when_i_press_back
-    then_i_see_the_check_answers_page
+  end
+
+  context 'when the user has reached the email question' do
+    it 'pressing back' do
+      given_i_am_on_the_home_page
+      when_i_press_the_start_button
+      when_i_choose_no_ni_number
+      when_i_choose_no_itt_provider
+      then_i_see_the_email_page
+      when_i_press_back
+      then_i_see_the_home_page
+    end
+  end
+
+  context 'when the user has reached the ITT provider question' do
+    it 'pressing back' do
+      given_i_am_on_the_home_page
+      when_i_press_the_start_button
+      when_i_choose_no_ni_number
+      then_i_see_the_itt_provider_page
+      when_i_press_back
+      then_i_see_the_home_page
+    end
+  end
+
+  context 'when the user has reached the check answers page' do
+    it 'pressing back' do
+      given_i_have_completed_a_trn_request
+      when_i_press_change_email
+      and_i_press_back
+      then_i_see_the_check_answers_page
+      when_i_press_change_itt_provider
+      then_i_see_the_itt_provider_page
+      when_i_press_back
+      then_i_see_the_check_answers_page
+      when_i_press_change_ni_number
+      then_i_see_the_ni_page
+      when_i_press_back
+      then_i_see_the_check_answers_page
+    end
   end
 
   it 'refreshing the page and pressing back' do
@@ -81,20 +104,12 @@ RSpec.describe 'TRN requests', type: :system do
     visit root_path
   end
 
-  def given_i_am_on_the_itt_provider_page
-    visit root_path
-    click_on 'Start'
-  end
-
   def given_i_have_completed_a_trn_request
     visit root_path
     click_on 'Start'
-    choose 'No', visible: false
-    click_on 'Continue'
-    choose 'No', visible: false
-    click_on 'Continue'
-    fill_in 'Your email address', with: 'email@example.com'
-    click_on 'Continue'
+    when_i_choose_no_ni_number
+    when_i_choose_no_itt_provider
+    when_i_fill_in_my_email_address
   end
 
   def then_i_see_the_check_answers_page
@@ -187,6 +202,11 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_choose_no_ni_number
     choose 'No', visible: false
+    click_on 'Continue'
+  end
+
+  def when_i_fill_in_my_email_address
+    fill_in 'Your email address', with: 'email@example.com'
     click_on 'Continue'
   end
 


### PR DESCRIPTION
We store the TrnRequest#id in the session to be able to pass state
between screens. The value needs to be set when the first question is
answered.

This change was missed when we added the NI questions and as a result
the TrnRequest doesn't persist correctly between questions.

As we add new questions, this step will continue to migrate to the front
of the flow and we will need to add better tests to ensure we don't miss
this in the future.

For now, I avoided adding extra tests as there are other issues to be
fixed before we can do that.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
