### PR TITLE
Fix displaying existing has_ni_number value

### DIFF
--- a/app/views/ni_number/new.html.erb
+++ b/app/views/ni_number/new.html.erb
@@ -3,8 +3,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: trn_request, url: have_ni_number_path, method: :post do |f| %>
-      <% options = [OpenStruct.new(label: 'Yes', value: 1), OpenStruct.new(label: 'No', value: 0)] %>
+    <%= form_with model: trn_request, url: have_ni_number_path, method: trn_request.new_record? ? :post : :patch do |f| %>
+      <% options = [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)] %>
+      <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(:has_ni_number, 
             options, 
             :value, 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get '/email', to: 'email#edit'
   patch '/email', to: 'email#update'
   get '/have-ni-number', to: 'ni_number#new'
+  patch '/have-ni-number', to: 'ni_number#create'
   post '/have-ni-number', to: 'ni_number#create'
   get '/health', to: proc { [200, {}, ['success']] }
   get '/helpdesk-request-submitted', to: 'pages#helpdesk_request_submitted'

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -105,11 +105,11 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   def given_i_have_completed_a_trn_request
-    visit root_path
-    click_on 'Start'
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
     when_i_choose_no_ni_number
     when_i_choose_no_itt_provider
-    when_i_fill_in_my_email_address
+    when_i_submit_my_email_address
   end
 
   def then_i_see_the_check_answers_page
@@ -168,10 +168,10 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   def when_i_am_on_the_email_page
-    visit root_path
-    click_on 'Start now'
-    choose 'No', visible: false
-    click_on 'Continue'
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
+    when_i_choose_no_ni_number
+    when_i_choose_no_itt_provider
   end
 
   def when_i_change_my_email
@@ -189,6 +189,7 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_change_my_ni_number
     click_on 'Change ni_number'
+    expect(find_field('No', checked: true, visible: false)).to be_truthy
     choose 'Yes', visible: false
     click_on 'Continue'
     fill_in 'What is your National Insurance number?', with: 'QQ123456C'
@@ -202,11 +203,6 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_choose_no_ni_number
     choose 'No', visible: false
-    click_on 'Continue'
-  end
-
-  def when_i_fill_in_my_email_address
-    fill_in 'Your email address', with: 'email@example.com'
     click_on 'Continue'
   end
 
@@ -225,6 +221,10 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_press_change_ni_number
     click_on 'Change ni_number'
+  end
+
+  def when_i_press_continue
+    click_on 'Continue'
   end
 
   def when_i_press_the_start_button


### PR DESCRIPTION
When returning to the `/have-ni-number` screen, the existing value of
the request isn't populating the form.

The saved value doesn't match the options used in the form. The original
integer values get typecast into booleans when saved in the DB,
resulting in this mismatch.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
