### PR TITLE
Ensure ITT provider enrolled gets persisted

### DIFF
--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class TrnRequest < ApplicationRecord
   validates :email, valid_for_notify: true, if: %i[itt_provider_answered? ni_number_answered?]
-  validates :itt_provider_enrolled, presence: true, inclusion: { in: [true, false] }, if: %i[ni_number_answered?]
+  validates :itt_provider_enrolled, inclusion: { in: [true, false] }, if: %i[ni_number_answered?]
   validates :itt_provider_name, allow_blank: true, length: { maximum: 255 }
 
   def answers_checked=(value)

--- a/app/views/itt_providers/edit.html.erb
+++ b/app/views/itt_providers/edit.html.erb
@@ -6,13 +6,13 @@
     <%= form_with model: @trn_request, url: itt_provider_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset(:itt_provider_enrolled, legend: { size: 'xl', text: 'Have you ever been enrolled in initial teacher training in England or Wales?' }) do %>
-        <%= f.govuk_radio_button :itt_provider_enrolled, 'yes', label: { text: 'Yes' } do %>
+        <%= f.govuk_radio_button :itt_provider_enrolled, true, label: { text: 'Yes' } do %>
           <%= f.govuk_text_field(:itt_provider_name,
                 label: { text: 'Your school, university or other training provider' }
             )
           %>
         <% end %>
-        <%= f.govuk_radio_button :itt_provider_enrolled, 'no', label: { text: 'No' } %>
+        <%= f.govuk_radio_button :itt_provider_enrolled, false, label: { text: 'No' } %>
       <% end %>
       <%= f.govuk_submit prevent_double_click: false %>
     <% end %>

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_change_my_itt_provider
     click_on 'Change itt_provider'
+    expect(find_field('No', checked: true, visible: false)).to be_truthy
     choose 'Yes', visible: false
     fill_in 'Your school, university or other training provider', with: 'Test ITT Provider', visible: false
     click_on 'Continue'


### PR DESCRIPTION
The options used to render the value of `itt_provider_name` are
different to what is stored in the DB, which prevents teh saved value
from displaying in the form correctly.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
