### PR TITLE
Fix the back link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,7 @@ module ApplicationHelper
   def back_link_url(trn_request)
     referer = controller.request.env['HTTP_REFERER']
     return check_answers_path if referer&.include?('check-answers') || trn_request&.email?
+    return referer if referer
 
     start_path
   end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'TRN requests', type: :system do
       when_i_choose_no_itt_provider
       then_i_see_the_email_page
       when_i_press_back
-      then_i_see_the_home_page
+      then_i_see_the_itt_provider_page
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe 'TRN requests', type: :system do
       when_i_choose_no_ni_number
       then_i_see_the_itt_provider_page
       when_i_press_back
-      then_i_see_the_home_page
+      then_i_see_the_ni_page
     end
   end
 


### PR DESCRIPTION
When a user navigates through the questions the back link should behave
differently depending on whether the user has visited the check answers
page or not.

In the case where they haven't yet viewed the check answers page
(implied by the absence of an email address) then the back link should
simply go to the previous page.

If check answers has been visited, ie. there's an email address saved,
then return the user to the check answers page.

Assumptions
* the HTTP_REFERER will be present in scenarios where we want to go back to
  the previous page

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
