### PR TITLE
Represent NINO and ITT answers on check answers

### DIFF
--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -7,15 +7,18 @@
     <p class="govuk-body">We will send your TRN to <%= @trn_request.email %> if we find one matching your details.</p>
 
     <% rows = [
-        { key: { text: 'Email address '}, value: { text: @trn_request.email }, actions: [{ href: email_path, visually_hidden_text: 'email address' }] },
+        { key: { text: 'Email address '},
+          value: { text: @trn_request.email },
+          actions: [{ href: email_path, visually_hidden_text: 'email address' }]
+        },
         {
-          key: { text: 'Teacher training provider' },
-          value: { text: @trn_request.itt_provider_name.presence || 'Not given' },
+          key: { text: @trn_request.itt_provider_enrolled ? 'Teacher training provider' : 'Have you been enrolled in initial teacher training in England or Wales?' },
+          value: { text: @trn_request.itt_provider_name.presence || 'No' },
           actions: [{ href: itt_provider_path, visually_hidden_text: 'teacher training provider' }]
         },
         {
-          key: { text: 'National Insurance number' },
-          value: { text: @trn_request.has_ni_number? ? pretty_ni_number(@trn_request.ni_number) : 'Not given' },
+          key: { text: @trn_request.has_ni_number? ? 'National Insurance number' : 'Do you have a National Insurance number?' },
+          value: { text: @trn_request.has_ni_number? ? pretty_ni_number(@trn_request.ni_number) : 'No' },
           actions: [{ href: have_ni_number_path, visually_hidden_text: 'national insurance number' }]
         }
     ] %>

--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -7,16 +7,16 @@
     <p class="govuk-body">We will send your TRN to <%= @trn_request.email %> if we find one matching your details.</p>
 
     <% rows = [
-        { key: { text: 'Email address '}, value: { text: @trn_request.email }, actions: [{ href: email_path, visually_hidden_text: 'email' }] },
+        { key: { text: 'Email address '}, value: { text: @trn_request.email }, actions: [{ href: email_path, visually_hidden_text: 'email address' }] },
         {
           key: { text: 'Teacher training provider' },
           value: { text: @trn_request.itt_provider_name.presence || 'Not given' },
-          actions: [{ href: itt_provider_path, visually_hidden_text: 'itt_provider' }]
+          actions: [{ href: itt_provider_path, visually_hidden_text: 'teacher training provider' }]
         },
         {
           key: { text: 'National Insurance number' },
           value: { text: @trn_request.has_ni_number? ? pretty_ni_number(@trn_request.ni_number) : 'Not given' },
-          actions: [{ href: have_ni_number_path, visually_hidden_text: 'ni_number' }]
+          actions: [{ href: have_ni_number_path, visually_hidden_text: 'national insurance number' }]
         }
     ] %>
     <%= govuk_summary_list(rows: rows) %>

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -323,15 +323,15 @@ RSpec.describe 'TRN requests', type: :system do
   alias_method :and_i_fill_in_my_new_email_address, :when_i_fill_in_my_new_email_address
 
   def when_i_press_change_email
-    click_on 'Change email'
+    click_on 'Change email address'
   end
 
   def when_i_press_change_itt_provider
-    click_on 'Change itt_provider'
+    click_on 'Change teacher training provider'
   end
 
   def when_i_press_change_ni_number
-    click_on 'Change ni_number'
+    click_on 'Change national insurance number'
   end
 
   def when_i_press_continue


### PR DESCRIPTION
### Context

Followup to https://github.com/DFE-Digital/find-a-lost-trn-prototype/pull/51.

### Changes proposed in this pull request

Update change link contents in show answers page.

Update content on check your answers page when users answer "No."

### Guidance to review

![image](https://user-images.githubusercontent.com/1650875/157089888-abd78cc4-4b7d-4d57-af60-4bc80dc27dfc.png)


### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
