### PR TITLE
Allow support users to toggle feature flags on/off

### DIFF
--- a/app/components/flash_message_component.html.erb
+++ b/app/components/flash_message_component.html.erb
@@ -1,0 +1,8 @@
+<%= govuk_notification_banner(
+  title_text: title,
+  classes: classes,
+  html_attributes: { role: role },
+) do |notification_banner| %>
+  <% notification_banner.heading(text: heading) %>
+  <%= body %>
+<% end %>

--- a/app/components/flash_message_component.rb
+++ b/app/components/flash_message_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+class FlashMessageComponent < ViewComponent::Base
+  ALLOWED_PRIMARY_KEYS = %i[info warning success].freeze
+
+  def initialize(flash:)
+    super
+    @flash = flash.to_hash.symbolize_keys!
+  end
+
+  def message_key
+    flash.keys.detect { |key| ALLOWED_PRIMARY_KEYS.include?(key) }
+  end
+
+  def title
+    I18n.t(message_key, scope: :notification_banner)
+  end
+
+  def classes
+    "govuk-notification-banner--#{message_key}"
+  end
+
+  def role
+    %i[warning success].include?(message_key) ? 'alert' : 'region'
+  end
+
+  def heading
+    messages.is_a?(Array) ? messages[0] : messages
+  end
+
+  def body
+    tag.p(messages[1], class: 'govuk-body') if messages.is_a?(Array) && messages.count >= 2
+  end
+
+  def render?
+    !flash.empty? && message_key
+  end
+
+  private
+
+  def messages
+    flash[message_key]
+  end
+
+  attr_reader :flash
+end

--- a/app/controllers/support_interface/feature_flags_controller.rb
+++ b/app/controllers/support_interface/feature_flags_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module SupportInterface
+  class FeatureFlagsController < SupportInterfaceController
+    def index
+      @features = FeatureFlag::FEATURES
+    end
+
+    def activate
+      FeatureFlag.activate(params[:feature_name])
+
+      flash[:success] = "Feature “#{feature_name}” activated"
+      redirect_to support_interface_features_path
+    end
+
+    def deactivate
+      FeatureFlag.deactivate(params[:feature_name])
+
+      flash[:success] = "Feature “#{feature_name}” deactivated"
+      redirect_to support_interface_features_path
+    end
+
+    private
+
+    def feature_name
+      params[:feature_name].humanize
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,9 @@ module ApplicationHelper
   def pretty_ni_number(ni_number)
     ni_number.scan(/..?/).join(' ').upcase
   end
+
+  def current_namespace
+    section = request.path.split('/').second
+    section == 'support' ? 'support_interface' : 'find_interface'
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,21 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(service_name: "Find a lost teacher reference number (TRN)") %>
+    <%= govuk_header(service_name: "Find a lost teacher reference number (TRN)") do |header| %>
+      <% case try(:current_namespace) %>
+      <% when 'support_interface' %>
+        <% header.navigation_item(
+          text: "TRN Requests",
+          href: support_interface_trn_requests_path,
+          active: current_page?(support_interface_trn_requests_path),
+        ) %>
+        <% header.navigation_item(
+          text: "Features",
+          href: support_interface_features_path,
+          active: current_page?(support_interface_features_path)
+        ) %>
+      <% end %>
+    <% end %>
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }, text: "This is a new service – your feedback will help us to improve it. ") %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,6 +37,7 @@
       <%= govuk_phase_banner(tag: { text: "Beta" }, text: "This is a new service – your feedback will help us to improve it. ") %>
       <%= govuk_back_link(href: yield(:back_link_url)) unless yield(:back_link_url).blank? %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield %>
       </main>
     </div>

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :page_title, 'Features' %>
+
+<h1 class="govuk-heading-l">Features</h1>
+
+<% @features.each do |feature_name, feature_flag| %>
+  <h2 class="govuk-heading-m">
+    <%= feature_name.humanize %>
+    <span class="govuk-visually-hidden">
+      - <%= FeatureFlag.active?(feature_name) ? 'Active' : 'Inactive' %>
+    </span>
+  </h2>
+  <% rows = [
+      { key: { text: 'Description'},
+        value: { text: feature_flag.description },
+      },
+      { key: { text: 'Status'},
+        value: {
+          text: govuk_tag(
+            text: FeatureFlag.active?(feature_name) ? 'Active' : 'Inactive',
+            colour: FeatureFlag.active?(feature_name) ? 'green' : 'grey',
+          )
+        },
+      },
+      { key: { text: 'Owner'},
+        value: { text: feature_flag.owner },
+      },
+  ] %>
+  <%= govuk_summary_list(rows: rows) %>
+  <% if FeatureFlag.active?(feature_name) then %>
+    <%= form_with(url: support_interface_deactivate_feature_path(feature_name)) do |f| %>
+      <%= form_with(url: support_interface_deactivate_feature_path(feature_name)) do |f| %>
+        <%= f.govuk_submit 'Deactivate ' + feature_name.humanize, prevent_double_click: false %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= form_with(url: support_interface_activate_feature_path(feature_name)) do |f| %>
+      <%= f.govuk_submit 'Activate ' + feature_name.humanize, prevent_double_click: false %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,10 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: 'Hello world'
+  notification_banner:
+    info: Information
+    warning: Warning
+    success: Success
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,10 @@ Rails.application.routes.draw do
   namespace :support_interface, path: '/support' do
     get '/', to: redirect('/support/trn-requests')
     get '/trn-requests', to: 'trn_requests#index'
+
+    get '/features', to: 'feature_flags#index'
+    post '/features/:feature_name/activate', to: 'feature_flags#activate', as: :activate_feature
+    post '/features/:feature_name/deactivate', to: 'feature_flags#deactivate', as: :deactivate_feature
   end
 
   get '/check-answers', to: 'trn_requests#show'

--- a/spec/components/flash_message_component_spec.rb
+++ b/spec/components/flash_message_component_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe FlashMessageComponent, type: :component do
+  let(:component) { render_inline(described_class.new(flash: flash)) }
+  let(:flash) { {} }
+
+  it 'does not render any content when flash is not set' do
+    expect(component.text).to be_empty
+  end
+
+  context 'when an invalid flash key is provided' do
+    let(:flash) { { alert: 'Message' } }
+
+    it 'fails when an invalid key is provided' do
+      expect(component.text).to be_empty
+    end
+  end
+
+  context 'when a valid flash key is provided' do
+    let(:flash) { { success: 'Your application has been updated' } }
+
+    it 'the component is rendered with the correct content' do
+      expect(component.css('.govuk-notification-banner__heading').text).to include('Your application has been updated')
+    end
+  end
+
+  context 'when an info flash key is provided' do
+    let(:flash) { { info: 'This service will be unavailable tomorrow' } }
+
+    it 'the component is rendered with a region role' do
+      expect(component.css('.govuk-notification-banner').attribute('role').value).to eq('region')
+    end
+  end
+
+  context 'when a success flash key is provided' do
+    let(:flash) { { success: 'Your application has been updated' } }
+
+    it 'the component is rendered with an alert role' do
+      expect(component.css('.govuk-notification-banner').attribute('role').value).to eq('alert')
+    end
+  end
+
+  context 'when a warning flash key is provided' do
+    let(:flash) { { warning: 'There is a problem' } }
+
+    it 'the component is rendered with an alert role' do
+      expect(component.css('.govuk-notification-banner').attribute('role').value).to eq('alert')
+    end
+  end
+
+  context 'when a secondary message is provided' do
+    let(:flash) { { info: ['Message', 'Some more details...'] } }
+
+    it 'the component is rendered with the correct content' do
+      expect(component.text).to include('Message')
+      expect(component.text).to include('Some more details...')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require_relative '../config/environment'
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'view_component/test_helpers'
 require 'capybara/cuprite'
 
 Capybara.register_driver(:cuprite) do |app|
@@ -72,6 +73,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.before(:each, type: :system) { driven_by(:cuprite) }
+
+  config.include ViewComponent::TestHelpers, type: :component
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Support', type: :system do
   end
 
   def when_i_visit_the_feature_flags_page
-    visit support_interface_features_path
+    click_on 'Features'
   end
 
   def when_i_activate_the_zendesk_feature_flag

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -2,10 +2,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Support', type: :system do
-  it 'visiting the support interface' do
+  it 'using the support interface' do
     when_i_am_authorized_as_a_support_user
     and_i_visit_the_support_page
     then_i_see_the_trn_requests_page
+
+    when_i_visit_the_feature_flags_page
+    then_i_see_the_feature_flags
+
+    when_i_activate_the_zendesk_feature_flag
+    then_the_zendesk_flag_is_on
+
+    when_i_deactivate_the_zendesk_feature_flag
+    then_the_zendesk_flag_is_off
   end
 
   private
@@ -14,11 +23,37 @@ RSpec.describe 'Support', type: :system do
     page.driver.basic_authorize('test', 'test')
   end
 
+  def when_i_visit_the_feature_flags_page
+    visit support_interface_features_path
+  end
+
+  def when_i_activate_the_zendesk_feature_flag
+    click_on 'Activate Zendesk integration'
+  end
+
+  def when_i_deactivate_the_zendesk_feature_flag
+    click_on 'Deactivate Zendesk integration'
+  end
+
   def and_i_visit_the_support_page
     visit support_interface_path
   end
 
   def then_i_see_the_trn_requests_page
     expect(page).to have_content('TRN Requests')
+  end
+
+  def then_i_see_the_feature_flags
+    expect(page).to have_content('Features')
+  end
+
+  def then_the_zendesk_flag_is_on
+    expect(page).to have_content('Feature “Zendesk integration” activated')
+    expect(page).to have_content("Zendesk integration\n- Active")
+  end
+
+  def then_the_zendesk_flag_is_off
+    expect(page).to have_content('Feature “Zendesk integration” deactivated')
+    expect(page).to have_content("Zendesk integration\n- Inactive")
   end
 end


### PR DESCRIPTION
### Context

We need a GUI to activate/deactivate feature flags.

### Changes proposed in this pull request

- Lift `FlashMessageComponent` from Apply
- Add controller/views/system specs for toggling feature flags
- Add header subnavigation in support interface

### Guidance to review

Review commit by commit.

![image](https://user-images.githubusercontent.com/1650875/157268984-9dad6516-cd0d-4039-804f-844d845b92b8.png)

### Checklist

https://trello.com/c/xWruEyTV

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
