### PR TITLE
Fix error link in ITT provider page

### DIFF
--- a/app/views/itt_providers/edit.html.erb
+++ b/app/views/itt_providers/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @itt_provider_form, url: itt_provider_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset(:itt_provider_enrolled, legend: { size: 'xl', text: 'Have you ever been enrolled in initial teacher training in England or Wales?' }) do %>
-        <%= f.govuk_radio_button :itt_provider_enrolled, true, label: { text: 'Yes' } do %>
+        <%= f.govuk_radio_button :itt_provider_enrolled, true, label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_field(:itt_provider_name,
                 label: { text: 'Your school, university or other training provider' }
             )


### PR DESCRIPTION
> The form builder does not keep track of its contents so to ensure the error summary correctly links to the first radio button link_errors must be set to true

https://govuk-form-builder.netlify.app/form-elements/radios/#radios-fieldset-with-conditional-content-and-a-divider

https://github.com/DFE-Digital/govuk-formbuilder/blob/416f7c0d8dca5db4854daa9f7b26b3eb49cf6a79/lib/govuk_design_system_formbuilder/builder.rb#L567-L568