### PR TITLE
Add Status Cake

### DIFF
--- a/terraform/statuscake.tf
+++ b/terraform/statuscake.tf
@@ -1,0 +1,12 @@
+resource "statuscake_test" "alert" {
+  for_each = var.statuscake_alerts
+
+  website_name   = each.value.website_name
+  website_url    = each.value.website_url
+  test_type      = each.value.test_type
+  contact_group  = each.value.contact_group
+  check_rate     = each.value.check_rate
+  trigger_rate   = each.value.trigger_rate
+  node_locations = each.value.node_locations
+  confirmations  = each.value.confirmations
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -15,5 +15,10 @@ terraform {
       source  = "cloudfoundry-community/cloudfoundry"
       version = "~> 0.15"
     }
+
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = "1.0.1"
+    }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -56,6 +56,10 @@ variable "postgres_database_service_plan" {
   default = "small-13"
 }
 
+variable "statuscake_alerts" {
+  type = map(any)
+}
+
 locals {
   flt_routes = flatten([
     cloudfoundry_route.flt_public,

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -4,5 +4,6 @@
   "resource_group_name": "s165d01-rg",
   "flt_app_name": "find-a-lost-trn-dev",
   "paas_space": "tra-dev",
-  "postgres_database_name": "find-a-lost-trn-dev-pg-svc"
+  "postgres_database_name": "find-a-lost-trn-dev-pg-svc",
+  "statuscake_alerts": {}
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -4,5 +4,17 @@
   "resource_group_name": "s165t01-preprod-rg",
   "flt_app_name": "find-a-lost-trn-preprod",
   "paas_space": "tra-test",
-  "postgres_database_name": "find-a-lost-trn-preprod-pg-svc"
+  "postgres_database_name": "find-a-lost-trn-preprod-pg-svc",
+  "statuscake_alerts": {
+    "tra-flt-preprod": {
+      "website_name": "find-a-lost-trn-preprod",
+      "website_url": "https://find-a-lost-trn-preprod.london.cloudapps.digital/health",
+      "test_type": "HTTP",
+      "contact_group": ["twd_tra_dqt"],
+      "check_rate": 30,
+      "trigger_rate": 0,
+      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
+      "confirmations": 2
+    }
+  }
 }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -4,5 +4,17 @@
   "resource_group_name": "s165p01-rg",
   "flt_app_name": "find-a-lost-trn-production",
   "paas_space": "tra-production",
-  "postgres_database_name": "find-a-lost-trn-production-pg-svc"
+  "postgres_database_name": "find-a-lost-trn-production-pg-svc",
+  "statuscake_alerts": {
+    "tra-flt-prod": {
+      "website_name": "find-a-lost-trn-prod",
+      "website_url": "https://find-a-lost-trn-prod.london.cloudapps.digital/health",
+      "test_type": "HTTP",
+      "contact_group": ["twd_tra_dqt"],
+      "check_rate": 30,
+      "trigger_rate": 0,
+      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
+      "confirmations": 2
+    }
+  }
 }


### PR DESCRIPTION
### Context

Support for status cake will help identify when the website is down and
alerts the TRA team through Slack. This commit adds Terraform code for
Status Cake.

### Trello card

https://trello.com/c/Dk0oBosR
