### PR TITLE
Declare ZENDESK_TOKEN during Docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN echo "Europe/London" > /etc/timezone && \
 ENV RAILS_ENV=production \
     RAILS_SERVE_STATIC_FILES=yes \
     LANG=en_GB.UTF-8 \
-    SECRET_KEY_BASE=TestKey
+    SECRET_KEY_BASE=TestKey \
+    ZENDESK_TOKEN=TestToken
 
 WORKDIR /app
 


### PR DESCRIPTION
This is necessary to get the pipeline to successfully run `assets:precompile`.