### PR TITLE
Move email validations to a form object

### DIFF
--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 class EmailController < ApplicationController
   def edit
-    @trn_request = TrnRequest.find_by(id: session[:trn_request_id]) || TrnRequest.new
+    trn_request = TrnRequest.find_by(id: session[:trn_request_id])
+    @email_form = EmailForm.new(trn_request: trn_request)
   end
 
   def update
-    @trn_request = TrnRequest.find_by(id: session[:trn_request_id]) || TrnRequest.new
-    if @trn_request.update(email: email_params[:email])
+    trn_request = TrnRequest.find_by(id: session[:trn_request_id])
+    @email_form = EmailForm.new(email: email_params[:email], trn_request: trn_request)
+    if @email_form.save
       redirect_to check_answers_url
     else
       render :edit
@@ -16,6 +18,6 @@ class EmailController < ApplicationController
   private
 
   def email_params
-    params.require(:trn_request).permit(:email)
+    params.require(:email_form).permit(:email)
   end
 end

--- a/app/forms/email_form.rb
+++ b/app/forms/email_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class EmailForm
+  include ActiveModel::Model
+
+  attr_accessor :trn_request
+  attr_writer :email
+
+  validates :email, valid_for_notify: true
+
+  delegate :email?, to: :trn_request, allow_nil: true
+
+  def email
+    @email ||= trn_request&.email
+  end
+
+  def save
+    return false if invalid?
+
+    trn_request.email = email
+    trn_request.save
+  end
+end

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 class TrnRequest < ApplicationRecord
-  validates :email, valid_for_notify: true, if: %i[itt_provider_answered? ni_number_answered?]
-
   def answers_checked=(value)
     return unless value
 

--- a/app/views/email/edit.html.erb
+++ b/app/views/email/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :page_title, "#{'Error: ' if @trn_request.errors.any?}Your email address" %>
-<%= content_for :back_link_url, back_link_url(@trn_request) %>
+<% content_for :page_title, "#{'Error: ' if @email_form.errors.any?}Your email address" %>
+<%= content_for :back_link_url, back_link_url(@email_form) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @trn_request, url: email_path, method: :patch do |f| %>
+    <%= form_with model: @email_form, url: email_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_email_field(
             :email, 

--- a/spec/forms/email_form_spec.rb
+++ b/spec/forms/email_form_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe EmailForm, type: :model do
+  subject(:email_form) { described_class.new }
+
+  specify do
+    expect(email_form).to validate_presence_of(:email).with_message(
+      'Enter an email address in the correct format, like name@example.com',
+    )
+  end
+
+  describe '#save' do
+    subject(:save) { name_form.save }
+
+    let(:email) { 'test@example.com' }
+    let(:name_form) { described_class.new(email: email, trn_request: trn_request) }
+    let(:trn_request) { TrnRequest.new }
+
+    it { is_expected.to be_truthy }
+
+    it 'sets the email on the TrnRequest' do
+      save
+      expect(trn_request.email).to eq('test@example.com')
+    end
+
+    context 'when the email is blank' do
+      let(:email) { '' }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe '#email' do
+    subject { name_form.email }
+
+    context 'when the email is set on TrnRequest' do
+      let(:name_form) { described_class.new(trn_request: trn_request) }
+      let(:trn_request) { TrnRequest.new(email: 'test@example.com') }
+
+      it { is_expected.to eq('test@example.com') }
+    end
+
+    context 'when initialized with an email address' do
+      let(:name_form) { described_class.new(email: 'new@example.com', trn_request: trn_request) }
+      let(:trn_request) { TrnRequest.new(email: 'old@example.com') }
+
+      it { is_expected.to eq('new@example.com') }
+    end
+  end
+end

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -28,16 +28,6 @@ RSpec.describe TrnRequest, type: :model do
     end
   end
 
-  context 'when the ITT provider enrollment and NI number questions have been asked' do
-    subject(:trn_request) { described_class.create(has_ni_number: false, itt_provider_enrolled: true) }
-
-    it 'validates the presence of the email address' do
-      expect(trn_request).to validate_presence_of(:email).with_message(
-        'Enter an email address in the correct format, like name@example.com',
-      )
-    end
-  end
-
   describe '#name' do
     subject { trn_request.name }
 


### PR DESCRIPTION
The email validations for a TrnRequest are currently located on the
model, which requires a state check to see if we can run the validation
or not.

Elsewhere in the request flow, we have opted for a pattern where a form
object defines the validations, which decouples these validations from
the current state of the object. This makes it easier to reason about
those validations and also easier to change the request flow.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
