### PR TITLE
Add missing ZENDESK_USER to build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV RAILS_ENV=production \
     RAILS_SERVE_STATIC_FILES=yes \
     LANG=en_GB.UTF-8 \
     SECRET_KEY_BASE=TestKey \
+    ZENDESK_USER=TestUser \
     ZENDESK_TOKEN=TestToken
 
 WORKDIR /app

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -7,6 +7,7 @@ GDS_ZENDESK_CLIENT =
     GDSZendesk::DummyClient.new(development_mode: true, logger: Rails.logger)
   else
     GDSZendesk::Client.new(
+      username: ENV['ZENDESK_USER'],
       token: ENV['ZENDESK_TOKEN'],
       logger: Rails.logger,
       url: 'https://teachingregulationagency.zendesk.com/api/v2/',

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -3,7 +3,8 @@ locals {
     SECRET_KEY_BASE  = local.infrastructure_secrets.SECRET_KEY_BASE,
     SUPPORT_USERNAME = local.infrastructure_secrets.SUPPORT_USERNAME,
     SUPPORT_PASSWORD = local.infrastructure_secrets.SUPPORT_PASSWORD,
-    ZENDESK_TOKEN    = local.infrastructure_secrets.ZENDESK_TOKEN
+    ZENDESK_TOKEN    = local.infrastructure_secrets.ZENDESK_TOKEN,
+    ZENDESK_USER     = local.infrastructure_secrets.ZENDESK_USER
   }
 }
 resource "cloudfoundry_route" "flt_public" {


### PR DESCRIPTION
This is necessarry but was omitted when building because we didn't test the implementation end to end.

Follow-up PR necessary to add it to the env vars for the build env.