### PR TITLE
Add Email and Requester to Zendesk payload

### DIFF
--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -24,6 +24,10 @@ class ZendeskService
             "\nNI number: #{trn_request.ni_number || 'Not provided'}" \
             "\nITT provider: #{trn_request.itt_provider_name || 'Not provided'}\n",
       },
+      requester: {
+        email: trn_request.email,
+        name: trn_request.name,
+      },
     }
   end
 

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe ZendeskService do
                     "\nNI number: QC123456A" \
                     "\nITT provider: Big SCITT\n",
               },
+              requester: {
+                email: 'test@example.com',
+                name: 'Test User',
+              },
             },
           )
       end


### PR DESCRIPTION
Update the ticket creation to include the email (previously missing) and to also add the Requester which will allow support agents to directly reply to the Zendesk ticket.