### PR TITLE
Add intro screens

### DIFF
--- a/app/controllers/check_trn_controller.rb
+++ b/app/controllers/check_trn_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class CheckTrnController < ApplicationController
+  def new
+    @check_trn_form = CheckTrnForm.new
+  end
+
+  def create
+    @check_trn_form = CheckTrnForm.new(check_trn_params)
+    if @check_trn_form.valid?
+      redirect_to @check_trn_form.trn? ? ask_questions_path : you_dont_have_a_trn_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def check_trn_params
+    params.require(:check_trn_form).permit(:has_trn)
+  end
+end

--- a/app/forms/check_trn_form.rb
+++ b/app/forms/check_trn_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class CheckTrnForm
+  include ActiveModel::Model
+
+  attr_accessor :has_trn
+
+  validates :has_trn, inclusion: { in: %w[true false] }
+
+  def trn?
+    ActiveModel::Type::Boolean.new.cast(has_trn)
+  end
+
+  def email?
+    false
+  end
+end

--- a/app/views/check_trn/new.html.erb
+++ b/app/views/check_trn/new.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, "#{'Error: ' if @check_trn_form.errors.any?}Check if you have a TRN number" %>
+<% content_for :back_link_url, back_link_url(@check_trn_form) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Check if you have a TRN</h1>
+    <p class="govuk-body">You will have a TRN if you:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>hold qualified teacher status (QTS) in England or Wales</li>
+      <li>hold early years teacher status (EYTS) in England</li>
+      <li>hold a national professional qualification (NPQ)</li>
+      <li>are working towards QTS, EYTS or an NPQ</li>
+      <li>contribute to the Teachers’ Pensions scheme</li>
+      <li>have a relevant restriction in relation to teaching in England</li>
+    </ul>
+    <%= form_with model: @check_trn_form, url: check_trn_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(:has_trn, 
+            [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
+            :value, 
+            :label, 
+            legend: { size: 'm', text: 'Do you think you have a TRN?' }
+          ) %>
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/ask_questions.html.erb
+++ b/app/views/pages/ask_questions.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, 'We’ll ask you some questions to help find your TRN' %>
+<% content_for :back_link_url, check_trn_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class='govuk-heading-xl'>We’ll ask you some questions to help find your TRN</h1>
+
+    <p class="govuk-body govuk-!-margin-bottom-6">We’ll ask for your name, date of birth and National Insurance number. If you do not have your National Insurance number available, we may ask some follow-up questions.</p>
+    <%= govuk_button_link_to 'Continue', name_path %>
+  </div>
+</div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -43,7 +43,7 @@
       Have your National Insurance number ready, as we’ll ask for this.
     </p>
 
-    <%= govuk_start_button(text: 'Start now', href: name_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
+    <%= govuk_start_button(text: 'Start now', href: check_trn_path, classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
 
     <h2 class="govuk-heading-m">Other ways to find your TRN</h2>
 

--- a/app/views/pages/you_dont_have_a_trn.html.erb
+++ b/app/views/pages/you_dont_have_a_trn.html.erb
@@ -1,0 +1,65 @@
+<% content_for :page_title, 'You do not have a TRN' %>
+<% content_for :back_link_url, check_trn_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class='govuk-heading-xl'>You don’t have a TRN</h1>
+
+    <h2 class="govuk-heading-l" id="what-a-teacher-reference-number-trn-is-for">What a teacher reference number (TRN) is for</h2>
+    <p class='govuk-body'>You need a TRN for:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>view your record with the Teaching Regulation Agency (TRA), and download professional certificates in the <a class='govuk-link' href='https://teacherservices.education.gov.uk/SelfService/Login?_ga=2.206960218.899524735.1637088337-1609244267.1609598427'>Teacher self service portal</a></li>
+      <li>give to employers so they can complete mandatory teacher status checks</li>
+      <li>manage records of your contributions to the Teachers’ Pensions scheme</li>
+      <li>give to the Department for Education (DfE) when you have been awarded QTS so you can begin your early career teacher induction</li>
+      <li>register for a national professional qualification (NPQ)</li>
+    </ul>
+
+    <h2 class="govuk-heading-l" id="get-a-trn-to-register-for-an-npq">Get a TRN to register for an NPQ</h2>
+    <p class='govuk-body'>You do not need to be a teacher to get a TRN.</p>
+
+    <h3 class="govuk-heading-m" id="request-a-trn-by-email">Request a TRN by email</h3>
+    <p class='govuk-body'>
+      If you’ve never been given a TRN, email the Teaching Regulation Agency at <a class='govuk-link' href='mailto:qts.enquiries@education.gov.uk'>qts.enquiries@education.gov.uk</a>. The team aim to respond to valid email requests within 5 working days.
+    </p>
+    <p class='govuk-body'>You’ll need to provide contact details and proof of ID.</p>
+    <p class='govuk-body'>Use the free Galaxkey secure email platform to ensure your identification documents are protected.</p>
+
+    <h3 class="govuk-heading-m" id="register-to-send-a-secure-email">Register to send a secure email</h3>
+    <p class='govuk-body'>
+      To send a secure email to the department, go to the <a class='govuk-link' href='https://manager.galaxkey.com/services/registerme'>Galaxkey site</a>.
+    </p>
+    <p class='govuk-body'>Enter the email address that you wish to sign up with and complete the registration process.</p>
+    <p class='govuk-body'>
+      You’ll be sent an email to activate your account once you have completed this step. You can then send secure emails to the Teaching Regulation Agency using Galaxkey.
+    </p>
+
+    <h3 class="govuk-heading-m" id="send-your-id-documents-securely">Send your ID documents securely</h3>
+    <p class="govuk-body">Follow these steps to send your documents through Galaxkey:</p>
+    <ol class="govuk-list govuk-list--number"><li><p class="govuk-body">Select ‘Compose’ to create a new secure email.</p></li>
+      <li><p class="govuk-body">Enter ‘<a class="govuk-link" href="mailto:qts.enquiries@education.gov.uk">qts.enquiries@education.gov.uk</a>’ as the recipient.</p></li>
+      <li><p class="govuk-body">Enter ‘Undertaking an NPQ, do not have a TRN and require a number to be issued’ as the subject line.</p></li>
+      <li>
+        <p class="govuk-body">Include the following information in your email:</p>
+        <ul class="govuk-list govuk-list--bullet"><li>your full legal name</li>
+          <li>your date of birth</li>
+          <li>an email address for the team to reply to</li>
+        </ul>
+      </li>
+      <li>
+        <p class="govuk-body">Attach a scanned copy or photo of one of the following types of ID:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>passport</li>
+          <li>driving licence (full or provisional)</li>
+          <li>certificate of residence</li>
+          <li>birth certificate</li>
+        </ul>
+      </li>
+    </ol>
+    <p class="govuk-body">Follow the guidance on screen to make sure you send the correct file size.</p>
+    <p class="govuk-body">Find out more about how the Teaching Regulation Agency processes your data on the <a class="govuk-link" href="https://www.gov.uk/guidance/teacher-self-service-portal">teacher self-service site</a>.</p>
+
+    <h3 class="govuk-heading-m" id="what-happens-next">What happens next</h3>
+    <p class="govuk-body">The Teaching Regulation Agency will use the information you send to create a permanent record and your TRN.</p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,10 @@ en:
   activemodel:
     errors:
       models:
+        check_trn_form:
+          attributes:
+            has_trn:
+              inclusion: Tell us if you think you have a TRN
         date_of_birth_form:
           attributes:
             date_of_birth:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,10 @@ Rails.application.routes.draw do
     post '/features/:feature_name/deactivate', to: 'feature_flags#deactivate', as: :deactivate_feature
   end
 
+  get '/ask-questions', to: 'pages#ask_questions'
   get '/check-answers', to: 'trn_requests#show'
+  get '/check-trn', to: 'check_trn#new'
+  post '/check-trn', to: 'check_trn#create'
   get '/date-of-birth', to: 'date_of_birth#edit'
   patch '/date-of-birth', to: 'date_of_birth#update'
   get '/email', to: 'email#edit'
@@ -32,5 +35,6 @@ Rails.application.routes.draw do
   patch '/name', to: 'name#update'
   get '/ni-number', to: 'ni_number#edit'
   patch '/ni-number', to: 'ni_number#update'
+  get '/you-dont-have-a-trn', to: 'pages#you_dont_have_a_trn'
   get '/start', to: 'pages#start'
 end

--- a/spec/forms/check_trn_form_spec.rb
+++ b/spec/forms/check_trn_form_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CheckTrnForm, type: :model do
+  it { is_expected.to validate_inclusion_of(:has_trn).in_array(%w[true false]) }
+end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe 'TRN requests', type: :system do
   it 'completing a request' do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    then_i_see_the_check_trn_page
+
+    when_i_confirm_i_have_a_trn_number
+    then_i_see_the_ask_questions_page
+
+    when_i_press_continue
     then_i_see_the_name_page
 
     when_i_fill_in_the_name_form
@@ -44,6 +50,8 @@ RSpec.describe 'TRN requests', type: :system do
   it 'entering the NI number' do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    when_i_confirm_i_have_a_trn_number
+    when_i_press_continue
     then_i_see_the_name_page
 
     when_i_fill_in_the_name_form
@@ -123,6 +131,8 @@ RSpec.describe 'TRN requests', type: :system do
     it 'pressing back' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
+      when_i_confirm_i_have_a_trn_number
+      when_i_press_continue
       when_i_fill_in_the_name_form
       then_i_see_the_date_of_birth_page
 
@@ -135,6 +145,8 @@ RSpec.describe 'TRN requests', type: :system do
     it 'pressing back' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
+      when_i_confirm_i_have_a_trn_number
+      when_i_press_continue
       when_i_fill_in_the_name_form
       when_i_complete_my_date_of_birth
       then_i_see_the_have_ni_page
@@ -148,6 +160,8 @@ RSpec.describe 'TRN requests', type: :system do
     it 'pressing back' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
+      when_i_confirm_i_have_a_trn_number
+      when_i_press_continue
       when_i_fill_in_the_name_form
       when_i_complete_my_date_of_birth
       and_i_choose_no
@@ -167,6 +181,8 @@ RSpec.describe 'TRN requests', type: :system do
     it 'pressing back' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
+      when_i_confirm_i_have_a_trn_number
+      when_i_press_continue
       when_i_fill_in_the_name_form
       when_i_complete_my_date_of_birth
       and_i_choose_no
@@ -208,6 +224,8 @@ RSpec.describe 'TRN requests', type: :system do
   it 'ITT provider validations' do
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    when_i_confirm_i_have_a_trn_number
+    when_i_press_continue
     when_i_fill_in_the_name_form
     when_i_complete_my_date_of_birth
     then_i_see_the_ni_page
@@ -222,6 +240,13 @@ RSpec.describe 'TRN requests', type: :system do
     when_i_choose_yes
     and_i_press_continue
     then_i_see_a_validation_error
+  end
+
+  it 'no TRN' do
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
+    when_i_choose_no_trn
+    then_i_see_the_no_trn_page
   end
 
   private
@@ -239,6 +264,8 @@ RSpec.describe 'TRN requests', type: :system do
   def given_i_have_completed_a_trn_request
     given_i_am_on_the_home_page
     when_i_press_the_start_button
+    when_i_confirm_i_have_a_trn_number
+    when_i_press_continue
     when_i_fill_in_the_name_form
     when_i_complete_my_date_of_birth
     when_i_choose_no
@@ -251,6 +278,12 @@ RSpec.describe 'TRN requests', type: :system do
 
     when_i_fill_in_my_email_address
     and_i_press_continue
+  end
+
+  def then_i_see_the_ask_questions_page
+    expect(page).to have_current_path('/ask-questions')
+    expect(page.driver.browser.current_title).to start_with('We’ll ask you some questions to help find your TRN')
+    expect(page).to have_content('We’ll ask you some questions to help find your TRN')
   end
 
   def then_i_see_the_check_answers_page
@@ -271,6 +304,12 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_current_path('/check-answers')
     expect(page).to have_content('Teacher training provider')
     expect(page).to have_content('Test ITT Provider')
+  end
+
+  def then_i_see_the_check_trn_page
+    expect(page).to have_current_path('/check-trn')
+    expect(page.driver.browser.current_title).to start_with('Check if you have a TRN')
+    expect(page).to have_content('Check if you have a TRN')
   end
 
   def then_i_see_the_confirmation_page
@@ -336,6 +375,12 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('Enter a National Insurance number')
   end
 
+  def then_i_see_the_no_trn_page
+    expect(page).to have_current_path('/you-dont-have-a-trn')
+    expect(page.driver.browser.current_title).to start_with('You do not have a TRN')
+    expect(page).to have_content('You don’t have a TRN')
+  end
+
   def then_i_see_the_updated_email_address
     expect(page).to have_content('new@example.com')
   end
@@ -366,6 +411,16 @@ RSpec.describe 'TRN requests', type: :system do
     when_i_complete_my_date_of_birth
     when_i_choose_no_ni_number
     when_i_choose_no_itt_provider
+  end
+
+  def when_i_choose_no_trn
+    choose 'No', visible: false
+    when_i_press_continue
+  end
+
+  def when_i_confirm_i_have_a_trn_number
+    choose 'Yes', visible: false
+    when_i_press_continue
   end
 
   def when_i_enter_a_new_name


### PR DESCRIPTION
We have designs for screens to better introduce people to the TRN
request flow and ensure they are informed about what it requires.

There are 3 new screens, a "Check you have a TRN" screen that forks to
either a "You don't have a TRN" screen or a screen that sets
expectations for the series of questions that follow.

Assumptions:
* we don't need to persist the answer to the "Do you have a TRN" question

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
