### PR TITLE
Remove previous run cancellation step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,16 +20,6 @@ env:
   CONTAINER_REGISTRY: ghcr.io
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   docker:
     name: Docker build and push
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Context

Remove cancelation of previous job runs as its not needed. Having this step introduced parallel run issues which corrupted Terraform statefile. Concurrency should make it queue for multiple runs.
