### PR TITLE
Add a "it's taking longer" screen via a feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -15,7 +15,7 @@ class FeatureFlag
   PERMANENT_SETTINGS = [].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:longer_than_normal, 'It’s taking us longer than usual to find TRNs', 'Felix Clack'],
+    [:processing_delays, 'Show users banners and interstitials warning them of increased waiting times', 'Felix Clack'],
     [:zendesk_integration, 'Submit tickets to Zendesk on behalf of users at the end of the journey', 'Theodor Vararu'],
   ].freeze
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -15,6 +15,7 @@ class FeatureFlag
   PERMANENT_SETTINGS = [].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
+    [:longer_than_normal, 'It’s taking us longer than usual to find TRNs', 'Felix Clack'],
     [:zendesk_integration, 'Submit tickets to Zendesk on behalf of users at the end of the journey', 'Theodor Vararu'],
   ].freeze
 

--- a/app/views/pages/ask_questions.html.erb
+++ b/app/views/pages/ask_questions.html.erb
@@ -6,6 +6,6 @@
     <h1 class='govuk-heading-xl'>We’ll ask you some questions to help find your TRN</h1>
 
     <p class="govuk-body govuk-!-margin-bottom-6">We’ll ask for your name, date of birth and National Insurance number. If you do not have your National Insurance number available, we may ask some follow-up questions.</p>
-    <%= govuk_button_link_to 'Continue', FeatureFlag.active?(:longer_than_normal) ? longer_than_normal_path : name_path %>
+    <%= govuk_button_link_to 'Continue', FeatureFlag.active?(:processing_delays) ? longer_than_normal_path : name_path %>
   </div>
 </div>

--- a/app/views/pages/ask_questions.html.erb
+++ b/app/views/pages/ask_questions.html.erb
@@ -6,6 +6,6 @@
     <h1 class='govuk-heading-xl'>We’ll ask you some questions to help find your TRN</h1>
 
     <p class="govuk-body govuk-!-margin-bottom-6">We’ll ask for your name, date of birth and National Insurance number. If you do not have your National Insurance number available, we may ask some follow-up questions.</p>
-    <%= govuk_button_link_to 'Continue', name_path %>
+    <%= govuk_button_link_to 'Continue', FeatureFlag.active?(:longer_than_normal) ? longer_than_normal_path : name_path %>
   </div>
 </div>

--- a/app/views/pages/longer_than_normal.html.erb
+++ b/app/views/pages/longer_than_normal.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, 'It’s taking us longer than usual to find TRNs' %>
+<% content_for :back_link_url, ask_questions_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class='govuk-heading-xl'>It’s taking us longer than usual to find TRNs</h1>
+    <p class='govuk-body'>
+      Normally, if we find a match we would send your TRN straight away, but at the moment we are having technical problems.
+    </p>
+    <p class='govuk-body'>
+      If you give us all the information we need, you won’t get a response straight away. And if the information you give is 
+      incomplete, it might take more than five days to get back to you.
+    </p>
+    <h2 class="govuk-heading-m">If you need your TRN urgently</h2>
+    <p class='govuk-body'>
+      Call the Teaching Regulation Agency, and have your National Insurance number ready:
+    </p>
+    <ul class="govuk-list">
+      <li>Telephone: 020 7593 5394</li>
+      <li>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</li>
+    </ul>
+    <%= govuk_button_link_to 'Continue', name_path %>
+  </div>
+</div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -4,17 +4,6 @@
       Find a lost teacher reference number (TRN)
     </h1>
 
-    <%= govuk_notification_banner(
-      title_text: "Important",
-      classes: 'govuk-!-margin-bottom-4') do |nb| %>
-      <%- nb.heading(text: "It’s taking longer than usual to find TRNs") %>
-      <p class="govuk-body">
-        If you give us all the information we need, you won’t get a response
-        straight away. And if the information you give is incomplete, it might
-        take more than five days to get back to you.
-      </p>
-    <% end %>
-
     <p class="govuk-body">Use this service to:</p>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   get '/helpdesk-request-submitted', to: 'pages#helpdesk_request_submitted'
   get '/itt-provider', to: 'itt_providers#edit'
   patch '/itt-provider', to: 'itt_providers#update'
+  get '/longer-than-normal', to: 'pages#longer_than_normal'
   get '/name', to: 'name#edit'
   patch '/name', to: 'name#update'
   get '/ni-number', to: 'ni_number#edit'

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -249,6 +249,17 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_no_trn_page
   end
 
+  it 'taking longer than usual' do
+    given_it_is_taking_longer_than_usual
+    when_i_am_on_the_home_page
+    when_i_press_the_start_button
+    when_i_confirm_i_have_a_trn_number
+    when_i_press_continue
+    then_i_see_the_taking_longer_page
+    when_i_press_continue
+    then_i_see_the_name_page
+  end
+
   private
 
   def and_the_date_of_birth_is_prepopulated
@@ -260,6 +271,7 @@ RSpec.describe 'TRN requests', type: :system do
   def given_i_am_on_the_home_page
     visit root_path
   end
+  alias_method :when_i_am_on_the_home_page, :given_i_am_on_the_home_page
 
   def given_i_have_completed_a_trn_request
     given_i_am_on_the_home_page
@@ -278,6 +290,10 @@ RSpec.describe 'TRN requests', type: :system do
 
     when_i_fill_in_my_email_address
     and_i_press_continue
+  end
+
+  def given_it_is_taking_longer_than_usual
+    FeatureFlag.activate(:longer_than_normal)
   end
 
   def then_i_see_the_ask_questions_page
@@ -377,6 +393,10 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_current_path('/you-dont-have-a-trn')
     expect(page.driver.browser.current_title).to start_with('You do not have a TRN')
     expect(page).to have_content('You don’t have a TRN')
+  end
+
+  def then_i_see_the_taking_longer_page
+    expect(page).to have_current_path('/longer-than-normal')
   end
 
   def then_i_see_the_updated_email_address

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   def given_it_is_taking_longer_than_usual
-    FeatureFlag.activate(:longer_than_normal)
+    FeatureFlag.activate(:processing_delays)
   end
 
   def then_i_see_the_ask_questions_page


### PR DESCRIPTION
We want to be able to toggle the "it's taking longer than usual" message
for users via a feature flag.

This adds the page and inserts it into the flow before any questions are
asked if the feature flag, :longer_than_normal is enabled.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
