### PR TITLE
Ensure the back link works in all scenarios

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def back_link_url(trn_request)
-    referer = controller.request.env['HTTP_REFERER']
-    return check_answers_path if referer&.include?('check-answers') || trn_request&.email?
-    return referer if referer
+  def back_link_url
+    return url_for(:back) unless url_for(:back).include?(request.path)
 
-    start_path
+    'javascript:history.go(-2)'
   end
 
   def pretty_ni_number(ni_number)

--- a/app/views/check_trn/new.html.erb
+++ b/app/views/check_trn/new.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if @check_trn_form.errors.any?}Check if you have a TRN number" %>
-<% content_for :back_link_url, back_link_url(@check_trn_form) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/date_of_birth/edit.html.erb
+++ b/app/views/date_of_birth/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if date_of_birth_form.errors.any?}Your date of birth" %>
-<% content_for :back_link_url, back_link_url(date_of_birth_form) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/email/edit.html.erb
+++ b/app/views/email/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if @email_form.errors.any?}Your email address" %>
-<%= content_for :back_link_url, back_link_url(@email_form) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/itt_providers/edit.html.erb
+++ b/app/views/itt_providers/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if @itt_provider_form.errors.any?}Have you been awarded qualified teacher status (QTS)?" %>
-<%= content_for :back_link_url, back_link_url(@trn_request) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }, text: "This is a new service – your feedback will help us to improve it. ") %>
-      <%= govuk_back_link(href: yield(:back_link_url)) unless yield(:back_link_url).blank? %>
+      <%= govuk_back_link(href: back_link_url) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= yield %>

--- a/app/views/name/edit.html.erb
+++ b/app/views/name/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if @name_form.errors.any?}Your name" %>
-<% content_for :back_link_url, back_link_url(@name_form) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/ni_number/edit.html.erb
+++ b/app/views/ni_number/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "#{'Error: ' if ni_number.errors.any?}What is your National Insurance number?" %>
-<% content_for :back_link_url, back_link_url(ni_number) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/ni_number/new.html.erb
+++ b/app/views/ni_number/new.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "Do you have a National Insurance number?" %>
-<% content_for :back_link_url, back_link_url(trn_request) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/ask_questions.html.erb
+++ b/app/views/pages/ask_questions.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, 'We’ll ask you some questions to help find your TRN' %>
-<% content_for :back_link_url, check_trn_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/longer_than_normal.html.erb
+++ b/app/views/pages/longer_than_normal.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, 'It’s taking us longer than usual to find TRNs' %>
-<% content_for :back_link_url, ask_questions_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/you_dont_have_a_trn.html.erb
+++ b/app/views/pages/you_dont_have_a_trn.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, 'You do not have a TRN' %>
-<% content_for :back_link_url, check_trn_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, 'Check your answers' %>
-<%= content_for :back_link_url, start_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -127,8 +127,18 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_home_page
   end
 
+  context 'when the user sees a validation error' do
+    it 'pressing back goes to the previous page' do
+      given_i_am_on_the_home_page
+      when_i_press_the_start_button
+      when_i_press_continue
+      when_i_press_back
+      then_i_see_the_home_page
+    end
+  end
+
   context 'when the user has reached the date of birth question' do
-    it 'pressing back' do
+    it 'pressing back goes to the name page' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
       when_i_confirm_i_have_a_trn_number
@@ -142,7 +152,7 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   context 'when the user has reached the have NI question' do
-    it 'pressing back' do
+    it 'pressing back goes to the date of birth page' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
       when_i_confirm_i_have_a_trn_number
@@ -157,7 +167,7 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   context 'when the user has reached the email question' do
-    it 'pressing back' do
+    it 'pressing back goes to the ITT provider page' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
       when_i_confirm_i_have_a_trn_number
@@ -178,7 +188,7 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   context 'when the user has reached the ITT provider question' do
-    it 'pressing back' do
+    it 'pressing back goes to the NI page' do
       given_i_am_on_the_home_page
       when_i_press_the_start_button
       when_i_confirm_i_have_a_trn_number
@@ -195,7 +205,7 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   context 'when the user has reached the check answers page' do
-    it 'pressing back' do
+    it 'pressing back goes to the check answers page' do
       given_i_have_completed_a_trn_request
       when_i_press_change_email
       and_i_press_back
@@ -207,6 +217,11 @@ RSpec.describe 'TRN requests', type: :system do
       when_i_press_change_ni_number
       then_i_see_the_have_ni_page
       when_i_press_back
+      then_i_see_the_check_answers_page
+      when_i_press_change_email
+      and_i_enter_a_blank_email_address
+      and_i_press_continue
+      and_i_press_back
       then_i_see_the_check_answers_page
     end
   end
@@ -261,6 +276,10 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   private
+
+  def and_i_enter_a_blank_email_address
+    fill_in 'Your email address', with: '', visible: false
+  end
 
   def and_the_date_of_birth_is_prepopulated
     expect(page).to have_field('Day', with: '1')


### PR DESCRIPTION
There are cases where the back link doesn't behave as a user might
expect.

eg. when a form renders a validation message like a field is blank, then
the back link currently goes back to the same page but without the
error.

This is strange from a user's point of view.

Instead, we want the back link to return to the last unique page the
user was on.

I've opted to use Javascript to approximate this. The implicit
assumption here is that when the referer for a request is the same, we
assume that we need to go back 2 pages in the browser history.

This doesn't work if the form has failed validation multiple times.

For this iteration, I decided that this will handle more of the error
cases than we currently are, without having to use a session variable to
store the page of origin.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
