### PR TITLE
Create new back link helper

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,6 @@ class PagesController < ApplicationController
   end
 
   def start
-    @trn_request = TrnRequest.new
+    session[:form_complete] = false
   end
 end

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -2,10 +2,12 @@
 class TrnRequestsController < ApplicationController
   def show
     redirect_to root_url unless trn_request
+    session[:form_complete] = true
   end
 
   def update
     redirect_to root_url unless trn_request
+    session[:form_complete] = false
 
     trn_request.update(trn_request_params)
     ZendeskService.create_ticket!(trn_request)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def back_link_url(trn_request)
-    referer = controller.request.env['HTTP_REFERER']
-    return check_answers_path if referer&.include?('check-answers') || trn_request&.email?
-    return referer if referer
+  def back_link_url(back = url_for(:back))
+    return check_answers_path if session[:form_complete]
 
-    start_path
+    back
   end
 
   def pretty_ni_number(ni_number)

--- a/app/views/check_trn/new.html.erb
+++ b/app/views/check_trn/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @check_trn_form.errors.any?}Check if you have a TRN number" %>
-<% content_for :back_link_url, back_link_url(@check_trn_form) %>
+<% content_for :back_link_url, start_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -15,10 +15,10 @@
     </ul>
     <%= form_with model: @check_trn_form, url: check_trn_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_radio_buttons(:has_trn, 
+      <%= f.govuk_collection_radio_buttons(:has_trn,
             [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
-            :value, 
-            :label, 
+            :value,
+            :label,
             legend: { size: 'm', text: 'Do you think you have a TRN?' }
           ) %>
       <%= f.govuk_submit prevent_double_click: false %>

--- a/app/views/date_of_birth/edit.html.erb
+++ b/app/views/date_of_birth/edit.html.erb
@@ -1,15 +1,15 @@
 <% content_for :page_title, "#{'Error: ' if date_of_birth_form.errors.any?}Your date of birth" %>
-<% content_for :back_link_url, back_link_url(date_of_birth_form) %>
+<% content_for :back_link_url, back_link_url(name_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: date_of_birth_form, url: date_of_birth_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_date_field(
-            :date_of_birth, 
-            date_of_birth: true, 
-            legend: { size: 'xl', text: 'Your date of birth' }, 
-            hint: { text: 'For example, 27 3 1987' } 
+            :date_of_birth,
+            date_of_birth: true,
+            legend: { size: 'xl', text: 'Your date of birth' },
+            hint: { text: 'For example, 27 3 1987' }
           )
       %>
       <%= f.govuk_submit prevent_double_click: false %>

--- a/app/views/email/edit.html.erb
+++ b/app/views/email/edit.html.erb
@@ -1,14 +1,14 @@
 <% content_for :page_title, "#{'Error: ' if @email_form.errors.any?}Your email address" %>
-<%= content_for :back_link_url, back_link_url(@email_form) %>
+<%= content_for :back_link_url, back_link_url(itt_provider_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @email_form, url: email_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_email_field(
-            :email, 
-            label: { size: 'xl', text: 'Your email address' }, 
-            hint: { text: 'If we can find your TRN, we’ll send it to the email address you give.' } 
+            :email,
+            label: { size: 'xl', text: 'Your email address' },
+            hint: { text: 'If we can find your TRN, we’ll send it to the email address you give.' }
           )
       %>
       <%= f.govuk_submit prevent_double_click: false %>

--- a/app/views/itt_providers/edit.html.erb
+++ b/app/views/itt_providers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @itt_provider_form.errors.any?}Have you been awarded qualified teacher status (QTS)?" %>
-<%= content_for :back_link_url, back_link_url(@trn_request) %>
+<%= content_for :back_link_url, back_link_url(have_ni_number_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/name/edit.html.erb
+++ b/app/views/name/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @name_form.errors.any?}Your name" %>
-<% content_for :back_link_url, back_link_url(@name_form) %>
+<% content_for :back_link_url, back_link_url(ask_questions_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/ni_number/edit.html.erb
+++ b/app/views/ni_number/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if ni_number.errors.any?}What is your National Insurance number?" %>
-<% content_for :back_link_url, back_link_url(ni_number) %>
+<% content_for :back_link_url, have_ni_number_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/ni_number/new.html.erb
+++ b/app/views/ni_number/new.html.erb
@@ -1,14 +1,14 @@
 <% content_for :page_title, "Do you have a National Insurance number?" %>
-<% content_for :back_link_url, back_link_url(trn_request) %>
+<% content_for :back_link_url, back_link_url(date_of_birth_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @has_ni_number_form, url: have_ni_number_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_radio_buttons(:has_ni_number, 
+      <%= f.govuk_collection_radio_buttons(:has_ni_number,
             [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
-            :value, 
-            :label, 
+            :value,
+            :label,
             legend: { size: 'xl', text: 'Do you have a National Insurance number?' }
           ) %>
       <%= f.govuk_submit prevent_double_click: false %>

--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, 'Check your answers' %>
-<%= content_for :back_link_url, start_path %>
+<%= content_for :back_link_url, back_link_url %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -7,19 +7,15 @@
     <p class="govuk-body">We will send your TRN to <%= @trn_request.email %> if we find one matching your details.</p>
 
     <% rows = [
-        { 
-          key: { text: 'Name' }, 
-          value: { text: @trn_request.name }, 
+        {
+          key: { text: 'Name' },
+          value: { text: @trn_request.name },
           actions: [{ href: name_path, visually_hidden_text: 'name' }]
         },
-        { 
-          key: { text: 'Date of birth' }, 
-          value: { text: @trn_request.date_of_birth? ? @trn_request.date_of_birth.to_fs(:long_ordinal_uk) : 'Not given' }, 
+        {
+          key: { text: 'Date of birth' },
+          value: { text: @trn_request.date_of_birth? ? @trn_request.date_of_birth.to_fs(:long_ordinal_uk) : 'Not given' },
           actions: [{ href: date_of_birth_path, visually_hidden_text: 'date of birth' }]
-        },
-        { key: { text: 'Email address '},
-          value: { text: @trn_request.email },
-          actions: [{ href: email_path, visually_hidden_text: 'email address' }]
         },
         {
           key: { text: @trn_request.has_ni_number? ? 'National Insurance number' : 'Do you have a National Insurance number?' },
@@ -31,7 +27,11 @@
           value: { text: @trn_request.itt_provider_enrolled ? @trn_request.itt_provider_name : 'No' },
           actions: [{ href: itt_provider_path, visually_hidden_text: 'teacher training provider' }]
         },
-      ] 
+        { key: { text: 'Email address '},
+          value: { text: @trn_request.email },
+          actions: [{ href: email_path, visually_hidden_text: 'email address' }]
+        },
+      ]
 
       previous_name = {
         key: { text: 'Previous name' },


### PR DESCRIPTION
This uses a specified URL, or the `:back` Rails action as a fallback when nothing is specified. When `session[:form_complete]` is set, the behaviour changes so that the back button takes users back to the form.

We re-set this when users submit the form or go back to the homepage.

In my testing this seems to work as expected in almost all situations; there's still one hard to trigger edge case: a user can submit every step of the form, get to check answers, and then back -> email -> back -> takes them to check answers instead of to the previous steps. But I think that's acceptable.