### PR TITLE
Switch to secure cookies in production

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+Rails.application.config.session_store :cookie_store, secure: Rails.env.production?


### PR DESCRIPTION
I couldn't verify this locally because it would require switching the protocol to HTTPS and a self-provisioned cert. But it should just work in Prod.