### PR TITLE
Prevent skipping steps

### DIFF
--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module EnforceQuestionOrder
+  extend ActiveSupport::Concern
+
+  included { before_action :redirect_by_status }
+
+  def redirect_by_status # rubocop:disable Metrics
+    redirect_to(start_url) and return if start_page_is_required?
+    redirect_to(name_url) and return if trn_request.nil?
+    return if current_page_is_allowed?
+
+    expected_url = urls[trn_request.status]
+    redirect_to(expected_url) if expected_url && expected_url != request.url
+  end
+
+  private
+
+  def current_page_is_allowed?
+    order = urls.keys.index(trn_request&.status)
+    current_position = urls.values.index(request.url)
+    current_position && order && current_position <= order
+  end
+
+  def start_page_is_required?
+    trn_request.nil? && request.path == '/trn-request'
+  end
+
+  def trn_request
+    @trn_request ||= TrnRequest.find_by(id: session[:trn_request_id])
+  end
+
+  def urls
+    {
+      name: name_url,
+      date_of_birth: date_of_birth_url,
+      has_ni_number: have_ni_number_url,
+      ni_number: ni_number_url,
+      itt_provider: itt_provider_url,
+      email: email_url,
+    }
+  end
+end

--- a/app/controllers/date_of_birth_controller.rb
+++ b/app/controllers/date_of_birth_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class DateOfBirthController < ApplicationController
+  include EnforceQuestionOrder
+
   def edit; end
 
   def update
@@ -19,9 +21,5 @@ class DateOfBirthController < ApplicationController
 
   def date_of_birth_params
     params.require(:date_of_birth_form).permit('date_of_birth(3i)', 'date_of_birth(2i)', 'date_of_birth(1i)')
-  end
-
-  def trn_request
-    @trn_request ||= TrnRequest.find_by(id: session[:trn_request_id])
   end
 end

--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 class EmailController < ApplicationController
+  include EnforceQuestionOrder
+
   def edit
-    trn_request = TrnRequest.find_by(id: session[:trn_request_id])
     @email_form = EmailForm.new(trn_request: trn_request)
   end
 
   def update
-    trn_request = TrnRequest.find_by(id: session[:trn_request_id])
     @email_form = EmailForm.new(email: email_params[:email], trn_request: trn_request)
     if @email_form.save
       redirect_to check_answers_url

--- a/app/controllers/itt_providers_controller.rb
+++ b/app/controllers/itt_providers_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class IttProvidersController < ApplicationController
+  include EnforceQuestionOrder
+
   def edit
     @itt_provider_form = IttProviderForm.new(trn_request: trn_request).assign_form_values
   end
@@ -20,9 +22,5 @@ class IttProvidersController < ApplicationController
       .require(:itt_provider_form)
       .permit(:itt_provider_enrolled, :itt_provider_name)
       .merge(trn_request: trn_request)
-  end
-
-  def trn_request
-    @trn_request ||= TrnRequest.find(session[:trn_request_id])
   end
 end

--- a/app/controllers/ni_number_controller.rb
+++ b/app/controllers/ni_number_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class NiNumberController < ApplicationController
+  include EnforceQuestionOrder
+
   def new
     @has_ni_number_form = HasNiNumberForm.new(trn_request: trn_request)
   end
@@ -36,7 +38,7 @@ class NiNumberController < ApplicationController
   end
 
   def trn_request
-    @trn_request ||= TrnRequest.find_by(id: session[:trn_request_id]) || TrnRequest.new
+    @trn_request ||= TrnRequest.find_by(id: session[:trn_request_id])
   end
   helper_method :trn_request
 end

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class TrnRequestsController < ApplicationController
+  include EnforceQuestionOrder
+
   def show
     redirect_to root_url unless trn_request
     session[:form_complete] = true
@@ -27,10 +29,6 @@ class TrnRequestsController < ApplicationController
   end
 
   private
-
-  def trn_request
-    @trn_request ||= TrnRequest.find_by(id: session[:trn_request_id])
-  end
 
   def trn_request_params
     params.require(:trn_request).permit(:answers_checked)

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -27,4 +27,15 @@ class TrnRequest < ApplicationRecord
 
     !has_ni_number.nil? && !has_ni_number_was.nil?
   end
+
+  def status # rubocop:disable Metrics
+    return :answers if email.present?
+    return :email unless itt_provider_enrolled.nil?
+    return :itt_provider if (!has_ni_number.nil? && ni_number.present?) || (!has_ni_number.nil? && !has_ni_number)
+    return :ni_number if has_ni_number
+    return :has_ni_number if date_of_birth.present?
+    return :date_of_birth if first_name.present?
+
+    :name
+  end
 end

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -67,4 +67,70 @@ RSpec.describe TrnRequest, type: :model do
       it { is_expected.to eq('John Smith') }
     end
   end
+
+  describe '#status' do
+    subject { trn_request.status }
+
+    let(:trn_request) { described_class.new(attributes) }
+
+    context 'when no attributes are present' do
+      let(:attributes) { nil }
+
+      it { is_expected.to eq(:name) }
+    end
+
+    context 'when a name is present' do
+      let(:attributes) { { first_name: 'John', last_name: 'Smith' } }
+
+      it { is_expected.to eq(:date_of_birth) }
+    end
+
+    context 'when a date of birth is present' do
+      let(:attributes) { { date_of_birth: '01/01/2000', first_name: 'John', last_name: 'Smith' } }
+
+      it { is_expected.to eq(:has_ni_number) }
+    end
+
+    context 'when has_ni_number is true' do
+      let(:attributes) { { date_of_birth: '01/01/2000', first_name: 'John', has_ni_number: true, last_name: 'Smith' } }
+
+      it { is_expected.to eq(:ni_number) }
+    end
+
+    context 'when an NI number is present' do
+      let(:attributes) { { date_of_birth: '01/01/2000', has_ni_number: false, first_name: 'John', last_name: 'Smith' } }
+
+      it { is_expected.to eq(:itt_provider) }
+    end
+
+    context 'when an ITT provider is present' do
+      let(:attributes) do
+        {
+          date_of_birth: '01/01/2000',
+          first_name: 'John',
+          itt_provider_enrolled: false,
+          last_name: 'Smith',
+          has_ni_number: false,
+        }
+      end
+
+      it { is_expected.to eq(:email) }
+    end
+
+    context 'when an email is present' do
+      let(:attributes) do
+        {
+          date_of_birth: '01/01/2000',
+          email: 'test@example.com',
+          first_name: 'John',
+          itt_provider_enrolled: 'yes',
+          itt_provider_name: 'Example',
+          last_name: 'Smith',
+          ni_number: 'QQ123456C',
+        }
+      end
+
+      it { is_expected.to eq(:answers) }
+    end
+  end
 end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -47,6 +47,38 @@ RSpec.describe 'TRN requests', type: :system do
 
     when_i_try_to_go_to_the_check_answers_page
     then_i_see_the_home_page
+
+    when_i_am_on_the_name_page
+    when_i_try_to_go_to_the_date_of_birth_page
+    then_i_see_the_name_page
+
+    when_i_fill_in_the_name_form
+    then_i_see_the_date_of_birth_page
+
+    when_i_try_to_go_to_the_ni_number_page
+    then_i_see_the_date_of_birth_page
+
+    when_i_complete_my_date_of_birth
+    then_i_see_the_have_ni_page
+
+    when_i_try_to_go_to_the_ni_number_page
+    then_i_see_the_have_ni_page
+    when_i_try_to_go_to_the_itt_provider_page
+    then_i_see_the_have_ni_page
+
+    when_i_choose_no
+    and_i_press_continue
+    then_i_see_the_itt_provider_page
+
+    when_i_try_to_go_to_the_email_page
+    then_i_see_the_itt_provider_page
+
+    when_i_choose_no
+    and_i_press_continue
+    then_i_see_the_email_page
+
+    when_i_try_to_go_to_the_check_answers_page
+    then_i_see_the_email_page
   end
 
   it 'entering the NI number' do
@@ -382,6 +414,7 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page.driver.browser.current_title).to start_with('Your date of birth')
     expect(page).to have_content('Your date of birth')
   end
+  alias_method :then_i_am_redirected_to_the_date_of_birth_page, :then_i_see_the_date_of_birth_page
 
   def then_i_see_the_email_page
     expect(page).to have_current_path('/email')
@@ -416,6 +449,7 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page.driver.browser.current_title).to start_with('Your name')
     expect(page).to have_content('Your name')
   end
+  alias_method :then_i_am_redirected_to_the_name_page, :then_i_see_the_name_page
 
   def then_i_see_the_ni_page
     expect(page).to have_current_path('/have-ni-number')
@@ -481,6 +515,18 @@ RSpec.describe 'TRN requests', type: :system do
     when_i_complete_my_date_of_birth
     when_i_choose_no_ni_number
     when_i_choose_no_itt_provider
+  end
+
+  def when_i_am_on_the_name_page
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
+    then_i_see_the_check_trn_page
+
+    when_i_confirm_i_have_a_trn_number
+    then_i_see_the_ask_questions_page
+
+    when_i_press_continue
+    then_i_see_the_name_page
   end
 
   def when_i_choose_no_trn
@@ -607,6 +653,22 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_try_to_go_to_the_check_answers_page
     visit trn_request_path
+  end
+
+  def when_i_try_to_go_to_the_date_of_birth_page
+    visit date_of_birth_path
+  end
+
+  def when_i_try_to_go_to_the_email_page
+    visit email_path
+  end
+
+  def when_i_try_to_go_to_the_itt_provider_page
+    visit itt_provider_path
+  end
+
+  def when_i_try_to_go_to_the_ni_number_page
+    visit ni_number_path
   end
 
   def when_i_am_authorized_as_a_support_user


### PR DESCRIPTION
Currently, we don't enforce the order of the steps in the request and if
someone happens to know a valid URL, they can enter it and effectively
skip steps in the request flow.

The check answers screen doesn't expect missing values and throws an
error in those cases.

I've opted to go with a lightweight version of a state machine and
implement a `status` method on `TrnRequest`. This was the smallest step
I thought was needed to achieve our goal here.

This determines the furthest step that has been completed in the request
based on the presence of the attributes.

The system needs to allow people to go to a previously completed step as
well.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
