### PR TITLE
Use deliver_now for TRN found email

### DIFF
--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -21,7 +21,7 @@ class TrnRequestsController < ApplicationController
     begin
       response = DqtApi.find_trn!(trn_request)
       trn_request.update(trn: response['trn'])
-      TeacherMailer.found_trn(trn_request).deliver_later
+      TeacherMailer.found_trn(trn_request).deliver_now
       redirect_to trn_found_path
     rescue DqtApi::ApiError, Faraday::ConnectionFailed, Faraday::TimeoutError, DqtApi::TooManyResults
       ZendeskService.create_ticket!(trn_request)


### PR DESCRIPTION
Not sure why `deliver_later` isn't working in production at the moment.
