### PR TITLE
Fix error summary JS not focusing on page load

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": "true",
   "dependencies": {
     "esbuild": "^0.14.29",
-    "govuk-frontend": "^4.0.0",
+    "govuk-frontend": "^4.0.1",
     "sass": "^1.49.10"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,10 +679,10 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-govuk-frontend@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz"
-  integrity sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ==
+govuk-frontend@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.0.1.tgz#bceff58ecb399272cba32bd2b357fe16198e3249"
+  integrity sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==
 
 has-bigints@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This was a recent change in 4.0.1: https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#remove-the-tabindex-attribute-from-the-error-summary-component

Upgrading fixes it.