### PR TITLE
Display Zendesk Ticket ID when users submit

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -6,4 +6,8 @@ module HostingEnvironment
   def self.environment_name
     ENV.fetch('HOSTING_ENVIRONMENT_NAME', 'unknown-environment')
   end
+
+  def self.test_environment?
+    TEST_ENVIRONMENTS.include?(HostingEnvironment.environment_name)
+  end
 end

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+
 class ZendeskService
   def self.create_ticket!(trn_request)
     return unless FeatureFlag.active?(:zendesk_integration)
 
     begin
-      GDS_ZENDESK_CLIENT.ticket.create!(ticket_template(trn_request))
+      ticket = GDS_ZENDESK_CLIENT.ticket.create!(ticket_template(trn_request))
+      trn_request.update!(zendesk_ticket_id: ticket.id)
     rescue ZendeskAPI::Error::RecordInvalid
       raise CreateError, 'Could not create Zendesk ticket'
     end

--- a/app/views/pages/helpdesk_request_submitted.html.erb
+++ b/app/views/pages/helpdesk_request_submitted.html.erb
@@ -14,7 +14,7 @@
     </p>
     <h2 class="govuk-heading-m">For urgent requests, call the Teaching Regulation Agency</h2>
     <p class="govuk-body">
-      Give the helpdesk your ticket number: <%= @trn_request.id %>
+      Give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>
     </p>
     <ul class="govuk-list">
       <li>Telephone: <%= t('tra.tel') %></li>

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -2,6 +2,23 @@
 require 'gds_zendesk/client'
 require 'gds_zendesk/dummy_client'
 
+module DummyTicketExtensions
+  # The create! method in the DummyTicket class does not actually return a
+  # real-ish Zendesk ticket. This is a monkey patch to call the original method
+  # and then return a ticket instance.
+  def create!(options)
+    super
+
+    ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)
+  end
+end
+
+module GDSZendesk
+  class DummyTicket
+    prepend DummyTicketExtensions
+  end
+end
+
 GDS_ZENDESK_CLIENT =
   if Rails.env.development? || Rails.env.test?
     GDSZendesk::DummyClient.new(development_mode: true, logger: Rails.logger)

--- a/db/migrate/20220412115717_add_zendesk_ticket_id_to_trn_request.rb
+++ b/db/migrate/20220412115717_add_zendesk_ticket_id_to_trn_request.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddZendeskTicketIdToTrnRequest < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trn_requests, :zendesk_ticket_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_22_103427) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_12_115717) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,6 +37,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_22_103427) do
     t.string "previous_first_name"
     t.string "previous_last_name"
     t.string "trn"
+    t.integer "zendesk_ticket_id"
   end
 
 end

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe ZendeskService do
 
     describe '.create_ticket!' do
       it 'creates a ticket' do
-        allow(ticket_client).to receive(:create!)
+        allow(ticket_client).to receive(:create!).and_return(ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42))
+
         trn_request =
           TrnRequest.new(
             date_of_birth: 20.years.ago,
@@ -76,6 +77,7 @@ RSpec.describe ZendeskService do
               },
             },
           )
+        expect(trn_request.zendesk_ticket_id).to eq(42)
       end
 
       it 'throws an error when it fails to create a ticket' do

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -2,7 +2,10 @@
 require 'rails_helper'
 
 RSpec.describe 'TRN requests', type: :system do
-  before { given_the_service_is_open }
+  before do
+    given_the_service_is_open
+    given_the_zendesk_integration_feature_is_enabled
+  end
 
   it 'completing a request' do
     given_i_am_on_the_home_page
@@ -373,6 +376,10 @@ RSpec.describe 'TRN requests', type: :system do
     FeatureFlag.activate(:use_dqt_api)
   end
 
+  def given_the_zendesk_integration_feature_is_enabled
+    FeatureFlag.activate(:zendesk_integration)
+  end
+
   def then_i_see_a_message_to_check_my_email
     expect(page).to have_content('We have sent your TRN to')
   end
@@ -412,6 +419,7 @@ RSpec.describe 'TRN requests', type: :system do
   def then_i_see_the_confirmation_page
     expect(page.driver.browser.current_title).to start_with('We’ve received your request')
     expect(page).to have_content('We’ve received your request')
+    expect(page).to have_content('Give the helpdesk your ticket number: 42')
   end
 
   def then_i_see_the_date_of_birth_page


### PR DESCRIPTION
### Context

We want to show users the zendesk ticket ID instead of the TRN Request ID when they complete the journey.

### Changes proposed in this pull request

- Add migration for the new field
- Monkey patch the DummyTicket class to return a ticket like the real Zendesk API does
- Tests

### Guidance to review

More PRs forthcoming with some refactoring and the other features in the card.

### Checklist

https://trello.com/c/8Cs42cy9/349-show-zendesk-ticket-ids-to-the-user-on-the-success-page-and-in-the-email

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
