### PR TITLE
Email users when they submit a Zendesk ticket

### DIFF
--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -14,6 +14,7 @@ class TrnRequestsController < ApplicationController
     update_trn_request
     unless FeatureFlag.active?(:use_dqt_api)
       ZendeskService.create_ticket!(trn_request)
+      TeacherMailer.information_received(trn_request).deliver_now
       redirect_to helpdesk_request_submitted_url
       return
     end
@@ -25,6 +26,7 @@ class TrnRequestsController < ApplicationController
       redirect_to trn_found_path
     rescue DqtApi::ApiError, Faraday::ConnectionFailed, Faraday::TimeoutError, DqtApi::TooManyResults
       ZendeskService.create_ticket!(trn_request)
+      TeacherMailer.information_received(trn_request).deliver_now
       redirect_to helpdesk_request_submitted_url
     end
   end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -9,4 +9,12 @@ class TeacherMailer < ApplicationMailer
 
     notify_email(mailer_options)
   end
+
+  def information_received(trn_request)
+    @trn_request = trn_request
+
+    mailer_options = { to: @trn_request.email, subject: 'We’ve received the information you submitted' }
+
+    notify_email(mailer_options)
+  end
 end

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -2,7 +2,10 @@
 
 class ZendeskService
   def self.create_ticket!(trn_request)
-    return unless FeatureFlag.active?(:zendesk_integration)
+    unless FeatureFlag.active?(:zendesk_integration)
+      raise ZendeskOffError, 'Could not create a Zendesk ticket because the ' \
+        ':zendesk_integration feature flag is off'
+    end
 
     begin
       ticket = GDS_ZENDESK_CLIENT.ticket.create!(ticket_template(trn_request))
@@ -34,5 +37,8 @@ class ZendeskService
   end
 
   class CreateError < StandardError
+  end
+
+  class ZendeskOffError < StandardError
   end
 end

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -3,8 +3,9 @@
 class ZendeskService
   def self.create_ticket!(trn_request)
     unless FeatureFlag.active?(:zendesk_integration)
-      raise ZendeskOffError, 'Could not create a Zendesk ticket because the ' \
-        ':zendesk_integration feature flag is off'
+      raise ZendeskOffError,
+            'Could not create a Zendesk ticket because the ' \
+              ':zendesk_integration feature flag is off'
     end
 
     begin

--- a/app/views/teacher_mailer/information_received.erb
+++ b/app/views/teacher_mailer/information_received.erb
@@ -1,0 +1,15 @@
+Dear <%= @trn_request.name %>,
+
+We’ve received the information you submitted.
+
+You’ll get an email with your TRN if we find a match. Otherwise, we’ll contact
+you for more information.
+
+We aim to respond in 5 working days.
+
+# If you need your TRN quickly
+
+Call the Teaching Regulation Agency and give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>.
+
+Telephone: <%= t('tra.tel') %>
+Monday to Friday, 9am to 5pm (except public holidays)

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -20,7 +20,7 @@ module GDSZendesk
 end
 
 GDS_ZENDESK_CLIENT =
-  if Rails.env.development? || Rails.env.test?
+  if HostingEnvironment.test_environment?
     GDSZendesk::DummyClient.new(development_mode: true, logger: Rails.logger)
   else
     GDSZendesk::Client.new(

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe ZendeskService do
         allow(ticket_client).to receive(:create!)
         trn_request = TrnRequest.new
 
-        described_class.create_ticket!(trn_request)
-
+        expect { described_class.create_ticket!(trn_request) }.to raise_error(ZendeskService::ZendeskOffError)
         expect(ticket_client).not_to have_received(:create!)
       end
     end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'TRN requests', type: :system do
 
     when_i_press_the_submit_button
     then_i_see_the_confirmation_page
+    and_i_receive_an_email_with_the_zendesk_ticket_number
   end
 
   it 'trying to skip steps' do
@@ -326,6 +327,12 @@ RSpec.describe 'TRN requests', type: :system do
   def and_i_receive_an_email_with_the_trn_number
     open_email('kevin@kevin.com')
     expect(current_email.subject).to eq('Your TRN is 1275362')
+  end
+
+  def and_i_receive_an_email_with_the_zendesk_ticket_number
+    open_email('kevin@kevin.com')
+    expect(current_email.subject).to eq('We’ve received the information you submitted')
+    expect(current_email.body).to include('give the helpdesk your ticket number: 42')
   end
 
   def and_the_date_of_birth_is_prepopulated


### PR DESCRIPTION
### Context

Carrying on with the Zendesk improvements.

### Changes proposed in this pull request

* Fail loudly when Zendesk integration is off
* Use the Zendesk DummyClient in the dev env
* Email users when they submit a Zendesk ticket

### Guidance to review

Review commit by commit.

Email:

![image](https://user-images.githubusercontent.com/1650875/162984882-df2ef0e8-1973-407d-b138-0358bf777202.png)

### Checklist

https://trello.com/c/8Cs42cy9/349-show-zendesk-ticket-ids-to-the-user-on-the-success-page-and-in-the-email

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
