### PR TITLE
Enquiry type

### DIFF
--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -34,6 +34,10 @@ class ZendeskService
         email: trn_request.email,
         name: trn_request.name,
       },
+      custom_fields: {
+        id: '4419328659089',
+        value: 'Request from Find a lost TRN app',
+      },
     }
   end
 

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe ZendeskService do
                 email: 'test@example.com',
                 name: 'Test User',
               },
+              custom_fields: {
+                id: '4419328659089',
+                value: 'Request from Find a lost TRN app',
+              },
             },
           )
         expect(trn_request.zendesk_ticket_id).to eq(42)


### PR DESCRIPTION
Prerequisite: https://github.com/DFE-Digital/find-a-lost-trn/pull/138

This will be used by a Zendesk automation to prevent an automatic email from being sent out to users when we create a ticket via Find a lost TRN, because we already send an email via Notify.