### PR TITLE
Reset the user's session after they submit 

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,11 +4,13 @@ class PagesController < ApplicationController
   def helpdesk_request_submitted
     @trn_request = TrnRequest.find_by(id: session[:trn_request_id])
     redirect_to root_url unless @trn_request
+    reset_session
   end
 
   def trn_found
     @trn_request = TrnRequest.find_by(id: session[:trn_request_id])
     redirect_to root_url unless @trn_request
+    reset_session
   end
 
   def start

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe 'TRN requests', type: :system do
     when_i_press_the_submit_button
     then_i_see_the_confirmation_page
     and_i_receive_an_email_with_the_zendesk_ticket_number
+
+    when_i_navigate_to_the_name_page
+    then_i_see_the_name_page
+    and_my_name_is_not_filled_in
   end
 
   it 'trying to skip steps' do
@@ -339,6 +343,10 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_field('Day', with: '1')
     expect(page).to have_field('Month', with: '1')
     expect(page).to have_field('Year', with: '1990')
+  end
+
+  def and_my_name_is_not_filled_in
+    expect(page).not_to have_field('First name', with: 'Kevin')
   end
 
   def given_i_am_on_the_home_page
@@ -693,5 +701,9 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_am_authorized_as_a_support_user
     page.driver.basic_authorize('test', 'test')
+  end
+
+  def when_i_navigate_to_the_name_page
+    visit name_path
   end
 end


### PR DESCRIPTION
### Context

Once the user is presented with the TRN Found or Helpdesk request submitted page, we should reset their sessions so that they can't go back / edit their data and resubmit.

### Changes proposed in this pull request

- Reset the user's session after they submit 
- Refactor update method in TrnRequests controller

### Guidance to review

Check that the tests make sense. Can review the `update` refactor separately as it's unrelated, I just felt like doing it.

### Checklist

https://trello.com/c/on7XJO4r/355-reset-a-users-session-after-they-submit-the-final-step

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
