### PR TITLE
Add validations for the presence of a previous name

### DIFF
--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -17,7 +17,7 @@ class NameController < ApplicationController
   private
 
   def name_params
-    params.require(:name_form).permit(:first_name, :previous_first_name, :previous_last_name, :last_name)
+    params.require(:name_form).permit(:first_name, :last_name, :name_changed, :previous_first_name, :previous_last_name)
   end
 
   def trn_request

--- a/app/forms/name_form.rb
+++ b/app/forms/name_form.rb
@@ -3,12 +3,12 @@ class NameForm
   include ActiveModel::Model
 
   attr_accessor :trn_request
-  attr_writer :first_name, :previous_first_name, :previous_last_name, :last_name, :name_changed
+  attr_writer :first_name, :last_name, :name_changed, :previous_first_name, :previous_last_name
 
   validates :first_name, presence: true, length: { maximum: 255 }
   validates :last_name, presence: true, length: { maximum: 255 }
-  validates :previous_first_name, length: { maximum: 255 }
-  validates :previous_last_name, length: { maximum: 255 }
+  validates :previous_first_name, presence: { if: %i[name_changed no_previous_last_name?] }, length: { maximum: 255 }
+  validates :previous_last_name, presence: { if: %i[name_changed no_previous_first_name?] }, length: { maximum: 255 }
 
   delegate :email?, :first_name, :last_name, to: :trn_request, allow_nil: true
 
@@ -19,7 +19,15 @@ class NameForm
   def name_changed
     return @name_changed unless @name_changed.nil?
 
-    @name_changed ||= previous_first_name.present? || previous_last_name.present? || trn_request.previous_name?
+    @name_changed ||= previous_first_name.present? || previous_last_name.present? || trn_request&.previous_name?
+  end
+
+  def no_previous_first_name?
+    previous_first_name.blank?
+  end
+
+  def no_previous_last_name?
+    previous_last_name.blank?
   end
 
   def previous_first_name

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -46,7 +46,7 @@ class DqtApi
         faraday.response :json
         faraday.response :logger, nil, { bodies: true, headers: true } do |logger|
           logger.filter(
-            /(emailAddress=|firstName=|lastName=|nationalInsuranceNumber=|previousFirstName=|previousLastName=)([^&]+)/,
+            /((emailAddress|firstName|lastName|nationalInsuranceNumber|previousFirstName|previousLastName)=)([^&]+)/,
             '\1[REDACTED]',
           )
         end

--- a/app/views/name/edit.html.erb
+++ b/app/views/name/edit.html.erb
@@ -21,7 +21,7 @@
           ) %>
 
       <%= f.govuk_check_boxes_fieldset :name_changed, legend: nil do %>
-        <%= f.govuk_check_box :name_changed, true, label: { text: 'I’ve changed my name since I received my TRN' }, link_errors: true do %>
+        <%= f.govuk_check_box :name_changed, "true", label: { text: 'I’ve changed my name since I received my TRN' }, link_errors: true, multiple: false do %>
           <%= f.govuk_text_field(:previous_first_name, label: { text: 'Previous first name' }) %>
           <%= f.govuk_text_field(:previous_last_name, label: { text: 'Previous last name' }) %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,8 +72,10 @@ en:
               blank: Enter your last name
               too_long: Enter a first name that is less than 255 letters long
             previous_first_name:
+              blank: Enter your previous first name
               too_long: Enter a previous first name that is less than 255 letters long
             previous_last_name:
+              blank: Enter your previous last name
               too_long: Enter a previous last name that is less than 255 letters long
         ni_number_form:
           attributes:

--- a/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/displays_the_TRN_returned_by_the_DQT_API.yml
+++ b/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/displays_the_TRN_returned_by_the_DQT_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Kevin&ittProviderName=&lastName=E&nationalInsuranceNumber&previousFirstName=&previousLastName=
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Kevin&ittProviderName=&lastName=E&nationalInsuranceNumber&previousFirstName&previousLastName
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/opens_a_Zendesk_ticket_when_there_is_no_match.yml
+++ b/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/opens_a_Zendesk_ticket_when_there_is_no_match.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName=&lastName=Match%20me&nationalInsuranceNumber&previousFirstName=&previousLastName=
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName=&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/forms/name_form_spec.rb
+++ b/spec/forms/name_form_spec.rb
@@ -6,10 +6,14 @@ RSpec.describe NameForm, type: :model do
   it { is_expected.to validate_presence_of(:last_name).with_message('Enter your last name') }
   it { is_expected.to validate_length_of(:first_name).is_at_most(255) }
   it { is_expected.to validate_length_of(:last_name).is_at_most(255) }
+  it { is_expected.not_to validate_presence_of(:previous_first_name) }
+  it { is_expected.not_to validate_presence_of(:previous_last_name) }
 
   context 'when name_changed is true' do
     subject { described_class.new(name_changed: true) }
 
+    it { is_expected.to validate_presence_of(:previous_first_name).with_message('Enter your previous first name') }
+    it { is_expected.to validate_presence_of(:previous_last_name).with_message('Enter your previous last name') }
     it { is_expected.to validate_length_of(:previous_first_name).is_at_most(255) }
     it { is_expected.to validate_length_of(:previous_last_name).is_at_most(255) }
   end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -416,8 +416,8 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   def then_i_see_a_missing_previous_name_error
-    expect(page).to have_content('Please enter your previous first name')
-    expect(page).to have_content('Please enter your previous last name')
+    expect(page).to have_content('Enter your previous first name')
+    expect(page).to have_content('Enter your previous last name')
   end
 
   def then_i_see_the_ask_questions_page

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -415,6 +415,11 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('We have sent your TRN to')
   end
 
+  def then_i_see_a_missing_previous_name_error
+    expect(page).to have_content('Please enter your previous first name')
+    expect(page).to have_content('Please enter your previous last name')
+  end
+
   def then_i_see_the_ask_questions_page
     expect(page).to have_current_path('/ask-questions')
     expect(page.driver.browser.current_title).to start_with('We’ll ask you some questions to help find your TRN')
@@ -587,6 +592,8 @@ RSpec.describe 'TRN requests', type: :system do
     fill_in 'First name', with: 'Kevin'
     fill_in 'Last name', with: 'Smith'
     check 'I’ve changed my name since I received my TRN', visible: false
+    when_i_press_continue
+    then_i_see_a_missing_previous_name_error
     fill_in 'Previous last name', with: 'Evans'
     when_i_press_continue
   end


### PR DESCRIPTION
If someone indicates they have changed their name by checking the
relevant box, there are no validations to check whether they actually
provide a previous first or last name.

We want to conditionally validate these fields whenever a name change
has been indicated.

### Guidance to review

Currently, this isn't working correctly. I can't seem to get the conditional fieldset to expand when there's a validation error.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
