### PR TITLE
Add an 'Error' prefix to the page title

### DIFF
--- a/app/views/ni_number/new.html.erb
+++ b/app/views/ni_number/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Do you have a National Insurance number?" %>
+<% content_for :page_title, "#{'Error: ' if @has_ni_number_form.errors.any?}Do you have a National Insurance number?" %>
 <% content_for :back_link_url, back_link_url(date_of_birth_path) %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
If someone fails to choose an answer for the 'Do you have a National
Insurance number?' question, we display an error message on the page but
not in the title.

This conditionally adds the prefix to the title.

<img width="1430" alt="Screen Shot 2022-04-13 at 12 18 16 pm" src="https://user-images.githubusercontent.com/3126/163169622-de65a16e-e798-4927-b346-71928ff2f362.png">


### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
