### PR TITLE
Fix the back link for the itt-provider screen

### DIFF
--- a/app/views/itt_providers/edit.html.erb
+++ b/app/views/itt_providers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @itt_provider_form.errors.any?}Have you been awarded qualified teacher status (QTS)?" %>
-<%= content_for :back_link_url, back_link_url(have_ni_number_path) %>
+<%= content_for :back_link_url, back_link_url(@itt_provider_form.trn_request.has_ni_number? ? ni_number_path : have_ni_number_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
When the 'Do you have a National Insurance number?' question has been
answered in the affirmative, the back link for the ITT provider screen
should return to the form to enter a national insurance number.
Currently, it goes to the screen previous to that.

I opted to check the answer in the itt provider view to determine the
correct URL to go back to. That seemed to be the simplest and easiest to
understand solution here.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
