### PR TITLE
Fix back link for the check answers screen

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module ApplicationHelper
   def back_link_url(back = url_for(:back))
-    return check_answers_path if session[:form_complete]
+    return check_answers_path if session[:form_complete] && request.path != check_answers_path
 
     back
   end


### PR DESCRIPTION
When viewing the check answers path, the back link
always points to itself.

There's a bug in the helper method that builds this link. When the form
is marked as complete, it always goes to the check answers screen.

I've updated it to ignore this if the link is generated on the check
answers screen.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
