### PR TITLE
Update the value of the Enquiry type custom field

### DIFF
--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -36,7 +36,7 @@ class ZendeskService
       },
       custom_fields: {
         id: '4419328659089',
-        value: 'Request from Find a lost TRN app',
+        value: 'request_from_find_a_lost_trn_app',
       },
     }
   end

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ZendeskService do
               },
               custom_fields: {
                 id: '4419328659089',
-                value: 'Request from Find a lost TRN app',
+                value: 'request_from_find_a_lost_trn_app',
               },
             },
           )


### PR DESCRIPTION
The field is of type `Dropdown` not `Text` in Zendesk, so we think we need to pass in this value for it to be picked up.