### PR TITLE
Add a presence validation for email

### DIFF
--- a/app/forms/email_form.rb
+++ b/app/forms/email_form.rb
@@ -5,7 +5,7 @@ class EmailForm
   attr_accessor :trn_request
   attr_writer :email
 
-  validates :email, valid_for_notify: true
+  validates :email, presence: true, valid_for_notify: { if: :email }
 
   delegate :email?, to: :trn_request, allow_nil: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,10 @@ en:
               missing_month: Your date of birth must include a month
               missing_year: Your date of birth must include a year
               in_the_future: Your date of birth must be in the past
+        email_form:
+          attributes:
+            email:
+              blank: Enter an email address
         has_ni_number_form:
           attributes:
             has_ni_number:

--- a/spec/forms/email_form_spec.rb
+++ b/spec/forms/email_form_spec.rb
@@ -4,10 +4,17 @@ require 'rails_helper'
 RSpec.describe EmailForm, type: :model do
   subject(:email_form) { described_class.new }
 
-  specify do
-    expect(email_form).to validate_presence_of(:email).with_message(
-      'Enter an email address in the correct format, like name@example.com',
-    )
+  specify { expect(email_form).to validate_presence_of(:email).with_message('Enter an email address') }
+
+  context 'when the email is in the wrong format' do
+    subject(:email_form) { described_class.new(email: 'not_an_email') }
+
+    specify do
+      email_form.valid?
+      expect(email_form.errors[:email]).to include(
+        'Enter an email address in the correct format, like name@example.com',
+      )
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
Currently, we use the notify format validations to also validate the
presence of an email address. This gives a slightly strange error
message for the nil case.

Our preference is to make that nil error simpler and notify the user
that the email address is missing.

I opted to conditionally apply the notify validations to avoid
displaying multiple error messages when the email field is blank.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
