### PR TITLE
Update the request submitted screen

### DIFF
--- a/app/views/pages/helpdesk_request_submitted.html.erb
+++ b/app/views/pages/helpdesk_request_submitted.html.erb
@@ -3,18 +3,18 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= govuk_panel(
-      title_text: 'We’ve received your request',
       classes: %w[govuk-!-margin-bottom-6]
     ) do %>
+      <h1 class='govuk-panel__title'>We’ve received your&nbsp;request</h1>
       <p class='app-!-inherit-colour govuk-!-margin-bottom-0 govuk-!-font-size-24'>You’ll get an email with your TRN if we find a match. Otherwise, we’ll contact you for more information.</p>
     <% end %>
     <h2 class="govuk-heading-m">What happens next?</h2>
     <p class='govuk-body'>
       We’re likely to get back to you in 2 working days, but it could take up to 5.
     </p>
-    <h2 class="govuk-heading-m">For urgent requests, call the Teaching Regulation Agency</h2>
+    <h2 class="govuk-heading-m">If you need your TRN quickly</h2>
     <p class="govuk-body">
-      Give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>
+      Call the Teaching Regulation Agency and give the helpdesk your request number: <%= @trn_request.zendesk_ticket_id %>
     </p>
     <ul class="govuk-list">
       <li>Telephone: <%= t('tra.tel') %></li>

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -455,7 +455,7 @@ RSpec.describe 'TRN requests', type: :system do
   def then_i_see_the_zendesk_confirmation_page
     expect(page.driver.browser.current_title).to start_with('We’ve received your request')
     expect(page).to have_content('We’ve received your request')
-    expect(page).to have_content('Give the helpdesk your ticket number: 42')
+    expect(page).to have_content('give the helpdesk your request number: 42')
   end
 
   def then_i_see_the_date_of_birth_page


### PR DESCRIPTION
A couple of small copy changes here.

* We want to ensure that the title keeps 'request received' on the same line.
* There's a copy change relating to instructions about urgent requests.

In order to get the title displaying correctly, I needed to insert a
non-breaking space character between the words we want to keep together.

The view component we use for the panel doesn't have an attribute to
allow inserting anything but plain text. As a result, I needed to
fallback to writing the HTML for the header.

<img width="914" alt="Screen Shot 2022-04-14 at 11 06 50 am" src="https://user-images.githubusercontent.com/3126/163363551-062c5328-1c67-406b-a0f3-7b0226ffef98.png">

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
