### PR TITLE
Add no match page

### DIFF
--- a/app/controllers/no_match_controller.rb
+++ b/app/controllers/no_match_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class NoMatchController < ApplicationController
+  include EnforceQuestionOrder
+
+  def new
+    @no_match_form = NoMatchForm.new
+  end
+
+  def create
+    @no_match_form = NoMatchForm.new(no_match_params)
+    if @no_match_form.valid? && @no_match_form.try_again?
+      redirect_to check_answers_path
+    elsif @no_match_form.valid?
+      create_zendesk_ticket
+
+      redirect_to helpdesk_request_submitted_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def no_match_params
+    params.require(:no_match_form).permit(:try_again)
+  end
+
+  def create_zendesk_ticket
+    ZendeskService.create_ticket!(trn_request)
+    TeacherMailer.information_received(trn_request).deliver_now
+  end
+end

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -17,10 +17,12 @@ class TrnRequestsController < ApplicationController
       find_trn_using_api
 
       redirect_to trn_found_path
-    rescue DqtApi::ApiError, Faraday::ConnectionFailed, Faraday::TimeoutError, DqtApi::TooManyResults, DqtApi::NoResults
+    rescue DqtApi::NoResults
+      redirect_to no_match_path
+    rescue DqtApi::ApiError, Faraday::ConnectionFailed, Faraday::TimeoutError, DqtApi::TooManyResults
       create_zendesk_ticket
 
-      redirect_to helpdesk_request_submitted_url
+      redirect_to helpdesk_request_submitted_path
     end
   end
 

--- a/app/forms/no_match_form.rb
+++ b/app/forms/no_match_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class NoMatchForm
+  include ActiveModel::Model
+
+  attr_accessor :try_again
+
+  validates :try_again, inclusion: { in: %w[true false] }
+
+  def try_again?
+    ActiveModel::Type::Boolean.new.cast(try_again)
+  end
+end

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -9,7 +9,7 @@ class DqtApi
   class NoResults < StandardError
   end
 
-  TWO_SECONDS = 2
+  FIVE_SECONDS = 5
 
   def self.find_trn!(trn_request) # rubocop:disable Metrics/AbcSize
     raise Faraday::TimeoutError, 'Time-out feature flag enabled' if FeatureFlag.active?(:dqt_api_always_timeout)
@@ -40,7 +40,7 @@ class DqtApi
 
   def client
     @client ||=
-      Faraday.new(url: ENV['DQT_API_URL'], request: { timeout: TWO_SECONDS }) do |faraday|
+      Faraday.new(url: ENV['DQT_API_URL'], request: { timeout: FIVE_SECONDS }) do |faraday|
         faraday.request :authorization, 'Bearer', ENV['DQT_API_KEY']
         faraday.request :json
         faraday.response :json

--- a/app/views/no_match/new.html.erb
+++ b/app/views/no_match/new.html.erb
@@ -1,0 +1,62 @@
+<% content_for :page_title, "#{'Error: ' if @no_match_form.errors.any?}We could not find your trn" %>
+<% content_for :back_link_url, check_answers_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @no_match_form, url: no_match_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">We could not find your TRN</h1>
+
+      <p class="govuk-body">This could be because you:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>abbreviated your first name, for example Rob/Robert</li>
+        <li>used a different name to the one held on the Teaching Regulation
+          Agency records</li>
+        <li>mistyped or entered some incorrect information</li>
+      </ul>
+
+      <h2 class="govuk-heading-m">Check your details</h2>
+
+      <% rows = [
+          {
+            key: { text: 'Name' },
+            value: { text: @trn_request.name },
+          },
+          {
+            key: { text: 'Date of birth' },
+            value: { text: @trn_request.date_of_birth? ? @trn_request.date_of_birth.to_fs(:long_ordinal_uk) : 'Not given' },
+          },
+          {
+            key: { text: @trn_request.has_ni_number? ? 'National Insurance number' : 'Do you have a National Insurance number?' },
+            value: { text: @trn_request.has_ni_number? ? pretty_ni_number(@trn_request.ni_number) : 'No' },
+          },
+          {
+            key: { text: @trn_request.itt_provider_enrolled ? 'Where did you get your QTS?' : 'Have you been awarded QTS?' },
+            value: { text: @trn_request.itt_provider_enrolled ? @trn_request.itt_provider_name : 'No' },
+          },
+          { key: { text: 'Email address '},
+            value: { text: @trn_request.email },
+          },
+        ]
+
+        previous_name = {
+          key: { text: 'Previous name' },
+          value: { text: @trn_request.previous_name },
+        }
+
+        rows.insert(1, previous_name) if @trn_request.previous_name?
+      %>
+      <%= govuk_summary_list(rows: rows) %>
+
+      <%= f.govuk_collection_radio_buttons(:try_again,
+            [OpenStruct.new(label: 'Yes, I have different details I can try', value: true), OpenStruct.new(label: 'No, submit these details, they are correct', value: false)],
+            :value,
+            :label,
+            legend: { size: 'm', text: 'Do you want to change something and try again?' }
+          ) %>
+      <%= f.govuk_submit 'Continue', prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,10 @@ en:
           attributes:
             has_trn:
               inclusion: Tell us if you think you have a TRN
+        no_match_form:
+          attributes:
+            try_again:
+              inclusion: Choose if you want to try different details, or keep the current ones
         date_of_birth_form:
           attributes:
             date_of_birth:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,9 @@ Rails.application.routes.draw do
   get '/check-trn', to: 'check_trn#new'
   post '/check-trn', to: 'check_trn#create'
 
+  get '/no-match', to: 'no_match#new'
+  post '/no-match', to: 'no_match#create'
+
   get '/ask-questions', to: 'pages#ask_questions'
   get '/helpdesk-request-submitted', to: 'pages#helpdesk_request_submitted'
   get '/longer-than-normal', to: 'pages#longer_than_normal'

--- a/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/shows_the_no_match_page_and_opens_a_Zendesk_ticket_when_there_is_no_match.yml
+++ b/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/shows_the_no_match_page_and_opens_a_Zendesk_ticket_when_there_is_no_match.yml
@@ -1,0 +1,115 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName=&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+          - Faraday v1.10.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - '*/*'
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Thu, 14 Apr 2022 12:54:12 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - '299'
+        X-Rate-Limit-Reset:
+          - '2022-04-14T12:55:00.0000000Z'
+        X-Vcap-Request-Id:
+          - bac61863-d3fa-495c-4174-9ba55a40f05d
+        X-Xss-Protection:
+          - '0'
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 89695f3a4a3f2f2d6df76a407130856e.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LIS50-C1
+        X-Amz-Cf-Id:
+          - ybOy6vIQo9fJZLTLrALNdcZv2u6bErmbazGxAni26eB74spubB7I1Q==
+      body:
+        encoding: UTF-8
+        string: '{"results":[]}'
+    recorded_at: Thu, 14 Apr 2022 12:54:12 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName=&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+          - Faraday v1.10.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - '*/*'
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Thu, 14 Apr 2022 12:54:13 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - '298'
+        X-Rate-Limit-Reset:
+          - '2022-04-14T12:55:00.0000000Z'
+        X-Vcap-Request-Id:
+          - 768fa711-9091-4c89-4a14-5d6367d75378
+        X-Xss-Protection:
+          - '0'
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 6767a485c1321860ef79f182d40e0050.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LIS50-C1
+        X-Amz-Cf-Id:
+          - WZ58Yo2uSFBwNWtxoHuSdsii9u25IYbpM0dhMlT-G4gTQi8ZJLMNOw==
+      body:
+        encoding: UTF-8
+        string: '{"results":[]}'
+    recorded_at: Thu, 14 Apr 2022 12:54:13 GMT
+recorded_with: VCR 6.1.0

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -326,11 +326,25 @@ RSpec.describe 'TRN requests', type: :system do
       and_i_receive_an_email_with_the_trn_number
     end
 
-    it 'opens a Zendesk ticket when there is no match', vcr: true do
+    it 'shows the no match page and opens a Zendesk ticket when there is no match', vcr: true do
       given_the_use_dqt_api_feature_is_enabled
       when_i_have_completed_a_trn_request_that_wont_match
       and_i_press_the_submit_button
+      then_i_see_the_no_match_page
+      and_i_see_my_not_matching_details
 
+      when_i_press_continue
+      then_i_see_the_no_match_validation_error
+
+      when_i_choose_yes_i_have_different_details
+      and_i_press_continue
+      then_i_see_the_check_answers_page_with_not_matching_details
+
+      when_i_press_the_submit_button
+      then_i_see_the_no_match_page
+
+      when_i_choose_no_my_details_are_correct
+      and_i_press_continue
       then_i_see_the_zendesk_confirmation_page
       and_i_receive_an_email_with_the_zendesk_ticket_number
     end
@@ -435,6 +449,21 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('Date of birth')
     expect(page).to have_content('1 January 1990')
   end
+
+  def then_i_see_the_check_answers_page_with_not_matching_details
+    expect(page).to have_current_path('/check-answers')
+    expect(page.driver.browser.current_title).to start_with('Check your answers')
+    expect(page).to have_content('Check your answers')
+    and_i_see_my_not_matching_details
+  end
+
+  def then_i_see_my_not_matching_details
+    expect(page).to have_content('Do not Match me')
+    expect(page).to have_content('kevin@kevin.com')
+    expect(page).to have_content('Date of birth')
+    expect(page).to have_content('1 January 1990')
+  end
+  alias_method :and_i_see_my_not_matching_details, :then_i_see_my_not_matching_details
 
   def then_i_see_the_ni_missing_error
     expect(page).to have_content('Tell us if you have a National Insurance number')
@@ -542,6 +571,15 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('There is a problem')
   end
 
+  def then_i_see_the_no_match_validation_error
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content('Choose if you want to try different details, or keep the current ones')
+  end
+
+  def then_i_see_the_no_match_page
+    expect(page).to have_content('We could not find your TRN')
+  end
+
   def then_i_should_see_the_home_page
     expect(page).to have_content('Find a lost teacher reference number')
   end
@@ -638,6 +676,14 @@ RSpec.describe 'TRN requests', type: :system do
   def when_i_choose_yes_to_ni_number
     choose 'Yes', visible: false
     click_on 'Continue'
+  end
+
+  def when_i_choose_yes_i_have_different_details
+    choose 'Yes, I have different details I can try', visible: false
+  end
+
+  def when_i_choose_no_my_details_are_correct
+    choose 'No, submit these details, they are correct', visible: false
   end
 
   def when_i_enter_a_valid_ni_number


### PR DESCRIPTION
### Context

When we receive exactly zero results from the API, we want to allow users to change their details and try again. If they refuse, we should open a Zendesk ticket for them as before.

### Changes proposed in this pull request

- Bump up DQT API timeout to 5 seconds (decreases the likelihood that users will skip this page and go directly to Zendesk)
- Add the no match page

### Guidance to review

I'd like to create a component for the user details that are shared in the check answers page, but I'll do that as a follow-up PR.

![image](https://user-images.githubusercontent.com/1650875/163399489-6c210efc-6387-4ff6-a13b-2fb9420d193f.png)

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
