### PR TITLE
Create and use TrnDetailsComponent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails'
+  gem 'factory_bot_rails'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
@@ -64,6 +65,7 @@ group :test do
   gem 'capybara', '~> 3.36'
   gem 'capybara-email'
   gem 'cuprite', '~> 0.13'
+  gem 'faker'
   gem 'rspec'
   gem 'rspec-rails'
   gem 'shoulda-matchers', '~> 5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,13 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    faker (2.20.0)
+      i18n (>= 1.8.11, < 2)
     faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -361,6 +368,8 @@ DEPENDENCIES
   cuprite (~> 0.13)
   debug
   dotenv-rails
+  factory_bot_rails
+  faker
   faraday (~> 1.10)
   foreman (~> 0.87.2)
   gds_zendesk

--- a/app/components/trn_details_component.html.erb
+++ b/app/components/trn_details_component.html.erb
@@ -1,29 +1,11 @@
-<% rows = [
-    {
-      key: { text: 'Name' },
-      value: { text: name },
-      actions: [{ href: name_path, visually_hidden_text: 'name' }]
-    },
-    {
-      key: { text: 'Date of birth' },
-      value: { text: date_of_birth },
-      actions: [{ href: date_of_birth_path, visually_hidden_text: 'date of birth' }]
-    },
-    {
-      key: { text: ni_key },
-      value: { text: ni_value },
-      actions: [{ href: have_ni_number_path, visually_hidden_text: 'national insurance number' }]
-    },
-    {
-      key: { text: itt_provider_key },
-      value: { text: itt_provider_value },
-      actions: [{ href: itt_provider_path, visually_hidden_text: 'teacher training provider' }]
-    },
-    { key: { text: 'Email address' },
-      value: { text: email },
-      actions: [{ href: email_path, visually_hidden_text: 'email address' }]
-    },
-  ]
+<%
+  rows = []
+
+  name_row = {
+    key: { text: 'Name' },
+    value: { text: name },
+    actions: [{ href: name_path, visually_hidden_text: 'name' }]
+  }
 
   previous_name_row = {
     key: { text: 'Previous name' },
@@ -31,7 +13,36 @@
     actions: [{ href: name_path, visually_hidden_text: 'previous name' }]
   }
 
-  rows.insert(1, previous_name_row) if @trn_request.previous_name?
+  date_of_birth_row = {
+    key: { text: 'Date of birth' },
+    value: { text: date_of_birth },
+    actions: [{ href: date_of_birth_path, visually_hidden_text: 'date of birth' }]
+  }
+
+  ni_row = {
+    key: { text: ni_key },
+    value: { text: ni_value },
+    actions: [{ href: have_ni_number_path, visually_hidden_text: 'national insurance number' }]
+  }
+
+  itt_provider_row = {
+    key: { text: itt_provider_key },
+    value: { text: itt_provider_value },
+    actions: [{ href: itt_provider_path, visually_hidden_text: 'teacher training provider' }]
+  }
+
+  email_row = {
+    key: { text: 'Email address' },
+    value: { text: email },
+    actions: [{ href: email_path, visually_hidden_text: 'email address' }]
+  }
+
+  rows.push(name_row)
+  rows.push(previous_name_row) if @trn_request.previous_name?
+  rows.push(date_of_birth_row)
+  rows.push(ni_row)
+  rows.push(itt_provider_row) unless @trn_request.itt_provider_enrolled.nil?
+  rows.push(email_row)
 
   rows.map! {|r| r.except(:actions)} unless @actions
 %>

--- a/app/components/trn_details_component.html.erb
+++ b/app/components/trn_details_component.html.erb
@@ -1,0 +1,38 @@
+<% rows = [
+    {
+      key: { text: 'Name' },
+      value: { text: name },
+      actions: [{ href: name_path, visually_hidden_text: 'name' }]
+    },
+    {
+      key: { text: 'Date of birth' },
+      value: { text: date_of_birth },
+      actions: [{ href: date_of_birth_path, visually_hidden_text: 'date of birth' }]
+    },
+    {
+      key: { text: ni_key },
+      value: { text: ni_value },
+      actions: [{ href: have_ni_number_path, visually_hidden_text: 'national insurance number' }]
+    },
+    {
+      key: { text: itt_provider_key },
+      value: { text: itt_provider_value },
+      actions: [{ href: itt_provider_path, visually_hidden_text: 'teacher training provider' }]
+    },
+    { key: { text: 'Email address' },
+      value: { text: email },
+      actions: [{ href: email_path, visually_hidden_text: 'email address' }]
+    },
+  ]
+
+  previous_name_row = {
+    key: { text: 'Previous name' },
+    value: { text: previous_name },
+    actions: [{ href: name_path, visually_hidden_text: 'previous name' }]
+  }
+
+  rows.insert(1, previous_name_row) if @trn_request.previous_name?
+
+  rows.map! {|r| r.except(:actions)} unless @actions
+%>
+<%= govuk_summary_list(rows: rows) %>

--- a/app/components/trn_details_component.rb
+++ b/app/components/trn_details_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class TrnDetailsComponent < ViewComponent::Base
   def initialize(trn_request:, actions: false, anonymise: false)
+    super
     @actions = actions
     @anonymise = anonymise
     @trn_request = trn_request
@@ -9,14 +10,7 @@ class TrnDetailsComponent < ViewComponent::Base
   end
 
   def name
-    if @anonymise
-      @trn_request.name
-        .split(' ')
-        .map {|name| name.first + '****' }
-        .join(' ')
-    else
-      @trn_request.name
-    end
+    @anonymise ? @trn_request.name.split.map { |name| "#{name.first}****" }.join(' ') : @trn_request.name
   end
 
   def date_of_birth
@@ -33,7 +27,7 @@ class TrnDetailsComponent < ViewComponent::Base
 
   def ni_value
     if @anonymise && @trn_request.has_ni_number?
-      @trn_request.ni_number.first + '* ** ** ** ' + @trn_request.ni_number.last
+      "#{@trn_request.ni_number.first}* ** ** ** #{@trn_request.ni_number.last}"
     else
       @trn_request.has_ni_number? ? helpers.pretty_ni_number(@trn_request.ni_number) : 'No'
     end
@@ -49,7 +43,7 @@ class TrnDetailsComponent < ViewComponent::Base
 
   def email
     if @anonymise && !@trn_request.email.nil?
-      @trn_request.email.first + '****@****.' + @trn_request.email.split('.').last
+      "#{@trn_request.email.first}****@****.#{@trn_request.email.split('.').last}"
     else
       @trn_request.email
     end
@@ -57,10 +51,7 @@ class TrnDetailsComponent < ViewComponent::Base
 
   def previous_name
     if @anonymise
-      @trn_request.previous_name
-        .split(' ')
-        .map {|name| name.first + '****' }
-        .join(' ')
+      @trn_request.previous_name.split.map { |name| "#{name.first}****" }.join(' ')
     else
       @trn_request.previous_name
     end

--- a/app/components/trn_details_component.rb
+++ b/app/components/trn_details_component.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+class TrnDetailsComponent < ViewComponent::Base
+  def initialize(trn_request:, actions: false, anonymise: false)
+    @actions = actions
+    @anonymise = anonymise
+    @trn_request = trn_request
+
+    raise ArgumentError, 'Cannot render both actions and anonymised data' if @actions && @anonymise
+  end
+
+  def name
+    if @anonymise
+      @trn_request.name
+        .split(' ')
+        .map {|name| name.first + '****' }
+        .join(' ')
+    else
+      @trn_request.name
+    end
+  end
+
+  def date_of_birth
+    if @anonymise
+      '** ** ****'
+    else
+      @trn_request.date_of_birth? ? @trn_request.date_of_birth.to_fs(:long_ordinal_uk) : 'Not given'
+    end
+  end
+
+  def ni_key
+    @trn_request.has_ni_number? ? 'National Insurance number' : 'Do you have a National Insurance number?'
+  end
+
+  def ni_value
+    if @anonymise && @trn_request.has_ni_number?
+      @trn_request.ni_number.first + '* ** ** ** ' + @trn_request.ni_number.last
+    else
+      @trn_request.has_ni_number? ? helpers.pretty_ni_number(@trn_request.ni_number) : 'No'
+    end
+  end
+
+  def itt_provider_key
+    @trn_request.itt_provider_enrolled ? 'Where did you get your QTS?' : 'Have you been awarded QTS?'
+  end
+
+  def itt_provider_value
+    @trn_request.itt_provider_enrolled ? @trn_request.itt_provider_name : 'No'
+  end
+
+  def email
+    if @anonymise && !@trn_request.email.nil?
+      @trn_request.email.first + '****@****.' + @trn_request.email.split('.').last
+    else
+      @trn_request.email
+    end
+  end
+
+  def previous_name
+    if @anonymise
+      @trn_request.previous_name
+        .split(' ')
+        .map {|name| name.first + '****' }
+        .join(' ')
+    else
+      @trn_request.previous_name
+    end
+  end
+end

--- a/app/controllers/support_interface/trn_requests_controller.rb
+++ b/app/controllers/support_interface/trn_requests_controller.rb
@@ -2,7 +2,7 @@
 module SupportInterface
   class TrnRequestsController < SupportInterfaceController
     def index
-      @trn_requests = TrnRequest.all
+      @trn_requests = TrnRequest.order(updated_at: :desc).limit(100)
     end
   end
 end

--- a/app/views/no_match/new.html.erb
+++ b/app/views/no_match/new.html.erb
@@ -19,36 +19,7 @@
 
       <h2 class="govuk-heading-m">Check your details</h2>
 
-      <% rows = [
-          {
-            key: { text: 'Name' },
-            value: { text: @trn_request.name },
-          },
-          {
-            key: { text: 'Date of birth' },
-            value: { text: @trn_request.date_of_birth? ? @trn_request.date_of_birth.to_fs(:long_ordinal_uk) : 'Not given' },
-          },
-          {
-            key: { text: @trn_request.has_ni_number? ? 'National Insurance number' : 'Do you have a National Insurance number?' },
-            value: { text: @trn_request.has_ni_number? ? pretty_ni_number(@trn_request.ni_number) : 'No' },
-          },
-          {
-            key: { text: @trn_request.itt_provider_enrolled ? 'Where did you get your QTS?' : 'Have you been awarded QTS?' },
-            value: { text: @trn_request.itt_provider_enrolled ? @trn_request.itt_provider_name : 'No' },
-          },
-          { key: { text: 'Email address '},
-            value: { text: @trn_request.email },
-          },
-        ]
-
-        previous_name = {
-          key: { text: 'Previous name' },
-          value: { text: @trn_request.previous_name },
-        }
-
-        rows.insert(1, previous_name) if @trn_request.previous_name?
-      %>
-      <%= govuk_summary_list(rows: rows) %>
+      <%= render(TrnDetailsComponent.new(trn_request: @trn_request)) %>
 
       <%= f.govuk_collection_radio_buttons(:try_again,
             [OpenStruct.new(label: 'Yes, I have different details I can try', value: true), OpenStruct.new(label: 'No, submit these details, they are correct', value: false)],

--- a/app/views/support_interface/trn_requests/index.html.erb
+++ b/app/views/support_interface/trn_requests/index.html.erb
@@ -1,14 +1,15 @@
 <% content_for :page_title, 'TRN Requests' %>
 
-<h1 class="govuk-heading-l">TRN Requests</h1>
+<h1 class="govuk-heading-l">
+  TRN Requests
+  <span class="govuk-caption-l">
+     Ordered by last updated, showing <%= "#{[100, TrnRequest.count].min} of #{TrnRequest.count}" %> total
+  </span>
+</h1>
 
 <% @trn_requests.each do |trn_request| %>
+  <h2 class="govuk-heading-m">TRN Request #<%= trn_request.id %></h2>
   <%= govuk_summary_list do |summary_list|
-    summary_list.row do |row|
-      row.key(text: 'ID')
-      row.value(text: trn_request.id)
-    end
-
     summary_list.row do |row|
       row.key(text: 'Created at')
       row.value(text: trn_request.created_at)
@@ -24,4 +25,8 @@
       row.value(text: trn_request.checked_at)
     end
   end %>
+
+  <h3 class="govuk-heading-s">Anonymised data</h3>
+
+  <%= render(TrnDetailsComponent.new(trn_request: trn_request, anonymise: true)) %>
 <% end %>

--- a/app/views/support_interface/trn_requests/index.html.erb
+++ b/app/views/support_interface/trn_requests/index.html.erb
@@ -22,19 +22,37 @@
 
     summary_list.row do |row|
       row.key(text: 'Submitted at')
-      row.value { trn_request.checked_at ? trn_request.checked_at.to_s : govuk_tag(colour: 'grey', text: 'Not yet submitted') }
+      row.value do
+        if trn_request.checked_at
+          trn_request.checked_at.to_s
+        else
+          govuk_tag(colour: 'grey', text: 'Not yet submitted')
+        end
+      end
     end
 
     if trn_request.checked_at
       summary_list.row do |row|
         row.key(text: 'TRN')
-        row.value { trn_request.trn ? govuk_tag(colour: 'green', text: 'Found 🎉') : govuk_tag(colour: 'yellow', text: 'Not found') }
+        row.value do
+          if trn_request.trn
+            govuk_tag(colour: 'green', text: 'Found 🎉')
+          else
+            govuk_tag(colour: 'yellow', text: 'Not found')
+          end
+        end
       end
 
       unless trn_request.trn
         summary_list.row do |row|
-          row.key(text: 'Zendesk ticket ID')
-          row.value { trn_request.zendesk_ticket_id ? govuk_tag(colour: 'pink', text: trn_request.zendesk_ticket_id) : govuk_tag(colour: 'grey', text: 'Not submitted') }
+          row.key(text: 'Zendesk ticket')
+          row.value do
+            if trn_request.zendesk_ticket_id
+              tag.a "Ticket #{trn_request.zendesk_ticket_id}", class: 'govuk-link', href: "https://teachingregulationagency.zendesk.com/agent/tickets/#{trn_request.zendesk_ticket_id}"
+            else
+              govuk_tag(colour: 'grey', text: 'Not submitted')
+            end
+          end
         end
       end
     end

--- a/app/views/support_interface/trn_requests/index.html.erb
+++ b/app/views/support_interface/trn_requests/index.html.erb
@@ -22,11 +22,32 @@
 
     summary_list.row do |row|
       row.key(text: 'Submitted at')
-      row.value(text: trn_request.checked_at)
+      row.value { trn_request.checked_at ? trn_request.checked_at.to_s : govuk_tag(colour: 'grey', text: 'Not yet submitted') }
+    end
+
+    if trn_request.checked_at
+      summary_list.row do |row|
+        row.key(text: 'TRN')
+        row.value { trn_request.trn ? govuk_tag(colour: 'green', text: 'Found 🎉') : govuk_tag(colour: 'yellow', text: 'Not found') }
+      end
+
+      unless trn_request.trn
+        summary_list.row do |row|
+          row.key(text: 'Zendesk ticket ID')
+          row.value { trn_request.zendesk_ticket_id ? govuk_tag(colour: 'pink', text: trn_request.zendesk_ticket_id) : govuk_tag(colour: 'grey', text: 'Not submitted') }
+        end
+      end
     end
   end %>
 
-  <h3 class="govuk-heading-s">Anonymised data</h3>
+  <% if Rails.env.production? %>
+    <h3 class="govuk-heading-s">Anonymised information</h3>
+  <% else %>
+    <h3 class="govuk-heading-s">
+      <%= govuk_tag(colour: 'blue', text: 'Development only') %>
+      Information
+    </h3>
+  <% end %>
 
-  <%= render(TrnDetailsComponent.new(trn_request: trn_request, anonymise: true)) %>
+  <%= render(TrnDetailsComponent.new(trn_request: trn_request, anonymise: Rails.env.production?)) %>
 <% end %>

--- a/app/views/support_interface/trn_requests/index.html.erb
+++ b/app/views/support_interface/trn_requests/index.html.erb
@@ -3,7 +3,7 @@
 <h1 class="govuk-heading-l">
   TRN Requests
   <span class="govuk-caption-l">
-     Ordered by last updated, showing <%= "#{[100, TrnRequest.count].min} of #{TrnRequest.count}" %> total
+    Ordered by last updated, showing <%= "#{[100, TrnRequest.count].min} of #{TrnRequest.count}" %> total
   </span>
 </h1>
 

--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -6,42 +6,7 @@
     <h1 class="govuk-heading-xl">Check your answers</h1>
     <p class="govuk-body">We will send your TRN to <%= @trn_request.email %> if we find one matching your details.</p>
 
-    <% rows = [
-        {
-          key: { text: 'Name' },
-          value: { text: @trn_request.name },
-          actions: [{ href: name_path, visually_hidden_text: 'name' }]
-        },
-        {
-          key: { text: 'Date of birth' },
-          value: { text: @trn_request.date_of_birth? ? @trn_request.date_of_birth.to_fs(:long_ordinal_uk) : 'Not given' },
-          actions: [{ href: date_of_birth_path, visually_hidden_text: 'date of birth' }]
-        },
-        {
-          key: { text: @trn_request.has_ni_number? ? 'National Insurance number' : 'Do you have a National Insurance number?' },
-          value: { text: @trn_request.has_ni_number? ? pretty_ni_number(@trn_request.ni_number) : 'No' },
-          actions: [{ href: have_ni_number_path, visually_hidden_text: 'national insurance number' }]
-        },
-        {
-          key: { text: @trn_request.itt_provider_enrolled ? 'Where did you get your QTS?' : 'Have you been awarded QTS?' },
-          value: { text: @trn_request.itt_provider_enrolled ? @trn_request.itt_provider_name : 'No' },
-          actions: [{ href: itt_provider_path, visually_hidden_text: 'teacher training provider' }]
-        },
-        { key: { text: 'Email address '},
-          value: { text: @trn_request.email },
-          actions: [{ href: email_path, visually_hidden_text: 'email address' }]
-        },
-      ]
-
-      previous_name = {
-        key: { text: 'Previous name' },
-        value: { text: @trn_request.previous_name },
-        actions: [{ href: name_path, visually_hidden_text: 'previous name' }]
-      }
-
-      rows.insert(1, previous_name) if @trn_request.previous_name?
-    %>
-    <%= govuk_summary_list(rows: rows) %>
+    <%= render(TrnDetailsComponent.new(trn_request: @trn_request, actions: true)) %>
 
     <%= form_with model: @trn_request, method: :put do |f| %>
       <%= f.hidden_field :answers_checked, value: true %>

--- a/spec/components/trn_details_component_spec.rb
+++ b/spec/components/trn_details_component_spec.rb
@@ -2,17 +2,19 @@
 require 'rails_helper'
 
 RSpec.describe TrnDetailsComponent, type: :component do
-  let(:trn_request) { TrnRequest.new(
-    date_of_birth: 20.years.ago.to_date,
-    email: 'test@example.com',
-    first_name: 'Test',
-    has_ni_number: true,
-    itt_provider_enrolled: true,
-    itt_provider_name: 'Big SCITT',
-    last_name: 'User',
-    ni_number: 'QC123456A',
-    previous_last_name: 'Smith',
-  ) }
+  let(:trn_request) do
+    TrnRequest.new(
+      date_of_birth: 20.years.ago.to_date,
+      email: 'test@example.com',
+      first_name: 'Test',
+      has_ni_number: true,
+      itt_provider_enrolled: true,
+      itt_provider_name: 'Big SCITT',
+      last_name: 'User',
+      ni_number: 'QC123456A',
+      previous_last_name: 'Smith',
+    )
+  end
   let(:component) { render_inline(described_class.new(trn_request: trn_request)) }
 
   it 'renders name' do
@@ -101,9 +103,9 @@ RSpec.describe TrnDetailsComponent, type: :component do
 
   context 'with both actions and anonymised data' do
     it 'raises an error' do
-      expect {
+      expect do
         render_inline(described_class.new(trn_request: trn_request, anonymise: true, actions: true))
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/components/trn_details_component_spec.rb
+++ b/spec/components/trn_details_component_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe TrnDetailsComponent, type: :component do
+  let(:trn_request) { TrnRequest.new(
+    date_of_birth: 20.years.ago.to_date,
+    email: 'test@example.com',
+    first_name: 'Test',
+    has_ni_number: true,
+    itt_provider_enrolled: true,
+    itt_provider_name: 'Big SCITT',
+    last_name: 'User',
+    ni_number: 'QC123456A',
+    previous_last_name: 'Smith',
+  ) }
+  let(:component) { render_inline(described_class.new(trn_request: trn_request)) }
+
+  it 'renders name' do
+    expect(component.text).to include('Test User')
+  end
+
+  it 'renders previous name' do
+    expect(component.text).to include('Test Smith')
+  end
+
+  it 'renders date of birth' do
+    expect(component.text).to include(20.years.ago.to_date.to_fs(:long_ordinal_uk))
+  end
+
+  it 'renders NI number' do
+    expect(component.text).to include('QC 12 34 56 A')
+  end
+
+  it 'renders ITT provider' do
+    expect(component.text).to include('Big SCITT')
+  end
+
+  it 'renders email' do
+    expect(component.text).to include('test@example.com')
+  end
+
+  it 'does not render change buttons' do
+    expect(component.text).not_to include('Change')
+  end
+
+  context 'with actions' do
+    let(:component) { render_inline(described_class.new(trn_request: trn_request, actions: true)) }
+
+    it 'renders change name' do
+      expect(component.text).to include('Change name')
+    end
+
+    it 'renders change previous name' do
+      expect(component.text).to include('Change previous name')
+    end
+
+    it 'renders change date of birth' do
+      expect(component.text).to include('Change date of birth')
+    end
+
+    it 'renders change NI number' do
+      expect(component.text).to include('Change national insurance number')
+    end
+
+    it 'renders change ITT provider' do
+      expect(component.text).to include('Change teacher training provider')
+    end
+
+    it 'renders change email' do
+      expect(component.text).to include('Change email')
+    end
+  end
+
+  context 'with anonymised data' do
+    let(:component) { render_inline(described_class.new(trn_request: trn_request, anonymise: true)) }
+
+    it 'renders anonymised name' do
+      expect(component.text).to include('T**** U****')
+    end
+
+    it 'renders anonymised previous name' do
+      expect(component.text).to include('T**** S****')
+    end
+
+    it 'renders anonymised date of birth' do
+      expect(component.text).to include('** ** ****')
+    end
+
+    it 'renders anonymised NI number' do
+      expect(component.text).to include('Q* ** ** ** A')
+    end
+
+    it 'renders ITT provider' do
+      expect(component.text).to include('Big SCITT')
+    end
+
+    it 'renders anonymised email' do
+      expect(component.text).to include('t****@****.com')
+    end
+  end
+
+  context 'with both actions and anonymised data' do
+    it 'raises an error' do
+      expect {
+        render_inline(described_class.new(trn_request: trn_request, anonymise: true, actions: true))
+      }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/factories/trn_request.rb
+++ b/spec/factories/trn_request.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :trn_request do
+    email { Faker::Internet.email }
+    date_of_birth { Faker::Date.between(from: 70.years.ago, to: 18.years.ago) }
+    has_ni_number { false }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+
+    trait :has_ni_number do
+      has_ni_number { true }
+      ni_number { 'QQ123456C' }
+    end
+
+    trait :has_itt_provider do
+      itt_provider_enrolled { true }
+      itt_provider_name { Faker::Educator.university }
+    end
+
+    trait :has_previous_name do
+      previous_first_name { Faker::Name.first_name }
+      previous_last_name { Faker::Name.last_name }
+    end
+
+    trait :has_trn do
+      checked_at { Faker::Date.backward(days: 14) }
+      trn { Faker::Number.number(7) }
+    end
+
+    trait :has_zendesk_ticket do
+      checked_at { Faker::Date.backward(days: 14) }
+      trn { nil }
+      zendesk_ticket_id { Faker::Number.number(4) }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,9 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Faker::Config.locale = 'en-GB'
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -76,6 +79,10 @@ RSpec.configure do |config|
   config.before(:each, type: :system) { driven_by(:cuprite) }
 
   config.include ViewComponent::TestHelpers, type: :component
+
+  config.include FactoryBot::Syntax::Methods
+
+  config.before { Faker::UniqueGenerator.clear }
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 
 RSpec.describe 'Support', type: :system do
   it 'using the support interface' do
+    given_there_is_a_trn_request_in_progress
     when_i_am_authorized_as_a_support_user
     and_i_visit_the_support_page
     then_i_see_the_trn_requests_page
+    and_there_is_a_trn_request_in_progress
 
     when_i_visit_the_feature_flags_page
     then_i_see_the_feature_flags
@@ -18,6 +20,10 @@ RSpec.describe 'Support', type: :system do
   end
 
   private
+
+  def given_there_is_a_trn_request_in_progress
+    create(:trn_request)
+  end
 
   def when_i_am_authorized_as_a_support_user
     page.driver.basic_authorize('test', 'test')
@@ -55,5 +61,12 @@ RSpec.describe 'Support', type: :system do
   def then_the_zendesk_flag_is_off
     expect(page).to have_content('Feature “Zendesk integration” deactivated')
     expect(page).to have_content("Zendesk integration\n- Inactive")
+  end
+
+  def and_there_is_a_trn_request_in_progress
+    trn_request = TrnRequest.last
+    expect(page).to have_content("TRN Request ##{trn_request.id}")
+    expect(page).to have_content(trn_request.name.to_s)
+    expect(page).to have_content('NOT YET SUBMITTED')
   end
 end


### PR DESCRIPTION
### Context

Create a new component to share the logic for showing a user's answers across the:

- Check answers page
- No match page
- Support (anonymised)

### Changes proposed in this pull request

Bit of a grab bag / a bunch of stuff mixed in; individual commits are PR worthy on their own but I decided not to open 4 PRs as they're all related

- Add `factory_bot_rails` and `faker` with a factory for `trn_request`
- Create `TrnDetailsComponent`
- Add anonymised support (on by default in all `.production?` Rails modes)
- Display more info about TRNs and Zendesk tickets in Support

### Guidance to review

Review commit by commit.

#### Not yet submitted

![image](https://user-images.githubusercontent.com/1650875/163576836-a4b2b8c3-ef63-4809-8b14-8912c6dfb453.png)

#### TRN found

![image](https://user-images.githubusercontent.com/1650875/163577295-8f268c55-6f49-4c5c-bbd4-990b6ae11ee4.png)

#### TRN not found, Zendesk not submitted

![image](https://user-images.githubusercontent.com/1650875/163577349-aa2190ce-6b60-4b3b-a03a-daeff5fee192.png)

#### Zendesk submitted

![image](https://user-images.githubusercontent.com/1650875/163577388-68374303-f459-47b7-b480-20a80e9412c0.png)

### Checklist

- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
