### PR TITLE
Skip QTS question if we find a match eagerly

### DIFF
--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -16,6 +16,8 @@ module EnforceQuestionOrder
   private
 
   def current_page_is_allowed?
+    return true if trn_request&.trn
+
     order = urls.keys.index(trn_request&.status)
     current_position = urls.values.index(request.url)
     current_position && order && current_position <= order

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -12,6 +12,8 @@ class DqtApi
   FIVE_SECONDS = 5
 
   def self.find_trn!(trn_request) # rubocop:disable Metrics/AbcSize
+    raise DqtApi::ApiError unless FeatureFlag.active?(:use_dqt_api)
+
     raise Faraday::TimeoutError, 'Time-out feature flag enabled' if FeatureFlag.active?(:dqt_api_always_timeout)
 
     response = new.client.get('/v2/teachers/find', trn_request_params(trn_request))

--- a/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/matches_eagerly.yml
+++ b/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/matches_eagerly.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress&firstName=Kevin&ittProviderName&lastName=E&nationalInsuranceNumber=QQ123456C&previousFirstName&previousLastName
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+          - Faraday v1.10.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - '*/*'
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Mon, 18 Apr 2022 12:36:21 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - '299'
+        X-Rate-Limit-Reset:
+          - '2022-04-18T12:37:00.0000000Z'
+        X-Vcap-Request-Id:
+          - d1d2fbcf-ee3f-49d1-6b91-e89170b48c7d
+        X-Xss-Protection:
+          - '0'
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 716cb04032c353fd28e60f55870a35f4.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR50-C1
+        X-Amz-Cf-Id:
+          - m210gxieTGykfM80WU1Bkl9ASY8E-XiS4NNEX-k1Gjfhp8Eotpnq8A==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"1275362","emailAddresses":["anonymous@anonymousdomain.org.net.co.uk"],"firstName":"Kevin","lastName":"Evans","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"f7891223-7661-e411-8047-005056822391"}]}'
+    recorded_at: Mon, 18 Apr 2022 12:36:21 GMT
+recorded_with: VCR 6.1.0

--- a/spec/services/dqt_api_spec.rb
+++ b/spec/services/dqt_api_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 require 'webmock/rspec'
 
 RSpec.describe DqtApi do
+  before { FeatureFlag.activate(:use_dqt_api) }
+
   describe '.find_trn!' do
     subject(:find_trn!) { described_class.find_trn!(trn_request) }
 

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -345,6 +345,29 @@ RSpec.describe 'TRN requests', type: :system do
       then_i_see_the_zendesk_confirmation_page
       and_i_receive_an_email_with_the_zendesk_ticket_number
     end
+
+    it 'matches eagerly', vcr: true do
+      given_the_use_dqt_api_feature_is_enabled
+      given_i_am_on_the_home_page
+      when_i_press_the_start_button
+      when_i_confirm_i_have_a_trn_number
+      when_i_press_continue
+      when_i_fill_in_the_name_form
+      when_i_complete_my_date_of_birth
+      when_i_choose_yes
+      when_i_press_continue
+      when_i_fill_in_my_ni_number
+      when_i_press_continue
+      then_i_see_the_email_page
+
+      when_i_fill_in_my_email_address
+      and_i_press_continue
+      then_i_see_the_check_answers_page
+
+      when_i_press_the_submit_button
+      then_i_see_a_message_to_check_my_email
+      and_i_receive_an_email_with_the_trn_number
+    end
   end
 
   private

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -25,9 +25,6 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_have_ni_page
 
     when_i_choose_no
-    then_i_see_the_ni_page
-
-    when_i_choose_no
     and_i_press_continue
     then_i_see_the_itt_provider_page
 
@@ -232,7 +229,7 @@ RSpec.describe 'TRN requests', type: :system do
       then_i_see_the_itt_provider_page
 
       when_i_press_back
-      then_i_see_the_ni_page
+      then_i_see_the_have_ni_page
     end
   end
 
@@ -270,7 +267,7 @@ RSpec.describe 'TRN requests', type: :system do
     when_i_press_continue
     when_i_fill_in_the_name_form
     when_i_complete_my_date_of_birth
-    then_i_see_the_ni_page
+    then_i_see_the_have_ni_page
 
     when_i_choose_no
     and_i_press_continue
@@ -528,12 +525,6 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('Your name')
   end
   alias_method :then_i_am_redirected_to_the_name_page, :then_i_see_the_name_page
-
-  def then_i_see_the_ni_page
-    expect(page).to have_current_path('/have-ni-number')
-    expect(page.driver.browser.current_title).to start_with('Do you have a National Insurance number?')
-    expect(page).to have_content('Do you have a National Insurance number?')
-  end
 
   def then_i_see_the_ni_number_page
     expect(page).to have_current_path('/ni-number')


### PR DESCRIPTION
### Context

We want to let users skip over the ITT provider question if we're able to match their TRN using just the name, DOB, and NI number.

### Changes proposed in this pull request

Query the API for the user's TRN earlier in the process and take the users to the email page if we find it.

### Guidance to review

Does not depend on https://github.com/DFE-Digital/find-a-lost-trn/pull/155, but that PR contains a change to the display logic for the check answers table to hide the ITT provider details if the user hasn't filled in the form with yes/no and the value is still `nil` in the database.

### Checklist

https://trello.com/c/Z4NVmIWx/341-skip-qts-question-if-we-find-a-match-with-just-name-dob-and-nino

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
