### PR TITLE
Fix NI edge case when displaying anonymised data

### DIFF
--- a/app/components/trn_details_component.rb
+++ b/app/components/trn_details_component.rb
@@ -26,10 +26,13 @@ class TrnDetailsComponent < ViewComponent::Base
   end
 
   def ni_value
-    if @anonymise && @trn_request.has_ni_number?
+    return 'Not provided' if @trn_request.has_ni_number? && !@trn_request.ni_number
+    return 'No' unless @trn_request.has_ni_number?
+
+    if @anonymise
       "#{@trn_request.ni_number.first}* ** ** ** #{@trn_request.ni_number.last}"
     else
-      @trn_request.has_ni_number? ? helpers.pretty_ni_number(@trn_request.ni_number) : 'No'
+      helpers.pretty_ni_number(@trn_request.ni_number)
     end
   end
 

--- a/spec/components/trn_details_component_spec.rb
+++ b/spec/components/trn_details_component_spec.rb
@@ -2,16 +2,18 @@
 require 'rails_helper'
 
 RSpec.describe TrnDetailsComponent, type: :component do
+  let(:has_ni_number) { true }
+  let(:ni_number) { 'QC123456A' }
   let(:trn_request) do
     TrnRequest.new(
       date_of_birth: 20.years.ago.to_date,
       email: 'test@example.com',
       first_name: 'Test',
-      has_ni_number: true,
+      has_ni_number: has_ni_number,
       itt_provider_enrolled: true,
       itt_provider_name: 'Big SCITT',
       last_name: 'User',
-      ni_number: 'QC123456A',
+      ni_number: ni_number,
       previous_last_name: 'Smith',
     )
   end
@@ -106,6 +108,24 @@ RSpec.describe TrnDetailsComponent, type: :component do
       expect do
         render_inline(described_class.new(trn_request: trn_request, anonymise: true, actions: true))
       end.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'when NI number not available' do
+    let(:has_ni_number) { false }
+    let(:ni_number) { nil }
+
+    it 'renders "No"' do
+      expect(component.text).to include('No')
+    end
+  end
+
+  context 'when NI number not provided' do
+    let(:has_ni_number) { true }
+    let(:ni_number) { nil }
+
+    it 'renders "Not provided"' do
+      expect(component.text).to include('Not provided')
     end
   end
 end


### PR DESCRIPTION
### Context

We had this bug happen in Sentry: https://sentry.io/organizations/dfe-teacher-services/issues/3207003600/?project=6275068&referrer=slack

It's because we attempted to call `.first` on a nil NI number on a TRN request that had answered yes to "Do you have a NI number?" but then didn't actually fill the number in.

### Changes proposed in this pull request

- Add a couple of guard clauses

### Guidance to review

Does this need tests? I feel reasonably confident it should be fine.

### Checklist

Sentry issue: https://sentry.io/organizations/dfe-teacher-services/issues/3207003600/?project=6275068&referrer=slack

- [x] Attach to Sentry issue
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
