### PR TITLE
Link back button to NI when QTS was skipped

### DIFF
--- a/app/controllers/ni_number_controller.rb
+++ b/app/controllers/ni_number_controller.rb
@@ -18,10 +18,10 @@ class NiNumberController < ApplicationController
 
   def edit; end
 
-  def update
+  def update # rubocop:disable Metrics/AbcSize
     if ni_number.update(ni_number_params)
       begin
-        find_trn_using_api
+        find_trn_using_api unless trn_request.trn
 
         redirect_to ni_number.email? ? check_answers_url : email_url
       rescue DqtApi::ApiError,

--- a/app/views/email/edit.html.erb
+++ b/app/views/email/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @email_form.errors.any?}Your email address" %>
-<%= content_for :back_link_url, back_link_url(itt_provider_path) %>
+<%= content_for :back_link_url, back_link_url(@trn_request.trn ? ni_number_path : itt_provider_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -360,6 +360,12 @@ RSpec.describe 'TRN requests', type: :system do
       when_i_press_continue
       then_i_see_the_email_page
 
+      when_i_press_back
+      then_i_see_the_ni_number_page
+
+      when_i_press_continue
+      then_i_see_the_email_page
+
       when_i_fill_in_my_email_address
       and_i_press_continue
       then_i_see_the_check_answers_page


### PR DESCRIPTION
### Context

> If there is a direct match and we skip the QTS question, if I hit `Back` on the email page, it should return me to the National Insurance number page, not the QTS one

When we match eagerly, we skip the QTS question, so we have to link the back button to the NI page instead.

### Changes proposed in this pull request

Link the back button to a different page if the `trn` is set.

### Guidance to review

The `unless trn_request.trn` is to prevent a second API request from firing off to find the user's TRN, which causes VCR to helpfully complain.

### Checklist

https://trello.com/c/utA4lqIV/367-new-snags

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
