### PR TITLE
Handle support TRN details when email is nil

### DIFF
--- a/app/components/trn_details_component.rb
+++ b/app/components/trn_details_component.rb
@@ -45,7 +45,9 @@ class TrnDetailsComponent < ViewComponent::Base
   end
 
   def email
-    if @anonymise && !@trn_request.email.nil?
+    return 'Not provided' if @trn_request.email.nil?
+
+    if @anonymise
       "#{@trn_request.email.first}****@****.#{@trn_request.email.split('.').last}"
     else
       helpers.shy_email(@trn_request.email)

--- a/spec/components/trn_details_component_spec.rb
+++ b/spec/components/trn_details_component_spec.rb
@@ -4,10 +4,11 @@ require 'rails_helper'
 RSpec.describe TrnDetailsComponent, type: :component do
   let(:has_ni_number) { true }
   let(:ni_number) { 'QC123456A' }
+  let(:email) { 'test@example.com' }
   let(:trn_request) do
     TrnRequest.new(
       date_of_birth: 20.years.ago.to_date,
-      email: 'test@example.com',
+      email: email,
       first_name: 'Test',
       has_ni_number: has_ni_number,
       itt_provider_enrolled: true,
@@ -126,6 +127,14 @@ RSpec.describe TrnDetailsComponent, type: :component do
 
     it 'renders "Not provided"' do
       expect(component.text).to include('Not provided')
+    end
+  end
+
+  context 'when email is nil' do
+    let(:email) { nil }
+
+    it 'renders "Not provided"' do
+      expect(component.text).to include('Email addressNot provided')
     end
   end
 end


### PR DESCRIPTION
Fixes https://sentry.io/organizations/dfe-teacher-services/issues/3209850541/?project=6275068&referrer=slack