### PR TITLE
Add a question about being awarded a QTS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,7 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Exclude:
     - spec/**/*
+
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+    - spec/components/trn_details_component_spec.rb

--- a/app/components/trn_details_component.html.erb
+++ b/app/components/trn_details_component.html.erb
@@ -25,6 +25,12 @@
     actions: [{ href: have_ni_number_path, visually_hidden_text: 'national insurance number' }]
   }
 
+  awarded_qts_row = {
+    key: { text: 'Have you been awarded QTS?' },
+    value: { text: awarded_qts_value },
+    actions: [{ href: awarded_qts_path, visually_hidden_text: 'awarded QTS' }]
+  }
+
   itt_provider_row = {
     key: { text: itt_provider_key },
     value: { text: itt_provider_value },
@@ -41,6 +47,7 @@
   rows.push(previous_name_row) if @trn_request.previous_name?
   rows.push(date_of_birth_row)
   rows.push(ni_row)
+  rows.push(awarded_qts_row)
   rows.push(itt_provider_row) unless @trn_request.itt_provider_enrolled.nil?
   rows.push(email_row)
 

--- a/app/components/trn_details_component.rb
+++ b/app/components/trn_details_component.rb
@@ -36,12 +36,20 @@ class TrnDetailsComponent < ViewComponent::Base
     end
   end
 
+  def awarded_qts_value
+    return 'Yes' if @trn_request.awarded_qts?
+
+    'No'
+  end
+
   def itt_provider_key
-    @trn_request.itt_provider_enrolled ? 'Where did you get your QTS?' : 'Have you been awarded QTS?'
+    return 'Where did you get your QTS?' if @trn_request.itt_provider_enrolled
+
+    'Did a university, SCITT or school award your QTS?'
   end
 
   def itt_provider_value
-    @trn_request.itt_provider_enrolled ? @trn_request.itt_provider_name : 'No'
+    @trn_request.itt_provider_enrolled ? @trn_request.itt_provider_name : 'No, I was awarded QTS another way'
   end
 
   def email

--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -37,6 +37,7 @@ module EnforceQuestionOrder
       date_of_birth: date_of_birth_url,
       has_ni_number: have_ni_number_url,
       ni_number: ni_number_url,
+      awarded_qts: awarded_qts_url,
       itt_provider: itt_provider_url,
       email: email_url,
     }

--- a/app/controllers/itt_providers_controller.rb
+++ b/app/controllers/itt_providers_controller.rb
@@ -2,6 +2,25 @@
 class IttProvidersController < ApplicationController
   include EnforceQuestionOrder
 
+  def new
+    @awarded_qts_form = AwardedQtsForm.new(trn_request: trn_request)
+  end
+
+  def create
+    @awarded_qts_form = AwardedQtsForm.new(trn_request: trn_request)
+    if @awarded_qts_form.update(awarded_qts_params)
+      next_url =
+        if trn_request.reload.awarded_qts
+          itt_provider_url
+        else
+          trn_request.email.blank? ? email_url : check_answers_url
+        end
+      redirect_to next_url
+    else
+      render :new
+    end
+  end
+
   def edit
     @itt_provider_form = IttProviderForm.new(trn_request: trn_request).assign_form_values
   end
@@ -16,6 +35,10 @@ class IttProvidersController < ApplicationController
   end
 
   private
+
+  def awarded_qts_params
+    params.require(:awarded_qts_form).permit(:awarded_qts)
+  end
 
   def itt_provider_params
     params

--- a/app/controllers/ni_number_controller.rb
+++ b/app/controllers/ni_number_controller.rb
@@ -10,7 +10,7 @@ class NiNumberController < ApplicationController
     @has_ni_number_form = HasNiNumberForm.new(trn_request: trn_request)
     if @has_ni_number_form.update(has_ni_number: params[:has_ni_number_form][:has_ni_number])
       session[:trn_request_id] = trn_request.id
-      redirect_to trn_request.has_ni_number? ? ni_number_url : itt_provider_url
+      redirect_to trn_request.has_ni_number? ? ni_number_url : awarded_qts_url
     else
       render :new
     end
@@ -29,7 +29,7 @@ class NiNumberController < ApplicationController
              Faraday::TimeoutError,
              DqtApi::TooManyResults,
              DqtApi::NoResults
-        redirect_to ni_number.email? ? check_answers_url : itt_provider_url
+        redirect_to ni_number.email? ? check_answers_url : awarded_qts_url
       end
     else
       render :edit

--- a/app/forms/awarded_qts_form.rb
+++ b/app/forms/awarded_qts_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class AwardedQtsForm
+  include ActiveModel::Model
+
+  attr_accessor :trn_request
+
+  validates :awarded_qts, inclusion: { in: [true, false] }
+
+  delegate :awarded_qts, :awarded_qts=, to: :trn_request, allow_nil: true
+
+  def update(params = {})
+    self.awarded_qts = params[:awarded_qts]
+    clear_itt_provider unless awarded_qts
+    return false if invalid?
+
+    trn_request.save!
+  end
+
+  private
+
+  def clear_itt_provider
+    trn_request.itt_provider_enrolled = nil
+    trn_request.itt_provider_name = nil
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,9 @@
 
 module ApplicationHelper
   def back_link_url(back = url_for(:back))
-    return check_answers_path if session[:form_complete] && request.path != check_answers_path
+    if session[:form_complete] && [check_answers_path, itt_provider_path].exclude?(request.path)
+      return check_answers_path
+    end
 
     back
   end

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -30,8 +30,9 @@ class TrnRequest < ApplicationRecord
 
   def status # rubocop:disable Metrics
     return :answers if email.present?
-    return :email unless itt_provider_enrolled.nil?
-    return :itt_provider if (!has_ni_number.nil? && ni_number.present?) || (!has_ni_number.nil? && !has_ni_number)
+    return :email if (!awarded_qts.nil? && !awarded_qts && itt_provider_enrolled.nil?) || !itt_provider_enrolled.nil?
+    return :itt_provider if awarded_qts
+    return :awarded_qts if (!has_ni_number.nil? && ni_number.present?) || (!has_ni_number.nil? && !has_ni_number)
     return :ni_number if has_ni_number
     return :has_ni_number if date_of_birth.present?
     return :date_of_birth if first_name.present?

--- a/app/views/email/edit.html.erb
+++ b/app/views/email/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @email_form.errors.any?}Your email address" %>
-<%= content_for :back_link_url, back_link_url(@trn_request.trn ? ni_number_path : itt_provider_path) %>
+<%= content_for :back_link_url, back_link_url(@trn_request.trn ? ni_number_path : (@trn_request.awarded_qts ? itt_provider_path : awarded_qts_path)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/itt_providers/edit.html.erb
+++ b/app/views/itt_providers/edit.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, "#{'Error: ' if @itt_provider_form.errors.any?}Have you been awarded qualified teacher status (QTS)?" %>
-<%= content_for :back_link_url, back_link_url(@itt_provider_form.trn_request.has_ni_number? ? ni_number_path : have_ni_number_path) %>
+<% content_for :page_title, "#{'Error: ' if @itt_provider_form.errors.any?}Did a university, SCITT or school award your QTS?" %>
+<%= content_for :back_link_url, back_link_url(awarded_qts_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @itt_provider_form, url: itt_provider_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_radio_buttons_fieldset(:itt_provider_enrolled, legend: { tag: 'h1', size: 'xl', text: 'Have you been awarded qualified teacher status (QTS)?' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:itt_provider_enrolled, legend: { tag: 'h1', size: 'xl', text: 'Did a university, SCITT or school award your QTS?' }) do %>
         <%= f.govuk_radio_button :itt_provider_enrolled, true, label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_field(:itt_provider_name,
                 hint: { text: 'Your university, SCITT, school or other training provider' },
@@ -13,7 +13,7 @@
             )
           %>
         <% end %>
-        <%= f.govuk_radio_button :itt_provider_enrolled, false, label: { text: 'No' } %>
+        <%= f.govuk_radio_button :itt_provider_enrolled, false, label: { text: 'No, I was awarded QTS another way' } %>
       <% end %>
       <%= f.govuk_submit prevent_double_click: false %>
     <% end %>

--- a/app/views/itt_providers/new.html.erb
+++ b/app/views/itt_providers/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title, "#{'Error: ' if @awarded_qts_form.errors.any?}Have you been awarded qualified teacher status (QTS)?" %>
+<%= content_for :back_link_url, back_link_url(@awarded_qts_form.trn_request.has_ni_number? ? ni_number_path : have_ni_number_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @awarded_qts_form, url: awarded_qts_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(:awarded_qts,
+            [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
+            :value,
+            :label,
+            legend: { tag: 'h1', size: 'xl', text: 'Have you been awarded qualified teacher status (QTS)?' }
+          ) %>
+      <%= f.govuk_submit prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,10 @@ en:
   activemodel:
     errors:
       models:
+        awarded_qts_form:
+          attributes:
+            awarded_qts:
+              inclusion: Tell us if you have been awarded qualified teacher status (QTS)
         check_trn_form:
           attributes:
             has_trn:
@@ -96,7 +100,7 @@ en:
         itt_provider_form:
           attributes:
             itt_provider_enrolled:
-              inclusion: Tell us if you have been awarded QTS
+              inclusion: Tell us how you were awarded qualified teacher status (QTS)
             itt_provider_name:
               blank: Enter your university, SCITT, school or other training provider
               too_long: Enter a school that is less than 255 letters long

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
   get '/ni-number', to: 'ni_number#edit'
   patch '/ni-number', to: 'ni_number#update'
 
+  get '/awarded-qts', to: 'itt_providers#new'
+  post '/awarded-qts', to: 'itt_providers#create'
   get '/itt-provider', to: 'itt_providers#edit'
   patch '/itt-provider', to: 'itt_providers#update'
 

--- a/db/migrate/20220420065448_add_awarded_qts_to_trn_request.rb
+++ b/db/migrate/20220420065448_add_awarded_qts_to_trn_request.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddAwardedQtsToTrnRequest < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trn_requests, :awarded_qts, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_12_115717) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_20_065448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_12_115717) do
     t.string "previous_last_name"
     t.string "trn"
     t.integer "zendesk_ticket_id"
+    t.boolean "awarded_qts"
   end
 
 end

--- a/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/displays_the_TRN_returned_by_the_DQT_API.yml
+++ b/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/displays_the_TRN_returned_by_the_DQT_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Kevin&ittProviderName=&lastName=E&nationalInsuranceNumber&previousFirstName&previousLastName
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Kevin&ittProviderName&lastName=E&nationalInsuranceNumber&previousFirstName&previousLastName
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/opens_a_Zendesk_ticket_when_there_is_no_match.yml
+++ b/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/opens_a_Zendesk_ticket_when_there_is_no_match.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName=&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/shows_the_no_match_page_and_opens_a_Zendesk_ticket_when_there_is_no_match.yml
+++ b/spec/cassettes/TRN_requests/when_the_use_dqt_api_feature_is_enabled/shows_the_no_match_page_and_opens_a_Zendesk_ticket_when_there_is_no_match.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName=&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
       body:
         encoding: US-ASCII
         string: ''
@@ -58,7 +58,7 @@ http_interactions:
     recorded_at: Thu, 14 Apr 2022 12:54:12 GMT
   - request:
       method: get
-      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName=&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Do%20not&ittProviderName&lastName=Match%20me&nationalInsuranceNumber&previousFirstName&previousLastName
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/components/trn_details_component_spec.rb
+++ b/spec/components/trn_details_component_spec.rb
@@ -3,15 +3,17 @@ require 'rails_helper'
 
 RSpec.describe TrnDetailsComponent, type: :component do
   let(:has_ni_number) { true }
+  let(:itt_provider_enrolled) { true }
   let(:ni_number) { 'QC123456A' }
   let(:email) { 'test@example.com' }
   let(:trn_request) do
     TrnRequest.new(
+      awarded_qts: true,
       date_of_birth: 20.years.ago.to_date,
       email: email,
       first_name: 'Test',
       has_ni_number: has_ni_number,
-      itt_provider_enrolled: true,
+      itt_provider_enrolled: itt_provider_enrolled,
       itt_provider_name: 'Big SCITT',
       last_name: 'User',
       ni_number: ni_number,
@@ -34,6 +36,11 @@ RSpec.describe TrnDetailsComponent, type: :component do
 
   it 'renders NI number' do
     expect(component.text).to include('QC 12 34 56 A')
+  end
+
+  it 'renders the qualified teacher status' do
+    expect(component.text).to include('Have you been awarded QTS?')
+    expect(component.text).to include('Yes')
   end
 
   it 'renders ITT provider' do
@@ -136,5 +143,14 @@ RSpec.describe TrnDetailsComponent, type: :component do
     it 'renders "Not provided"' do
       expect(component.text).to include('Email addressNot provided')
     end
+  end
+
+  context 'when ITT provider not enrolled' do
+    subject { component.text }
+
+    let(:itt_provider_enrolled) { false }
+
+    it { is_expected.to include('Did a university, SCITT or school award your QTS?') }
+    it { is_expected.to include('No, I was awarded QTS another way') }
   end
 end

--- a/spec/forms/awarded_qts_form_spec.rb
+++ b/spec/forms/awarded_qts_form_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AwardedQtsForm, type: :model do
+  subject(:awarded_qts_form) { described_class.new(trn_request: trn_request) }
+
+  let(:trn_request) { TrnRequest.new }
+
+  specify do
+    expect(awarded_qts_form).to validate_presence_of(:awarded_qts).with_message(
+      'Tell us if you have been awarded qualified teacher status (QTS)',
+    )
+  end
+
+  describe '#update' do
+    subject(:update) { awarded_qts_form.update(awarded_qts: awarded_qts) }
+
+    let(:awarded_qts) { true }
+
+    it 'updates the awarded_qts attribute on the trn_request' do
+      expect { update }.to change(trn_request, :awarded_qts).from(nil).to(true)
+    end
+
+    context 'when there are previous ITT provider details and awarded_qts is false' do
+      let(:awarded_qts) { false }
+      let(:trn_request) { TrnRequest.new(itt_provider_enrolled: true, itt_provider_name: 'Some ITT provider') }
+
+      it 'clears the previous ITT provider details' do
+        update
+        expect(trn_request.itt_provider_enrolled).to be_nil
+        expect(trn_request.itt_provider_name).to be_nil
+      end
+    end
+  end
+end

--- a/spec/forms/itt_provider_form_spec.rb
+++ b/spec/forms/itt_provider_form_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe IttProviderForm, type: :model do
   describe 'validations' do
     specify do
       form = described_class.new
-      expect(form).to validate_presence_of(:itt_provider_enrolled).with_message('Tell us if you have been awarded QTS')
+      expect(form).to validate_presence_of(:itt_provider_enrolled).with_message(
+        'Tell us how you were awarded qualified teacher status (QTS)',
+      )
     end
 
     specify do

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -100,12 +100,33 @@ RSpec.describe TrnRequest, type: :model do
     context 'when an NI number is present' do
       let(:attributes) { { date_of_birth: '01/01/2000', has_ni_number: false, first_name: 'John', last_name: 'Smith' } }
 
+      it { is_expected.to eq(:awarded_qts) }
+    end
+
+    context 'when awarded QTS is present' do
+      let(:attributes) { { awarded_qts: true, date_of_birth: '01/01/2000', first_name: 'John', last_name: 'Smith' } }
+
       it { is_expected.to eq(:itt_provider) }
+    end
+
+    context 'when awarded QTS is false' do
+      let(:attributes) do
+        {
+          awarded_qts: false,
+          date_of_birth: '01/01/2000',
+          first_name: 'John',
+          has_ni_number: false,
+          last_name: 'Smith',
+        }
+      end
+
+      it { is_expected.to eq(:email) }
     end
 
     context 'when an ITT provider is present' do
       let(:attributes) do
         {
+          awarded_qts: true,
           date_of_birth: '01/01/2000',
           first_name: 'John',
           itt_provider_enrolled: false,

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -26,9 +26,13 @@ RSpec.describe 'TRN requests', type: :system do
 
     when_i_choose_no
     and_i_press_continue
+    then_i_see_the_awarded_qts_page
+
+    when_i_choose_yes
+    and_i_press_continue
     then_i_see_the_itt_provider_page
 
-    when_i_choose_no
+    when_i_fill_in_my_itt_provider
     and_i_press_continue
     then_i_see_the_email_page
 
@@ -73,10 +77,10 @@ RSpec.describe 'TRN requests', type: :system do
 
     when_i_choose_no
     and_i_press_continue
-    then_i_see_the_itt_provider_page
+    then_i_see_the_awarded_qts_page
 
     when_i_try_to_go_to_the_email_page
-    then_i_see_the_itt_provider_page
+    then_i_see_the_awarded_qts_page
 
     when_i_choose_no
     and_i_press_continue
@@ -109,7 +113,7 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_ni_number_missing_error
 
     when_i_enter_a_valid_ni_number
-    then_i_see_the_itt_provider_page
+    then_i_see_the_awarded_qts_page
   end
 
   it 'changing my name' do
@@ -143,13 +147,21 @@ RSpec.describe 'TRN requests', type: :system do
 
   it 'changing my ITT provider' do
     given_i_have_completed_a_trn_request
-    when_i_press_change_itt_provider
+    when_i_press_change_awarded_qts
     then_no_should_be_checked
 
+    when_i_choose_yes
+    and_i_press_continue
     when_i_choose_yes
     and_i_fill_in_my_itt_provider
     and_i_press_continue
     then_i_see_the_updated_itt_provider
+
+    when_i_press_change_awarded_qts
+    then_yes_should_be_checked
+    when_i_choose_no
+    and_i_press_continue
+    then_i_see_no_qts_awarded
   end
 
   it 'changing my date of birth' do
@@ -205,14 +217,14 @@ RSpec.describe 'TRN requests', type: :system do
       when_i_complete_my_date_of_birth
       and_i_choose_no
       and_i_press_continue
-      then_i_see_the_itt_provider_page
+      then_i_see_the_awarded_qts_page
 
       when_i_choose_no
       and_i_press_continue
       then_i_see_the_email_page
 
       when_i_press_back
-      then_i_see_the_itt_provider_page
+      then_i_see_the_awarded_qts_page
     end
   end
 
@@ -226,7 +238,7 @@ RSpec.describe 'TRN requests', type: :system do
       when_i_complete_my_date_of_birth
       and_i_choose_no
       and_i_press_continue
-      then_i_see_the_itt_provider_page
+      then_i_see_the_awarded_qts_page
 
       when_i_press_back
       then_i_see_the_have_ni_page
@@ -239,8 +251,8 @@ RSpec.describe 'TRN requests', type: :system do
       when_i_press_change_email
       and_i_press_back
       then_i_see_the_check_answers_page
-      when_i_press_change_itt_provider
-      then_i_see_the_itt_provider_page
+      when_i_press_change_awarded_qts
+      then_i_see_the_awarded_qts_page
       when_i_press_back
       then_i_see_the_check_answers_page
       when_i_press_change_ni_number
@@ -271,10 +283,14 @@ RSpec.describe 'TRN requests', type: :system do
 
     when_i_choose_no
     and_i_press_continue
-    then_i_see_the_itt_provider_page
+    then_i_see_the_awarded_qts_page
 
     when_i_press_continue
     then_i_see_a_validation_error
+
+    when_i_choose_yes
+    and_i_press_continue
+    then_i_see_the_itt_provider_page
 
     when_i_choose_yes
     and_i_press_continue
@@ -414,7 +430,7 @@ RSpec.describe 'TRN requests', type: :system do
     when_i_complete_my_date_of_birth
     when_i_choose_no
     and_i_press_continue
-    then_i_see_the_itt_provider_page
+    then_i_see_the_awarded_qts_page
 
     when_i_choose_no
     and_i_press_continue
@@ -463,6 +479,12 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_current_path('/ask-questions')
     expect(page.driver.browser.current_title).to start_with('We’ll ask you some questions to help find your TRN')
     expect(page).to have_content('We’ll ask you some questions to help find your TRN')
+  end
+
+  def then_i_see_the_awarded_qts_page
+    expect(page).to have_current_path('/awarded-qts')
+    expect(page.driver.browser.current_title).to start_with('Have you been awarded qualified teacher status (QTS)?')
+    expect(page).to have_content('Have you been awarded qualified teacher status (QTS)?')
   end
 
   def then_i_see_the_check_answers_page
@@ -537,8 +559,8 @@ RSpec.describe 'TRN requests', type: :system do
 
   def then_i_see_the_itt_provider_page
     expect(page).to have_current_path('/itt-provider')
-    expect(page.driver.browser.current_title).to start_with('Have you been awarded qualified teacher status (QTS)?')
-    expect(page).to have_content('Have you been awarded qualified teacher status (QTS)?')
+    expect(page.driver.browser.current_title).to start_with('Did a university, SCITT or school award your QTS?')
+    expect(page).to have_content('Did a university, SCITT or school award your QTS?')
   end
 
   def then_i_see_the_have_ni_page
@@ -599,6 +621,13 @@ RSpec.describe 'TRN requests', type: :system do
     expect(page).to have_content('We could not find your TRN')
   end
 
+  def then_i_see_no_qts_awarded
+    expect(page).to have_current_path('/check-answers')
+    expect(page).to have_content('Have you been awarded QTS?')
+    expect(page).to have_content('No')
+    expect(page).not_to have_content('Where did you get your QTS?')
+  end
+
   def then_i_should_see_the_home_page
     expect(page).to have_content('Find a lost teacher reference number')
   end
@@ -609,6 +638,10 @@ RSpec.describe 'TRN requests', type: :system do
 
   def then_no_should_be_checked
     expect(find_field('No', checked: true, visible: false)).to be_truthy
+  end
+
+  def then_yes_should_be_checked
+    expect(find_field('Yes', checked: true, visible: false)).to be_truthy
   end
 
   def when_i_am_on_the_check_answers_page
@@ -633,6 +666,11 @@ RSpec.describe 'TRN requests', type: :system do
 
     when_i_press_continue
     then_i_see_the_name_page
+  end
+
+  def when_i_choose_no_itt_provider
+    choose 'No, I was awarded QTS another way', visible: false
+    when_i_press_continue
   end
 
   def when_i_choose_no_trn
@@ -668,6 +706,7 @@ RSpec.describe 'TRN requests', type: :system do
   end
 
   def when_i_fill_in_my_itt_provider
+    choose 'Yes', visible: false
     fill_in 'Where did you get your QTS?', with: 'Test ITT Provider', visible: false
   end
   alias_method :and_i_fill_in_my_itt_provider, :when_i_fill_in_my_itt_provider
@@ -738,6 +777,10 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_press_change_email
     click_on 'Change email address'
+  end
+
+  def when_i_press_change_awarded_qts
+    click_on 'Change awarded QTS'
   end
 
   def when_i_press_change_itt_provider


### PR DESCRIPTION
As part of the lessons learned from user feedback, we want to separate
out the question of whether someone has been awarded QTS from how they
were awarded it.

This allows us to be more inclusive of people who were awarded a QTS outside a
school or university.

I opted to introduce a new attribute on `TrnRequest` to store the answer
to the question of if someone has a QTS.

This allows us to use the `itt_provider_enrolled` attribute to now mean
whether someone was able to supply the name of the training provider or
not.

| New question | New answers |
| - | - |
| <img width="1022" alt="Screen Shot 2022-04-20 at 1 36 14 pm" src="https://user-images.githubusercontent.com/3126/164232783-f9e7dc3a-670f-423f-ae45-f17cb1117ffa.png"> | <img width="745" alt="Screen Shot 2022-04-20 at 1 41 42 pm" src="https://user-images.githubusercontent.com/3126/164232898-e4cfc3de-0fef-4ad9-844c-603517e738b0.png"> |



### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
