### PR TITLE
Log validation errors

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
 DQT_API_URL=https://preprod-teacher-qualifications-api.education.gov.uk/
 DQT_API_KEY=testkey
+GOVUK_NOTIFY_API_KEY=test
 HOSTING_ENVIRONMENT_NAME=local
 SUPPORT_PASSWORD=test
 SUPPORT_USERNAME=test

--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,5 @@
 DQT_API_URL=https://preprod-teacher-qualifications-api.education.gov.uk/
 DQT_API_KEY=testkey
-GOVUK_NOTIFY_API_KEY=test
 HOSTING_ENVIRONMENT_NAME=local
 SUPPORT_PASSWORD=test
 SUPPORT_USERNAME=test

--- a/app/forms/check_trn_form.rb
+++ b/app/forms/check_trn_form.rb
@@ -1,16 +1,25 @@
 # frozen_string_literal: true
 class CheckTrnForm
   include ActiveModel::Model
+  include LogErrors
 
   attr_accessor :has_trn
 
   validates :has_trn, inclusion: { in: %w[true false] }
 
+  def email?
+    false
+  end
+
   def trn?
     ActiveModel::Type::Boolean.new.cast(has_trn)
   end
 
-  def email?
-    false
+  def trn_request
+    TrnRequest.new
+  end
+
+  def valid?
+    super.tap { |result| log_errors unless result }
   end
 end

--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class DateOfBirthForm
   include ActiveModel::Model
+  include LogErrors
 
   attr_accessor :trn_request
   attr_writer :date_of_birth
@@ -28,11 +29,13 @@ class DateOfBirthForm
 
     if day.zero? && month.zero? && year.zero?
       errors.add(:date_of_birth, t('blank'))
+      log_errors
       return false
     end
 
     if day.zero?
       errors.add(:date_of_birth, t('missing_day'))
+      log_errors
       return false
     end
 
@@ -40,21 +43,25 @@ class DateOfBirthForm
 
     if month.zero?
       errors.add(:date_of_birth, t('missing_month'))
+      log_errors
       return false
     end
 
     if year < 1000
       errors.add(:date_of_birth, t('missing_year'))
+      log_errors
       return false
     end
 
     if year < 1900
       errors.add(:date_of_birth, t('born_after_1900'))
+      log_errors
       return false
     end
 
     if year > Time.zone.today.year
       errors.add(:date_of_birth, t('in_the_future'))
+      log_errors
       return false
     end
 
@@ -62,15 +69,20 @@ class DateOfBirthForm
       self.date_of_birth = Date.new(year, month, day)
     rescue Date::Error
       errors.add(:date_of_birth, t('blank'))
+      log_errors
       return false
     end
 
     if date_of_birth > 16.years.ago
       errors.add(:date_of_birth, t('inclusion'))
+      log_errors
       return false
     end
 
-    return false if invalid?
+    if invalid?
+      log_errors
+      return false
+    end
 
     trn_request.update!(date_of_birth: date_of_birth)
   end

--- a/app/forms/email_form.rb
+++ b/app/forms/email_form.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class EmailForm
   include ActiveModel::Model
+  include LogErrors
 
   attr_accessor :trn_request
   attr_writer :email
@@ -14,7 +15,10 @@ class EmailForm
   end
 
   def save
-    return false if invalid?
+    if invalid?
+      log_errors
+      return false
+    end
 
     trn_request.email = email
     trn_request.save

--- a/app/forms/has_ni_number_form.rb
+++ b/app/forms/has_ni_number_form.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class HasNiNumberForm
   include ActiveModel::Model
+  include LogErrors
 
   attr_accessor :trn_request
 
@@ -10,7 +11,10 @@ class HasNiNumberForm
 
   def update(params = {})
     self.has_ni_number = params[:has_ni_number]
-    return false if invalid?
+    if invalid?
+      log_errors
+      return false
+    end
 
     trn_request.save!
   end

--- a/app/forms/itt_provider_form.rb
+++ b/app/forms/itt_provider_form.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class IttProviderForm
   include ActiveModel::Model
+  include LogErrors
 
   attr_accessor :trn_request, :itt_provider_enrolled, :itt_provider_name
 
@@ -8,7 +9,10 @@ class IttProviderForm
   validates :itt_provider_name, presence: true, length: { maximum: 255 }, if: -> { itt_provider_enrolled == 'true' }
 
   def save
-    return false if invalid?
+    if invalid?
+      log_errors
+      return false
+    end
 
     trn_request.update(itt_provider_enrolled: itt_provider_enrolled, itt_provider_name: itt_provider_name)
   end

--- a/app/forms/name_form.rb
+++ b/app/forms/name_form.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class NameForm
   include ActiveModel::Model
+  include LogErrors
 
   attr_accessor :trn_request
   attr_writer :first_name, :last_name, :name_changed, :previous_first_name, :previous_last_name
@@ -44,7 +45,10 @@ class NameForm
   end
 
   def save
-    return false if invalid?
+    if invalid?
+      log_errors
+      return false
+    end
 
     trn_request.first_name = first_name
     trn_request.last_name = last_name

--- a/app/forms/ni_number_form.rb
+++ b/app/forms/ni_number_form.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class NiNumberForm
   include ActiveModel::Model
+  include LogErrors
 
   attr_accessor :trn_request
 
@@ -14,7 +15,10 @@ class NiNumberForm
 
   def update(params = {})
     self.ni_number = params[:ni_number]
-    return false if invalid?
+    if invalid?
+      log_errors
+      return false
+    end
 
     trn_request.save!
   end

--- a/app/models/concerns/log_errors.rb
+++ b/app/models/concerns/log_errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module LogErrors
+  extend ActiveSupport::Concern
+
+  included do
+    def log_errors
+      return unless FeatureFlag.active?(:log_validation_errors)
+
+      ValidationError.create(form_object: self.class.name, messages: errors.messages, trn_request: trn_request)
+    end
+  end
+end

--- a/app/models/validation_error.rb
+++ b/app/models/validation_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class ValidationError < ApplicationRecord
+  belongs_to :trn_request
+
+  validates :form_object, presence: true
+  validates :messages, presence: true
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -16,6 +16,7 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = [
     [:dqt_api_always_timeout, 'Always time-out the DQT API', 'Felix Clack'],
+    [:log_validation_errors, 'Log validation errors', 'Felix Clack'],
     [:processing_delays, 'Show users banners and interstitials warning them of increased waiting times', 'Felix Clack'],
     [:service_open, 'Allow users to access the service and submit TRN Requests', 'Theodor Vararu'],
     [:use_dqt_api, 'Use DQT API to find TRN', 'Felix Clack'],

--- a/db/migrate/20220422110101_create_validation_errors.rb
+++ b/db/migrate/20220422110101_create_validation_errors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class CreateValidationErrors < ActiveRecord::Migration[7.0]
+  def change
+    create_table :validation_errors do |t|
+      t.string :form_object, null: false
+      t.jsonb :messages, default: '{}', null: false
+      t.references :trn_request, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :validation_errors, :messages, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_20_065448) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_22_110101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,4 +41,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_20_065448) do
     t.boolean "awarded_qts"
   end
 
+  create_table "validation_errors", force: :cascade do |t|
+    t.string "form_object", null: false
+    t.jsonb "messages", default: "{}", null: false
+    t.bigint "trn_request_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["messages"], name: "index_validation_errors_on_messages", using: :gin
+    t.index ["trn_request_id"], name: "index_validation_errors_on_trn_request_id"
+  end
+
+  add_foreign_key "validation_errors", "trn_requests"
 end

--- a/spec/forms/check_trn_form_spec.rb
+++ b/spec/forms/check_trn_form_spec.rb
@@ -3,4 +3,24 @@ require 'rails_helper'
 
 RSpec.describe CheckTrnForm, type: :model do
   it { is_expected.to validate_inclusion_of(:has_trn).in_array(%w[true false]) }
+
+  describe '#valid?' do
+    subject(:valid) { check_trn_form.valid? }
+
+    let(:check_trn_form) { described_class.new(has_trn: has_trn) }
+    let(:has_trn) { 'true' }
+
+    it { is_expected.to be_truthy }
+
+    context 'when the has_trn is blank' do
+      let(:has_trn) { '' }
+
+      it { is_expected.to be_falsy }
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { valid }.to change(ValidationError, :count).by(1)
+      end
+    end
+  end
 end

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe DateOfBirthForm, type: :model do
         update
         expect(trn_request.date_of_birth).to be_nil
       end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
+      end
     end
 
     context 'with a blank date' do
@@ -44,6 +49,11 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'adds an error' do
         update
         expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Enter your date of birth'])
+      end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
       end
     end
 
@@ -57,6 +67,11 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'adds an error' do
         update
         expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Your date of birth must be in the past'])
+      end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
       end
     end
 
@@ -75,6 +90,11 @@ RSpec.describe DateOfBirthForm, type: :model do
         update
         expect(date_of_birth_form.errors[:date_of_birth]).to eq(['You must be 16 or over to use this service'])
       end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
+      end
     end
 
     context 'with a date before 1900' do
@@ -85,6 +105,11 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'adds an error' do
         update
         expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Year of birth must be 1900 or later'])
+      end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
       end
     end
 
@@ -97,6 +122,11 @@ RSpec.describe DateOfBirthForm, type: :model do
         update
         expect(date_of_birth_form.errors[:date_of_birth]).to eq(['The year must include 4 digits'])
       end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
+      end
     end
 
     context 'with a missing day' do
@@ -108,6 +138,11 @@ RSpec.describe DateOfBirthForm, type: :model do
         update
         expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Your date of birth must include a day'])
       end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
+      end
     end
 
     context 'with a missing month' do
@@ -118,6 +153,11 @@ RSpec.describe DateOfBirthForm, type: :model do
       it 'adds an error' do
         update
         expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Your date of birth must include a month'])
+      end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
       end
     end
   end

--- a/spec/forms/email_form_spec.rb
+++ b/spec/forms/email_form_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe EmailForm, type: :model do
       let(:email) { '' }
 
       it { is_expected.to be_falsy }
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { save }.to change(ValidationError, :count).by(1)
+      end
     end
   end
 

--- a/spec/forms/has_ni_number_form_spec.rb
+++ b/spec/forms/has_ni_number_form_spec.rb
@@ -11,4 +11,19 @@ RSpec.describe HasNiNumberForm, type: :model do
       'Tell us if you have a National Insurance number',
     )
   end
+
+  describe '#update' do
+    subject(:update) { has_ni_number_form.update(params) }
+
+    context 'when the form is invalid' do
+      let(:params) { { trn_request: TrnRequest.new } }
+
+      it { is_expected.to be_falsy }
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
+      end
+    end
+  end
 end

--- a/spec/forms/itt_provider_form_spec.rb
+++ b/spec/forms/itt_provider_form_spec.rb
@@ -26,25 +26,26 @@ RSpec.describe IttProviderForm, type: :model do
   end
 
   describe '#save' do
-    context 'when itt_provider_enrolled is missing' do
-      it 'returns false' do
-        form = described_class.new
+    subject(:save) { form.save }
 
-        expect(form.save).to be false
+    context 'when itt_provider_enrolled is missing' do
+      let(:form) { described_class.new(trn_request: TrnRequest.new) }
+
+      it { is_expected.to be_falsy }
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { save }.to change(ValidationError, :count).by(1)
       end
     end
 
     context 'when form data is correct' do
+      let(:form) do
+        described_class.new(trn_request: TrnRequest.new, itt_provider_enrolled: 'true', itt_provider_name: 'Big SCITT')
+      end
+
       it 'saves the model' do
-        form =
-          described_class.new(
-            trn_request: TrnRequest.new,
-            itt_provider_enrolled: 'true',
-            itt_provider_name: 'Big SCITT',
-          )
-
-        form.save
-
+        save
         expect(form.trn_request.itt_provider_enrolled).to be true
         expect(form.trn_request.itt_provider_name).to eq 'Big SCITT'
       end

--- a/spec/forms/name_form_spec.rb
+++ b/spec/forms/name_form_spec.rb
@@ -94,6 +94,20 @@ RSpec.describe NameForm, type: :model do
         save
         expect(name_form.errors[:first_name]).to include('Enter your first name')
       end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { save }.to change(ValidationError, :count).by(1)
+      end
+
+      it 'records all the validation error messages' do
+        FeatureFlag.activate(:log_validation_errors)
+        save
+        expect(ValidationError.last.messages).to include(
+          'first_name' => ['Enter your first name'],
+          'last_name' => ['Enter your last name'],
+        )
+      end
     end
   end
 

--- a/spec/forms/ni_number_form_spec.rb
+++ b/spec/forms/ni_number_form_spec.rb
@@ -78,4 +78,17 @@ RSpec.describe NiNumberForm, type: :model do
       end
     end
   end
+
+  describe '#update' do
+    subject(:update) { ni_number_form.update(ni_number: ni_number) }
+
+    context 'when the ni_number is invalid' do
+      let(:ni_number) { '' }
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
+      end
+    end
+  end
 end

--- a/spec/models/validation_error_spec.rb
+++ b/spec/models/validation_error_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ValidationError, type: :model do
+  it { is_expected.to belong_to(:trn_request) }
+  it { is_expected.to validate_presence_of(:form_object) }
+  it { is_expected.to validate_presence_of(:messages) }
+end


### PR DESCRIPTION
We want visibility into how people are using the service and in
particular, which error messages they see.

I took inspiration from [Apply](https://github.com/DFE-Digital/apply-for-teacher-training/pull/1922) when designing this.

Storing validation errors as a record in the database makes it easy for
us to display in the support interface. The UI for this will come in a
future change.

The scope of where a validation error can occur is more limited than the
Apply version, so I was able to keep it simpler.

An error will always be associated with a `TrnRequest` and the form
object that was validated has a one-to-one mapping with a particular
path, so we know where the error was seen.

I considered using a controller concern but instead went for including
it at the form object level. The idea being that logging the errors is
the responsibility of the form object that triggered the errors rather
than having another object have knowledge of both the form object and
how to record the errors.

Apply made the choice to log in the controller to avoid logging
validation errors more than necessary, ie. they assumed that form
objects would be used in more places than the controller.

In our case, we have an assumption that a form object is only used
by the controllers. We have no other way to use them. The pattern we
have followed is to use the form objects to encapsulate all side-effects
related to creating/mutating objects in the system.

This means that controller actions are responsible for co-ordinating
this process but not the implementation of it.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
