### PR TITLE
Add database backup to azure

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -1,0 +1,78 @@
+name: Backup Database to Azure Storage
+
+on:
+  workflow_dispatch:
+  schedule: # 01:00 UTC
+    - cron: '0 1 * * *'
+
+jobs:
+  backup:
+    name: Backup PaaS Database ( Production )
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.azure_credentials }}
+
+      - name: Set environment variables
+        shell: bash
+        run: |
+          tf_vars_file=terraform/workspace_variables/production.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "PAAS_SPACE=$(jq -r '.paas_space' ${tf_vars_file})" >> $GITHUB_ENV
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id: get_secrets
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secrets: 'BACKUP-STORAGE-CONNECTION-STRING,PAAS-USER,PAAS-PASSWORD'
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id: keyvault-yaml-secret
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secret: MONITORING
+          key: SLACK_WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Setup cf cli
+        uses: DFE-Digital/github-actions/setup-cf-cli@master
+        with:
+          CF_USERNAME: ${{ steps.get_secrets.outputs.PAAS-USER }}
+          CF_PASSWORD: ${{ steps.get_secrets.outputs.PAAS-PASSWORD }}
+          CF_SPACE_NAME: ${{ env.PAAS_SPACE }}
+          INSTALL_CONDUIT: true
+
+      - name: Setup postgres client
+        uses: DFE-Digital/github-actions/install-postgres-client@master
+
+      - name: Set environment variable
+        run: echo "BACKUP_FILE_NAME=find-a-lost-trn-production-pg-svc-$(date +"%F-%H-%M-%S")" >> $GITHUB_ENV
+
+      - name: Backup Production DB
+        run: |
+          cf conduit find-a-lost-trn-production-pg-svc -- pg_dump -E utf8 --clean --if-exists --no-owner --verbose --no-password -f ${BACKUP_FILE_NAME}.sql
+          tar -cvzf ${BACKUP_FILE_NAME}.tar.gz ${BACKUP_FILE_NAME}.sql
+
+      - name: Upload Backup to Azure Storage
+        run: |
+          az storage blob upload --container-name find-a-lost-trn \
+          --file ${BACKUP_FILE_NAME}.tar.gz --name ${BACKUP_FILE_NAME}.tar.gz \
+          --connection-string '${{ steps.get_secrets.outputs.BACKUP-STORAGE-CONNECTION-STRING }}'
+
+      - name: Notify Slack channel on job failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: CI Deployment
+          SLACK_TITLE: Database backup failure
+          SLACK_MESSAGE: Production database backup job failed
+          SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}
+          SLACK_COLOR: failure
+          SLACK_FOOTER: Sent from backup job in database-backup workflow

--- a/docs/restore-paas-postgres-database.md
+++ b/docs/restore-paas-postgres-database.md
@@ -83,3 +83,30 @@ Once the plan is reviewed, type **yes** to initiate the deployment process. This
 Once restore has been ran successfully and checked, make sure to delete the renamed instance created before the restore process was intitated in step 4.
 
 Run `cf delete-service <db-service-instance-name>-old`
+
+# How to restore backup from Azure storage
+
+Backup of production database **find-a-lost-trn-production-pg-svc** is taken every night and stored in Azure storage **s165p01dbbackup** for 35 days. You can download the backup file and restore it to the PaaS postgres instance.
+
+_Note: This process assumes that the database instance is available on PaaS._
+
+## Permissions required
+
+- **SpaceDeveloper** role to run the restore command in Gov PaaS.
+- **Contributor** access to **s165-teachingqualificationsservice-production** subscription raised through PIM request. This will enable access to storage account.
+
+## Tool required
+
+- Conduit plugin
+
+Install CF Conduit plugin by running `cf install-plugin conduit`
+
+### 1. Download the backup file
+
+- Go to Azure storage account **s165p01dbbackup** and container **find-a-lost-trn**.
+- Download the specific backup file avaialable to restore
+- extract the zip file locally
+
+## 2. Restore to database
+
+Run `cf conduit find-a-lost-trn-production-pg-svc -- psql < backup.sql`, where **backup.sql** is the backup you downloaded from Azure storage.


### PR DESCRIPTION
### Context

Backup of PaaS database needs to be available outside of PaaS infrastructure in the event of failure results in all available backups in PaaS are lost or not recoverable. Daily backup of the database can be stored in Azure storage. This PR adds a workflow to create backups which runs every night.

### Trello card

https://trello.com/c/xTdOCHxM

