### PR TITLE
Handle TRNs with active sanctions

### DIFF
--- a/app/controllers/ni_number_controller.rb
+++ b/app/controllers/ni_number_controller.rb
@@ -49,7 +49,7 @@ class NiNumberController < ApplicationController
 
   def find_trn_using_api
     response = DqtApi.find_trn!(trn_request)
-    trn_request.update(trn: response['trn'])
+    trn_request.update(trn: response['trn'], has_active_sanctions: response['hasActiveSanctions'])
   end
 
   def trn_request

--- a/db/migrate/20220504100623_add_has_active_sanctions_to_trn_request.rb
+++ b/db/migrate/20220504100623_add_has_active_sanctions_to_trn_request.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddHasActiveSanctionsToTrnRequest < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trn_requests, :has_active_sanctions, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_22_110101) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_04_100623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_22_110101) do
     t.string "trn"
     t.integer "zendesk_ticket_id"
     t.boolean "awarded_qts"
+    t.boolean "has_active_sanctions"
   end
 
   create_table "validation_errors", force: :cascade do |t|

--- a/spec/cassettes/TRN_requests/handles_a_TRN_with_active_sanctions.yml
+++ b/spec/cassettes/TRN_requests/handles_a_TRN_with_active_sanctions.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1999-05-05&emailAddress&firstName=Audrey&ittProviderName&lastName=Coady&nationalInsuranceNumber=JN123456A&previousFirstName&previousLastName
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+          - Faraday v1.10.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - '*/*'
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 04 May 2022 08:47:46 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - '299'
+        X-Rate-Limit-Reset:
+          - '2022-05-04T08:48:00.0000000Z'
+        X-Vcap-Request-Id:
+          - 938fde74-a1f4-4171-4da6-2b3e1ad914e5
+        X-Xss-Protection:
+          - '0'
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 dadbd3993b5303886df72c2fdce172ca.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - MAD51-C2
+        X-Amz-Cf-Id:
+          - gV-PQ9zrg_PopowBR9biRjF4EMyEnA2RTeWXRp-2UgJ0YpQWEZKE6w==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2600145","emailAddresses":["acoady2@myemail.co.uk"],"firstName":"Audrey","lastName":"Coady","dateOfBirth":"1999-05-05","nationalInsuranceNumber":"JN123456A","uid":"a3b16d4f-9134-eb11-a813-000d3a2287a4","hasActiveSanctions":true}]}'
+    recorded_at: Wed, 04 May 2022 08:47:46 GMT
+recorded_with: VCR 6.1.0

--- a/spec/system/active_sanctions_spec.rb
+++ b/spec/system/active_sanctions_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'TRN requests', type: :system do
+  before do
+    given_the_service_is_open
+    given_the_zendesk_integration_feature_is_enabled
+    given_the_use_dqt_api_feature_is_enabled
+  end
+
+  it 'handles a TRN with active sanctions', vcr: true do
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
+    when_i_confirm_i_have_a_trn_number
+    when_i_press_continue
+    when_i_fill_in_the_name_form
+    when_i_complete_my_date_of_birth
+    when_i_choose_yes
+    when_i_press_continue
+    when_i_fill_in_my_ni_number
+    when_i_press_continue
+    when_i_fill_in_my_email_address
+    and_i_press_continue
+    then_i_see_the_check_answers_page
+
+    when_i_press_the_submit_button
+    then_i_see_the_zendesk_confirmation_page
+    and_i_receive_an_email_with_the_zendesk_ticket_number
+  end
+
+  def given_the_service_is_open
+    FeatureFlag.activate(:service_open)
+  end
+
+  def given_the_use_dqt_api_feature_is_enabled
+    FeatureFlag.activate(:use_dqt_api)
+  end
+
+  def given_the_zendesk_integration_feature_is_enabled
+    FeatureFlag.activate(:zendesk_integration)
+  end
+
+  def given_i_am_on_the_home_page
+    visit root_path
+  end
+
+  def when_i_press_the_start_button
+    click_on 'Start now'
+  end
+
+  def when_i_confirm_i_have_a_trn_number
+    choose 'Yes', visible: false
+    when_i_press_continue
+  end
+
+  def when_i_press_continue
+    click_on 'Continue'
+  end
+  alias_method :and_i_press_continue, :when_i_press_continue
+
+  def when_i_fill_in_the_name_form
+    fill_in 'First name', with: 'Audrey'
+    fill_in 'Last name', with: 'Coady'
+    when_i_press_continue
+  end
+
+  def when_i_complete_my_date_of_birth
+    fill_in 'Day', with: '05'
+    fill_in 'Month', with: '05'
+    fill_in 'Year', with: '1999'
+    click_on 'Continue'
+  end
+
+  def when_i_fill_in_my_ni_number
+    fill_in 'What is your National Insurance number?', with: 'JN123456A'
+  end
+  alias_method :and_i_fill_in_my_ni_number, :when_i_fill_in_my_ni_number
+
+  def when_i_fill_in_my_email_address
+    fill_in 'Your email address', with: 'test@example.com'
+  end
+  alias_method :and_i_fill_in_my_email_address, :when_i_fill_in_my_email_address
+
+  def when_i_choose_yes
+    choose 'Yes', visible: false
+  end
+  alias_method :and_i_choose_yes, :when_i_choose_yes
+
+  def when_i_press_the_submit_button
+    click_on 'Submit'
+  end
+  alias_method :and_i_press_the_submit_button, :when_i_press_the_submit_button
+
+  def then_i_see_the_zendesk_confirmation_page
+    expect(page.driver.browser.current_title).to start_with('We’ve received your request')
+    expect(page).to have_content('We’ve received your request')
+    expect(page).to have_content('give the helpdesk your request number: 42')
+  end
+
+  def then_i_see_the_check_answers_page
+    expect(page).to have_current_path('/check-answers')
+    expect(page.driver.browser.current_title).to start_with('Check your answers')
+    expect(page).to have_content('Check your answers')
+    expect(page).to have_content('Audrey Coady')
+    expect(page).to have_content('Date of birth')
+    expect(page).to have_content('5 May 1999')
+  end
+
+  def and_i_receive_an_email_with_the_zendesk_ticket_number
+    open_email('test@example.com')
+    expect(current_email.subject).to eq('We’ve received the information you submitted')
+    expect(current_email.body).to include('give the helpdesk your ticket number: 42')
+  end
+end


### PR DESCRIPTION
### Context

When a user attempts to retrieve a TRN with active sanctions, we should send them to Zendesk so that the support agent can provide some additional guidance to how their TRN can be used.

### Changes proposed in this pull request

Handle new API field, save it to the TRN request, and read it to check if it's truthy at the appropriate time.

### Guidance to review

Nothing in particular.

### Checklist

https://trello.com/c/pbIitjyu/394-restrict-returning-trns-when-the-matched-trn-has-an-active-alert

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
