### PR TITLE
Strip hyphens from NI numbers

### DIFF
--- a/app/forms/ni_number_form.rb
+++ b/app/forms/ni_number_form.rb
@@ -10,7 +10,7 @@ class NiNumberForm
   delegate :email?, :ni_number, to: :trn_request
 
   def ni_number=(value)
-    trn_request.ni_number = value&.gsub(/\s/, '')
+    trn_request.ni_number = value&.gsub(/\s|-/, '')
   end
 
   def update(params = {})

--- a/spec/forms/ni_number_form_spec.rb
+++ b/spec/forms/ni_number_form_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe NiNumberForm, type: :model do
       'QQ123456C',
       'QQ 1 2 3 4 5 6 C',
       'qq123456c',
+      'QQ-12-34-56-C',
     ]
 
     valid_numbers_in_strange_formats.each do |ni_number|


### PR DESCRIPTION
We have people entering their national insurance numbers with hyphens in
between the numbers.

We can safely strip out the hyphens and use the resulting value as the
national insurance number.

[Trello](https://trello.com/c/zihpMy7i/414-allow-users-to-enter-nino-numbers-with-hyphens)

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
