### PR TITLE
Increase app instance and make database HA

### DIFF
--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -3,10 +3,13 @@
   "key_vault_name": "s165t01-preprod-kv",
   "resource_group_name": "s165t01-preprod-rg",
   "flt_app_name": "find-a-lost-trn-preprod",
+  "flt_instances": 2,
   "logging_service_name": "flt-logit-ssl-drain-preprod",
   "paas_space": "tra-test",
   "postgres_database_name": "find-a-lost-trn-preprod-pg-svc",
+  "postgres_database_service_plan": "small-ha-13",
   "redis_name": "find-a-lost-trn-preprod-redis-svc",
+  "redis_service_plan": "tiny-ha-6_x",
   "hostnames": ["preprod-find-a-lost-trn"],
   "statuscake_alerts": {
     "tra-flt-preprod": {


### PR DESCRIPTION
### Context

Production app deployment should be highly available. This means app
instances should be at least to and postgres and redis cache should be
on HA service plan. This commit over-rides default values to make
deployment HA.

