### PR TITLE
Allow people to continue without a national insurance number

### DIFF
--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -32,7 +32,7 @@ class TrnRequest < ApplicationRecord
     return :answers if email.present?
     return :email if (!awarded_qts.nil? && !awarded_qts && itt_provider_enrolled.nil?) || !itt_provider_enrolled.nil?
     return :itt_provider if awarded_qts
-    return :awarded_qts if (!has_ni_number.nil? && ni_number.present?) || (!has_ni_number.nil? && !has_ni_number)
+    return :awarded_qts unless has_ni_number.nil?
     return :ni_number if has_ni_number
     return :has_ni_number if date_of_birth.present?
     return :date_of_birth if first_name.present?

--- a/app/views/ni_number/edit.html.erb
+++ b/app/views/ni_number/edit.html.erb
@@ -21,7 +21,7 @@
           Or you can continue without it, but we are less likely to find your TRN.
         </p>
 
-        <%= govuk_button_link_to 'Continue without it', itt_provider_path, secondary: true %>
+        <%= govuk_button_link_to 'Continue without it', session[:form_complete] ? check_answers_path : itt_provider_path, secondary: true %>
       <% end %>
 
       <%= f.govuk_submit prevent_double_click: false %>

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -91,14 +91,22 @@ RSpec.describe TrnRequest, type: :model do
       it { is_expected.to eq(:has_ni_number) }
     end
 
-    context 'when has_ni_number is true' do
+    context 'when has_ni_number is true and ni_number is nil' do
       let(:attributes) { { date_of_birth: '01/01/2000', first_name: 'John', has_ni_number: true, last_name: 'Smith' } }
 
-      it { is_expected.to eq(:ni_number) }
+      it { is_expected.to eq(:awarded_qts) }
     end
 
     context 'when an NI number is present' do
-      let(:attributes) { { date_of_birth: '01/01/2000', has_ni_number: false, first_name: 'John', last_name: 'Smith' } }
+      let(:attributes) do
+        {
+          date_of_birth: '01/01/2000',
+          has_ni_number: true,
+          ni_number: 'QQ123456C',
+          first_name: 'John',
+          last_name: 'Smith',
+        }
+      end
 
       it { is_expected.to eq(:awarded_qts) }
     end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -116,6 +116,21 @@ RSpec.describe 'TRN requests', type: :system do
     then_i_see_the_awarded_qts_page
   end
 
+  it 'when the user has a NI number but says they do not remember it' do
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
+    when_i_confirm_i_have_a_trn_number
+    when_i_press_continue
+    when_i_fill_in_the_name_form
+    when_i_complete_my_date_of_birth
+    when_i_choose_yes_to_ni_number
+    then_i_see_the_ni_number_page
+
+    when_i_click_on_the_forgotten_ni_number_link
+    and_i_press_continue_without_it
+    then_i_see_the_awarded_qts_page
+  end
+
   it 'changing my name' do
     given_i_have_completed_a_trn_request
     when_i_press_change_name
@@ -838,6 +853,14 @@ RSpec.describe 'TRN requests', type: :system do
 
   def when_i_am_authorized_as_a_support_user
     page.driver.basic_authorize('test', 'test')
+  end
+
+  def when_i_click_on_the_forgotten_ni_number_link
+    find('.govuk-details__summary-text', text: 'I don’t know my National Insurance number').click
+  end
+
+  def and_i_press_continue_without_it
+    click_on 'Continue without it'
   end
 
   def when_i_navigate_to_the_name_page


### PR DESCRIPTION
When someone indicates they have a national insurance number, we present
them an option to skip entry if they don't know it.

The way we enforce the question order means that no-one is able to skip
this step and is always redirected back to the national insurance form.

We are relaxing constraints that prevent people from skipping the
national insurance question by typing in the ITT provider URL.

This allows us to enable skipping via the 'Continue without it' link.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
