### PR TITLE
Allow seeing all performance stats ?since_launch

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,8 +21,18 @@ class PagesController < ApplicationController
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def performance
-    trn_requests =
-      TrnRequest.where(created_at: 1.week.ago.beginning_of_day..Time.zone.now).group("date_trunc('day', created_at)")
+    since = 1.week.ago.beginning_of_day
+    until_days = 6
+    @since_text = 'over the last 7 days'
+
+    if params.key? :since_launch
+      launch_date = Date.new(2022, 5, 4).beginning_of_day
+      since = launch_date
+      until_days = ((Time.zone.now.beginning_of_day - since) / (3600 * 24)).to_i
+      @since_text = 'since launch'
+    end
+
+    trn_requests = TrnRequest.where(created_at: since..Time.zone.now).group("date_trunc('day', created_at)")
 
     trn_requests_total = trn_requests.count
 
@@ -30,18 +40,18 @@ class PagesController < ApplicationController
 
     trn_requests_with_zendesk_ticket = trn_requests.where.not(zendesk_ticket_id: nil).count
 
-    last_7_days = (0..6).map { |n| n.days.ago.beginning_of_day.utc }
+    last_n_days = (0..until_days).map { |n| n.days.ago.beginning_of_day.utc }
 
-    @requests_over_last_7_days = trn_requests_total.values.reduce(&:+)
+    @requests_over_last_n_days = trn_requests_total.values.reduce(&:+)
 
     @live_service_data = [%w[Date Requests]]
-    @live_service_data += last_7_days.map { |day| [day.strftime('%d %B'), trn_requests_total[day] || 0] }
+    @live_service_data += last_n_days.map { |day| [day.strftime('%d %B'), trn_requests_total[day] || 0] }
 
     @trns_found = trn_requests_with_trn.values.reduce(&:+)
 
     @submission_data = [['Date', 'TRNs found', 'Zendesk tickets opened']]
     @submission_data +=
-      last_7_days.map do |day|
+      last_n_days.map do |day|
         [day.strftime('%d %B'), trn_requests_with_trn[day] || 0, trn_requests_with_zendesk_ticket[day] || 0]
       end
   end

--- a/app/views/pages/performance.html.erb
+++ b/app/views/pages/performance.html.erb
@@ -14,13 +14,13 @@
 <div class="app-!-border-top-1 govuk-!-padding-top-2">
   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Live service usage</h2>
   <p class="govuk-!-font-size-16">
-    Number of TRN requests started daily over the last 7 days
+    Number of TRN requests started daily <%= @since_text %>
   </p>
 
   <div class="govuk-!-text-align-right">
     <div style="display: inline-block">
-      <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@requests_over_last_7_days) %></p>
-      <p>requests over the last 7 days</p>
+      <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@requests_over_last_n_days) %></p>
+      <p>requests <%= @since_text %></p>
     </div>
   </div>
 
@@ -30,13 +30,13 @@
 <div class="app-!-border-top-1 govuk-!-padding-top-2">
   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Submission results</h2>
   <p class="govuk-!-font-size-16">
-    Number of TRNs found versus number of Zendesk tickets opened over the last 7 days
+    Number of TRNs found versus number of Zendesk tickets opened <%= @since_text %>
   </p>
 
   <div class="govuk-!-text-align-right">
     <div style="display: inline-block">
       <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@trns_found) %></p>
-      <p>TRNs found over the last 7 days</p>
+      <p>TRNs found <%= @since_text %></p>
     </div>
   </div>
 

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Performance', type: :system do
-  before { Timecop.freeze(Date.new(2022, 0o4, 21)) }
+  before { Timecop.freeze(Date.new(2022, 5, 12)) }
 
   after { Timecop.return }
 
@@ -11,6 +11,9 @@ RSpec.describe 'Performance', type: :system do
     given_there_are_a_few_trns
     when_i_visit_the_performance_page
     then_i_see_the_live_stats
+
+    when_i_visit_the_performance_page_since_launch
+    then_i_see_the_live_stats_since_launch
   end
 
   private
@@ -20,7 +23,7 @@ RSpec.describe 'Performance', type: :system do
   end
 
   def given_there_are_a_few_trns
-    (0..6).each.with_index { |n, i| (i + 1).times { create(:trn_request, created_at: n.days.ago) } }
+    (0..8).each.with_index { |n, i| (i + 1).times { create(:trn_request, created_at: n.days.ago) } }
   end
 
   def when_i_visit_the_performance_page
@@ -28,8 +31,18 @@ RSpec.describe 'Performance', type: :system do
   end
 
   def then_i_see_the_live_stats
-    expect(page).to have_content("28\nrequests over the last 7 days")
-    expect(page).to have_content("21 April\t1")
-    expect(page).to have_content("15 April\t7")
+    expect(page).to have_content("36\nrequests over the last 7 days")
+    expect(page).to have_content("12 May\t1")
+    expect(page).to have_content("06 May\t7")
+  end
+
+  def when_i_visit_the_performance_page_since_launch
+    visit performance_path(since_launch: true)
+  end
+
+  def then_i_see_the_live_stats_since_launch
+    expect(page).to have_content("45\nrequests since launch")
+    expect(page).to have_content("12 May\t1")
+    expect(page).to have_content("04 May\t9")
   end
 end


### PR DESCRIPTION
Adds a `?since_launch` query string param to the performance dashboard that allows querying for the full data since May the 4th.

This page will likely get slow over time, but we can worry about that later. Making it a query string param makes it slightly more hidden than the regular performance dashboard, and less likely to impact overall service performance.

### After (local data)

![image](https://user-images.githubusercontent.com/1650875/168048126-707104bc-d34b-4cdd-bd2e-5fbecc315c1f.png)
