### PR TITLE
Fix exception from DOB month being a whitespace

### DIFF
--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -39,7 +39,7 @@ class DateOfBirthForm
       return false
     end
 
-    month = Date.parse(date_fields[1]).month if month.zero? && date_fields[1].length.positive?
+    month = Date.parse(date_fields[1]).month if month.zero? && date_fields[1].strip.length.positive?
 
     if month.zero?
       errors.add(:date_of_birth, t('missing_month'))

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -160,5 +160,21 @@ RSpec.describe DateOfBirthForm, type: :model do
         expect { update }.to change(ValidationError, :count).by(1)
       end
     end
+
+    context 'with a whitespace month' do
+      let(:params) { { 'date_of_birth(1i)' => '1990', 'date_of_birth(2i)' => ' ', 'date_of_birth(3i)' => '1' } }
+
+      it { is_expected.to be_falsy }
+
+      it 'adds an error' do
+        update
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Your date of birth must include a month'])
+      end
+
+      it 'logs a validation error' do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update }.to change(ValidationError, :count).by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Entering a space instead of a valid month on the 'date of birth' form raises a `Date::Error` exception.

[Sentry](https://sentry.io/organizations/dfe-teacher-services/issues/3274901284/?project=6275068&referrer=slack)

### Changes proposed in this pull request

Strip whitespace on the DOB month.

### Guidance to review

...

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
