### PR TITLE
Mention analysing data to improve service in privacy notice

### DIFF
--- a/app/views/static/privacy.md
+++ b/app/views/static/privacy.md
@@ -44,6 +44,8 @@ We use the data you give us to try and find your TRN in our records. If we can
 match your data to our records, we’ll email your TRN to you. This allows you to
 apply for teaching jobs or access other DfE services.
 
+We might also use your details when analysing data to improve the service.
+
 We use GOV.UK PaaS to run the service. [Visit the GOV.UK PaaS
 website](https://www.cloud.service.gov.uk/privacy-notice/#what-data-we-collect-from-end-users)
 to find out how they use and look after your data.


### PR DESCRIPTION
### Context

We want to be able to design with data. This means that some user data may be analysed in support of service improvements.

https://trello.com/c/y3I6165v/422-update-the-find-a-lost-trn-privacy-notice-to-include-analysing-personal-data-for-service-improvement

### Changes proposed in this pull request

<img width="810" alt="image" src="https://user-images.githubusercontent.com/23801/168830320-bdb93e60-69b5-4258-b0f0-1cc17be63b94.png">

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
