### PR TITLE
Be explicit about where the pension scheme is

### DIFF
--- a/app/views/check_trn/new.html.erb
+++ b/app/views/check_trn/new.html.erb
@@ -12,7 +12,7 @@
         <li>hold early years teacher status (EYTS) in England</li>
         <li>hold a national professional qualification (NPQ)</li>
         <li>are working towards QTS, EYTS or an NPQ</li>
-        <li>contribute to the Teachers’ Pensions scheme</li>
+        <li>contribute to the Teachers’ Pensions scheme in England or Wales</li>
         <li>have a relevant restriction in relation to teaching in England</li>
       </ul>
       <%= f.govuk_collection_radio_buttons(:has_trn,


### PR DESCRIPTION
In research we saw confusion with Scottish users who contribute to a Scottish Teachers' pensions scheme.