### PR TITLE
Changed port to 3000

### DIFF
--- a/terraform/network-policies.tf
+++ b/terraform/network-policies.tf
@@ -20,6 +20,6 @@ resource "cloudfoundry_network_policy" "prometheus_to_flt_policy" {
   policy {
     source_app      = data.cloudfoundry_app.prometheus_app[0].id
     destination_app = data.cloudfoundry_app.flt_web_app.id
-    port            = "80"
+    port            = "3000"
   }
 }


### PR DESCRIPTION
### Context

Metrics endpoint is down on port 80

### Changes proposed in this pull request

Changed port to 3000 as app is listening on it.


### Checklist

- [x] Attach to Trello card
- [x] Rebased master
