### PR TITLE
Fix IE build and allow date of birth to work with one -> twelve

### DIFF
--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -20,12 +20,14 @@ class DateOfBirthForm
   def update(params = {})
     date_fields = [params['date_of_birth(1i)'], params['date_of_birth(2i)'], params['date_of_birth(3i)']]
 
+    date_fields.map! { |f| f.is_a?(String) ? f.strip : f }
+
     # Use a struct instead of a date object to maintain what the user typed in,
     # and not transform the fields into other data types like integers that
     # Date.new is capable of accepting.
     self.date_of_birth = Struct.new(:year, :month, :day).new(*date_fields)
 
-    year, month, day = date_fields.map(&:to_i)
+    year, month, day = date_fields.map { |f| word_to_number(f) }.map(&:to_i)
 
     if day.zero? && month.zero? && year.zero?
       errors.add(:date_of_birth, t('blank'))
@@ -39,7 +41,7 @@ class DateOfBirthForm
       return false
     end
 
-    month = Date.parse(date_fields[1]).month if month.zero? && date_fields[1].strip.length.positive?
+    month = Date.parse(date_fields[1]).month if month.zero? && date_fields[1].length.positive?
 
     if month.zero?
       errors.add(:date_of_birth, t('missing_month'))
@@ -95,5 +97,26 @@ class DateOfBirthForm
 
   def t(str)
     I18n.t("activemodel.errors.models.date_of_birth_form.attributes.date_of_birth.#{str}")
+  end
+
+  def word_to_number(field)
+    return field if field.is_a? Integer
+
+    words = {
+      one: 1,
+      two: 2,
+      three: 3,
+      four: 4,
+      five: 5,
+      six: 6,
+      seven: 7,
+      eight: 8,
+      nine: 9,
+      ten: 10,
+      eleven: 11,
+      twelve: 12,
+    }
+
+    words[field.downcase.to_sym] || field
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,34 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
   tra:
     tel: 020 7593 5394
@@ -62,11 +31,11 @@ en:
           attributes:
             date_of_birth:
               blank: Enter your date of birth
-              born_after_1900: Year of birth must be 1900 or later
+              born_after_1900: Enter a year of birth later than 1900
               inclusion: You must be 16 or over to use this service
-              missing_day: Your date of birth must include a day
-              missing_month: Your date of birth must include a month
-              missing_year: The year must include 4 digits
+              missing_day: Enter a day for your date of birth
+              missing_month: Enter a month for your date of birth
+              missing_year: Enter a year with 4 digits
               in_the_future: Your date of birth must be in the past
         email_form:
           attributes:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sass": "^1.49.10"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
+    "build": "esbuild app/javascript/*.* --target=ie11 --bundle --sourcemap --outdir=app/assets/builds",
     "build:css": "sass ./app/assets/stylesheets/main.sass.scss ./app/assets/builds/main.css --no-source-map --load-path=node_modules",
     "lint": "eslint --ext .js,.ts,.tsx ./app/javascript",
     "preinstall": "mkdir -p public/assets/fonts public/assets/images",

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'adds an error' do
         update
-        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Year of birth must be 1900 or later'])
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Enter a year of birth later than 1900'])
       end
 
       it 'logs a validation error' do
@@ -120,7 +120,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'adds an error' do
         update
-        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['The year must include 4 digits'])
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Enter a year with 4 digits'])
       end
 
       it 'logs a validation error' do
@@ -136,7 +136,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'adds an error' do
         update
-        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Your date of birth must include a day'])
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Enter a day for your date of birth'])
       end
 
       it 'logs a validation error' do
@@ -152,7 +152,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'adds an error' do
         update
-        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Your date of birth must include a month'])
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Enter a month for your date of birth'])
       end
 
       it 'logs a validation error' do
@@ -168,7 +168,7 @@ RSpec.describe DateOfBirthForm, type: :model do
 
       it 'adds an error' do
         update
-        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Your date of birth must include a month'])
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(['Enter a month for your date of birth'])
       end
 
       it 'logs a validation error' do

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DateOfBirthForm, type: :model do
       end
     end
 
-    context 'with a word for for a number for the day and month' do
+    context 'with a word for a number for the day and month' do
       let(:params) do
         { 'date_of_birth(1i)' => '2000', 'date_of_birth(2i)' => 'tWeLvE  ', 'date_of_birth(3i)' => 'One' }
       end

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe DateOfBirthForm, type: :model do
       end
     end
 
+    context 'with a word for for a number for the day and month' do
+      let(:params) do
+        { 'date_of_birth(1i)' => '2000', 'date_of_birth(2i)' => 'tWeLvE  ', 'date_of_birth(3i)' => 'One' }
+      end
+
+      it 'updates the date of birth' do
+        update
+        expect(trn_request.date_of_birth).to eq(Date.new(2000, 12, 1))
+      end
+    end
+
     context 'without a valid date' do
       let(:params) { { 'date_of_birth(1i)' => '2000', 'date_of_birth(2i)' => '02', 'date_of_birth(3i)' => '30' } }
 

--- a/spec/system/validation_errors_spec.rb
+++ b/spec/system/validation_errors_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Validation errors', type: :system do
     create(:trn_request).tap do |trn_request|
       DateOfBirthForm
         .new(trn_request: trn_request)
-        .update('date_of_birth(1i)' => nil, 'date_of_birth(2i)' => nil, 'date_of_birth(3i)' => nil)
+        .update('date_of_birth(1i)' => '', 'date_of_birth(2i)' => '', 'date_of_birth(3i)' => '')
     end
   end
 


### PR DESCRIPTION
### Context

The internal accessibility audit uncovered some issues with our client-side JS, as well as suggested that some of our error messages can be improved.

### Changes proposed in this pull request

- Fix JS build on IE11
- Improve validation error messages for date of birth; use `Enter your` where relevant
- Make the DOB form work with numbers written out as words, one through twelve

### Guidance to review

#### Says month is incorrect, not day, meaning day is fine

![image](https://user-images.githubusercontent.com/1650875/170049858-21ff7268-4b4f-462b-92e9-08a752ca7f38.png)

### Checklist

https://trello.com/c/Qn1eluqa/424-arrange-internal-accessibility-audit

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
