### PR TITLE
Bump rack to a version without a vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.2.4)


### PR DESCRIPTION
### Context

This change aims to address some security vulnerabilities with `rack` and `nokogiri`.