### PR TITLE
Fix Zendesk API interface

### DIFF
--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -17,7 +17,7 @@ class ZendeskService
   end
 
   def self.find_ticket(id)
-    GDS_ZENDESK_CLIENT.ticket.find(id)
+    GDS_ZENDESK_CLIENT.ticket.find(id: id)
   end
 
   def self.ticket_template(trn_request)

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -12,7 +12,7 @@ module DummyTicketExtensions
     ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)
   end
 
-  def find(id)
+  def find(id:)
     ticket = ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: id)
     ticket.comments = [
       ZendeskAPI::Ticket::Comment.new(GDS_ZENDESK_CLIENT, id: 1, body: 'Example'),


### PR DESCRIPTION
The interface for finding a Zendesk ticket was set incorrectly, leading
to a [500 error](https://sentry.io/organizations/dfe-teacher-services/issues/3356653513/?project=6275068&query=is%3Aunresolved) in production.

This was caused by an incorrect usage of the library.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
