### PR TITLE
Align helpdesk opening times with start page

### DIFF
--- a/app/views/teacher_mailer/information_received.erb
+++ b/app/views/teacher_mailer/information_received.erb
@@ -12,4 +12,4 @@ We aim to respond in 5 working days.
 Call the Teaching Regulation Agency and give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>.
 
 Telephone: <%= t('tra.tel') %>
-Monday to Friday, 9am to 5pm (except public holidays)
+Monday to Thursday, 9am to 5pm, Friday 9am to 4.30pm (except public holidays)


### PR DESCRIPTION
### Context

When a TRN holder requests support from the TRA helpdesk, we send them an email.

### Changes proposed in this pull request

Align the helpdesk opening hours in the email with what's on the start page.

