### PR TITLE
Add delayed information received email

### DIFF
--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -17,4 +17,12 @@ class TeacherMailer < ApplicationMailer
 
     notify_email(mailer_options)
   end
+
+  def delayed_information_received(trn_request)
+    @trn_request = trn_request
+
+    mailer_options = { to: @trn_request.email, subject: 'We’ve received the information you submitted' }
+
+    notify_email(mailer_options)
+  end
 end

--- a/app/views/teacher_mailer/delayed_information_received.erb
+++ b/app/views/teacher_mailer/delayed_information_received.erb
@@ -1,0 +1,20 @@
+Dear <%= @trn_request.name %>,
+
+You recently requested help with finding your teacher reference number (TRN). We’re sorry you did not get an acknowledgement at the time. This was due to a technical problem, which we’ve now resolved.
+
+We’ve received the information you submitted, and you’ll get an email with your TRN if we find a match.
+
+Otherwise, we’ll contact you for more information.
+
+We aim to respond in 5 working days.
+
+# If you need your TRN quickly
+
+Call the Teaching Regulation Agency and give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>.
+
+Telephone: <%= t('tra.tel') %>
+Monday to Thursday, 9am to 5pm, Friday 9am to 4.30pm (except public holidays)
+
+# If you’ve already called our helpline
+
+Please ignore this message.


### PR DESCRIPTION
This will be run in a one-off script to notify that were affected by an incident that caused Zendesk tickets to no longer be opened.

In the future, we can repurpose it for similar situations where we have to send delayed notifications.