### PR TITLE
Remove unnecessary line break from zendesk email

### DIFF
--- a/app/views/teacher_mailer/information_received.erb
+++ b/app/views/teacher_mailer/information_received.erb
@@ -2,8 +2,7 @@ Dear <%= @trn_request.name %>,
 
 We’ve received the information you submitted.
 
-You’ll get an email with your TRN if we find a match. Otherwise, we’ll contact
-you for more information.
+You’ll get an email with your TRN if we find a match. Otherwise, we’ll contact you for more information.
 
 We aim to respond in 5 working days.
 


### PR DESCRIPTION
### Context

This causes an awkward line break in the Notify email

![image](https://user-images.githubusercontent.com/23801/174782984-d26458b4-ef11-4aec-9994-309c2eb7ccb1.png)

