### PR TITLE
Fix error with multiple comments on a ticket

### DIFF
--- a/app/services/fetch_trn_from_zendesk.rb
+++ b/app/services/fetch_trn_from_zendesk.rb
@@ -21,12 +21,10 @@ class FetchTrnFromZendesk
 
   def trn
     @trn ||=
-      zendesk_ticket.comments[1..]
-        .find { |comment| comment.body.scan(TRN_REGEX).flatten.first }
-        .body
-        .scan(TRN_REGEX)
-        .flatten
-        .first
+      begin
+        ticket = zendesk_ticket.comments[1..].find { |comment| comment.body.scan(TRN_REGEX).flatten.first }
+        ticket ? ticket.body.scan(TRN_REGEX).flatten.first : nil
+      end
   end
 
   def update_from_zendesk

--- a/spec/services/fetch_trn_from_zendesk_spec.rb
+++ b/spec/services/fetch_trn_from_zendesk_spec.rb
@@ -51,5 +51,24 @@ RSpec.describe FetchTrnFromZendesk, type: :model do
         expect { fetch }.to change(trn_request, :trn).from(nil).to('2921020')
       end
     end
+
+    context 'when there are multiple no matching comments on a ticket' do
+      let(:ticket) do
+        ZendeskAPI::Ticket
+          .new(GDS_ZENDESK_CLIENT, id: 1)
+          .tap do |ticket|
+            ticket.comments = [
+              ZendeskAPI::Ticket::Comment.new(GDS_ZENDESK_CLIENT, id: 1, body: 'Example'),
+              ZendeskAPI::Ticket::Comment.new(GDS_ZENDESK_CLIENT, id: 2, body: 'Thanks'),
+            ]
+          end
+      end
+
+      before { allow(GDS_ZENDESK_CLIENT.ticket).to receive(:find).and_return(ticket) }
+
+      it 'does not update the TrnRequest' do
+        expect { fetch }.not_to change(trn_request, :trn)
+      end
+    end
   end
 end


### PR DESCRIPTION
When a Zendesk ticket has multiple comments and none of them contain a
match for a TRN, the service throws an `NoMethodError`.

It expects there to always be a match when there are more than one
comment on a ticket. This is a faulty assumption.

Instead, we will only attempt to retrieve a TRN from a comment if there
has been a match first.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
