### PR TITLE
Simplify no TRN content

### DIFF
--- a/app/views/pages/you_dont_have_a_trn.html.erb
+++ b/app/views/pages/you_dont_have_a_trn.html.erb
@@ -1,65 +1,23 @@
-<% content_for :page_title, 'You do not have a TRN' %>
+<% content_for :page_title, 'If you do not have a TRN' %>
 <% content_for :back_link_url, check_trn_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class='govuk-heading-xl'>You don’t have a TRN</h1>
+    <h1 class="govuk-heading-xl">If you do not have a TRN</h1>
 
-    <h2 class="govuk-heading-l" id="what-a-teacher-reference-number-trn-is-for">What a teacher reference number (TRN) is for</h2>
-    <p class='govuk-body'>You need a TRN for:</p>
+    <h2 class="govuk-heading-l" id="how-to-get-a-trn">How to get a TRN</h2>
+    <p class="govuk-body">If you’re eligible for a TRN in England, you should be allocated one automatically by the Teaching Regulation Agency or Capita Teachers’ Pensions.</p>
+
+    <p class="govuk-body">If you do not have a TRN but need one to do a national professional qualification (NPQ), you should get instructions about how to request one. If you do not receive these instructions, email <a class="govuk-link" href="mailto:qts.enquiries@education.gov.uk">qts.enquiries@education.gov.uk</a>.</p>
+
+    <h2 class="govuk-heading-l" id="what-a-trn-is-for">What a TRN is for</h2>
+    <p class="govuk-body">You need a TRN to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>view your record with the Teaching Regulation Agency (TRA), and download professional certificates in the <a class='govuk-link' href='https://teacherservices.education.gov.uk/SelfService/Login?_ga=2.206960218.899524735.1637088337-1609244267.1609598427'>Teacher self service portal</a></li>
+      <li>view your record with the Teaching Regulation Agency (TRA), and download professional certificates in the <a class="govuk-link" href='https://teacherservices.education.gov.uk/SelfService/Login?_ga=2.206960218.899524735.1637088337-1609244267.1609598427'>Teacher self service portal</a></li>
       <li>give to employers so they can complete mandatory teacher status checks</li>
       <li>manage records of your contributions to the Teachers’ Pensions scheme</li>
       <li>give to the Department for Education (DfE) when you have been awarded QTS so you can begin your early career teacher induction</li>
-      <li>register for a national professional qualification (NPQ)</li>
+      <li>register for an NPQ</li>
     </ul>
-
-    <h2 class="govuk-heading-l" id="get-a-trn-to-register-for-an-npq">Get a TRN to register for an NPQ</h2>
-    <p class='govuk-body'>You do not need to be a teacher to get a TRN.</p>
-
-    <h3 class="govuk-heading-m" id="request-a-trn-by-email">Request a TRN by email</h3>
-    <p class='govuk-body'>
-      If you’ve never been given a TRN, email the Teaching Regulation Agency at <a class='govuk-link' href='mailto:qts.enquiries@education.gov.uk'>qts.enquiries@education.gov.uk</a>. The team aim to respond to valid email requests within 5 working days.
-    </p>
-    <p class='govuk-body'>You’ll need to provide contact details and proof of ID.</p>
-    <p class='govuk-body'>Use the free Galaxkey secure email platform to ensure your identification documents are protected.</p>
-
-    <h3 class="govuk-heading-m" id="register-to-send-a-secure-email">Register to send a secure email</h3>
-    <p class='govuk-body'>
-      To send a secure email to the department, go to the <a class='govuk-link' href='https://manager.galaxkey.com/services/registerme'>Galaxkey site</a>.
-    </p>
-    <p class='govuk-body'>Enter the email address that you wish to sign up with and complete the registration process.</p>
-    <p class='govuk-body'>
-      You’ll be sent an email to activate your account once you have completed this step. You can then send secure emails to the Teaching Regulation Agency using Galaxkey.
-    </p>
-
-    <h3 class="govuk-heading-m" id="send-your-id-documents-securely">Send your ID documents securely</h3>
-    <p class="govuk-body">Follow these steps to send your documents through Galaxkey:</p>
-    <ol class="govuk-list govuk-list--number"><li><p class="govuk-body">Select ‘Compose’ to create a new secure email.</p></li>
-      <li><p class="govuk-body">Enter ‘<a class="govuk-link" href="mailto:qts.enquiries@education.gov.uk">qts.enquiries@education.gov.uk</a>’ as the recipient.</p></li>
-      <li><p class="govuk-body">Enter ‘Undertaking an NPQ, do not have a TRN and require a number to be issued’ as the subject line.</p></li>
-      <li>
-        <p class="govuk-body">Include the following information in your email:</p>
-        <ul class="govuk-list govuk-list--bullet"><li>your full legal name</li>
-          <li>your date of birth</li>
-          <li>an email address for the team to reply to</li>
-        </ul>
-      </li>
-      <li>
-        <p class="govuk-body">Attach a scanned copy or photo of one of the following types of ID:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>passport</li>
-          <li>driving licence (full or provisional)</li>
-          <li>certificate of residence</li>
-          <li>birth certificate</li>
-        </ul>
-      </li>
-    </ol>
-    <p class="govuk-body">Follow the guidance on screen to make sure you send the correct file size.</p>
-    <p class="govuk-body">Find out more about how the Teaching Regulation Agency processes your data on the <a class="govuk-link" href="https://www.gov.uk/guidance/teacher-self-service-portal">teacher self-service site</a>.</p>
-
-    <h3 class="govuk-heading-m" id="what-happens-next">What happens next</h3>
-    <p class="govuk-body">The Teaching Regulation Agency will use the information you send to create a permanent record and your TRN.</p>
   </div>
 </div>

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -603,8 +603,8 @@ RSpec.describe 'TRN requests', type: :system do
 
   def then_i_see_the_no_trn_page
     expect(page).to have_current_path('/you-dont-have-a-trn')
-    expect(page.driver.browser.current_title).to start_with('You do not have a TRN')
-    expect(page).to have_content('You don’t have a TRN')
+    expect(page.driver.browser.current_title).to start_with('If you do not have a TRN')
+    expect(page).to have_content('If you do not have a TRN')
   end
 
   def then_i_see_the_taking_longer_page


### PR DESCRIPTION
We are removing instructions on how to get a TRN for NPQ users – they will have those instructions in the NPQ registration journey.

Instead we are matching the guidance we show on GOV.UK – users who are eligible for a TRN get given one, they should not need to do anything.

https://trello.com/c/ORhJfG5u/517-simplify-content-on-you-dont-have-a-trn-page

<img width="731" alt="Screenshot 2022-06-22 at 11 56 36" src="https://user-images.githubusercontent.com/319055/175012705-f566abb4-dc36-4eb0-b8c8-1c0cda702949.png">

