### PR TITLE
Fix posting to Slack

### DIFF
--- a/app/services/slack_client.rb
+++ b/app/services/slack_client.rb
@@ -8,7 +8,7 @@ class SlackClient
   end
 
   def create_message(message)
-    response = client.post('/', { text: message })
+    response = client.post('', { text: message })
     return if response.success?
 
     raise Error, "Status code: #{response.status} - #{response.body}"

--- a/spec/services/slack_client_spec.rb
+++ b/spec/services/slack_client_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SlackClient, type: :service do
 
     it 'posts a message to the Slack API' do
       create_message
-      expect(faraday).to have_received(:post).with('/', { text: message })
+      expect(faraday).to have_received(:post).with('', { text: message })
     end
 
     context 'when the API returns an error' do


### PR DESCRIPTION
When sending a message to a Slack webhook, a 302 response is returned.
This happens because of the trailing slash in post command.

There is no reason to pass a slash character in the post command, so we
safely remove it.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
