### PR TITLE
Customise the performance alert URL per host

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
 DQT_API_URL=https://preprod-teacher-qualifications-api.education.gov.uk/
 DQT_API_KEY=testkey
 GOVUK_NOTIFY_API_KEY=test
+HOSTING_DOMAIN=http://test
 HOSTING_ENVIRONMENT_NAME=test
 SLACK_WEBHOOK_URL=test
 SUPPORT_USERNAME=test

--- a/app/jobs/performance_alert_job.rb
+++ b/app/jobs/performance_alert_job.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 class PerformanceAlertJob < ApplicationJob
   include ActionView::Helpers::TextHelper
+  include Rails.application.routes.url_helpers
 
   def perform
     count = TrnRequest.where(created_at: 1.week.ago.beginning_of_day..Time.zone.now).count
-    message =
-      "There have been #{pluralize(count, 'TRN request')} started in the last 7 days on https://find-a-lost-trn.education.gov.uk/performance"
+    url = performance_url(host: ENV.fetch('HOSTING_DOMAIN'))
+    message = "There have been #{pluralize(count, 'TRN request')} started in the last 7 days on #{url}"
     SlackClient.create_message(message)
   end
 end

--- a/spec/jobs/performance_alert_job_spec.rb
+++ b/spec/jobs/performance_alert_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PerformanceAlertJob, type: :job do
       it 'sends the latest performance data as a Slack message' do
         perform
         expect(SlackClient).to have_received(:create_message).with(
-          'There have been 1 TRN request started in the last 7 days on https://find-a-lost-trn.education.gov.uk/performance',
+          'There have been 1 TRN request started in the last 7 days on http://test/performance',
         )
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe PerformanceAlertJob, type: :job do
       it 'sends the latest performance data as a Slack message' do
         perform
         expect(SlackClient).to have_received(:create_message).with(
-          'There have been 0 TRN requests started in the last 7 days on https://find-a-lost-trn.education.gov.uk/performance',
+          'There have been 0 TRN requests started in the last 7 days on http://test/performance',
         )
       end
     end


### PR DESCRIPTION
The URL that is included in the performance alert is hard-coded to
production. This makes it hard to distinguish alerts from other
environments.

We occasionally need to test this alert in other environments, so it is
beneficial to allow us to customise the URL.

I opted to use an environment variable to store the current hosting
domain, that can then be passed to the Rails URL helper to generate the
appropriate value.

This seems simpler and easier to extend across environments than the
alternative of keeping a list of all expected domains in code somewhere.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
