### PR TITLE
Use blue-green deployment strategy for the worker

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -92,7 +92,7 @@ resource "cloudfoundry_app" "worker" {
   disk_quota   = var.flt_disk_quota
   docker_image = var.flt_docker_image
   command      = "bundle exec sidekiq -C ./config/sidekiq.yml"
-  strategy     = "standard"
+  strategy     = "blue-green"
   environment  = local.app_environment_variables
 
   health_check_type = "process"


### PR DESCRIPTION
Apply experienced some issues with the worker not restarting correctly
after a deployment.

The [conversation around this](https://ukgovernmentdfe.slack.com/archives/C02JFQ8M3UY/p1655992190751289?thread_ts=1655990862.616699&cid=C02JFQ8M3UY) surfaced that we need to use the blue-green
deployment strategy for the worker.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
