### PR TITLE
Refactor tra.* translation strings to service.*

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -12,7 +12,7 @@
     </p>
     <p class="govuk-body">
       If you have any questions, please email us at <a class="govuk-link"
-        href="mailto:<%= t('tra.email') %>"><%= t('tra.email') %></a>.
+        href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
     </p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -12,8 +12,8 @@
     <p class="govuk-body">
       If the web address is correct or you selected a link or button and you
       need to speak to someone about this problem, contact the <%=
-      t('tra.service_name') %> team: <a class="govuk-link" href="mailto:<%=
-      t('tra.email') %>"><%= t('tra.email') %></a>.
+      t('service.name') %> team: <a class="govuk-link" href="mailto:<%=
+      t('service.email') %>"><%= t('service.email') %></a>.
     </p>
   </div>
 </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -7,9 +7,9 @@
     <p class="govuk-body">Try again later.</p>
 
     <p class="govuk-body">
-      If you continue to see this error contact the <%= t('tra.service_name')
-      %> team: <a class="govuk-link" href="mailto:<%= t('tra.email') %>"><%=
-      t('tra.email') %></a>.
+      If you continue to see this error contact the <%= t('service.name')
+      %> team: <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%=
+      t('service.email') %></a>.
     </p>
   </div>
 </div>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title><%= [yield(:page_title).presence, t('tra.service_name')].compact.join(' - ') %></title>
+    <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -29,7 +29,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(service_name: t('tra.service_name')) do |header| %>
+    <%= govuk_header(service_name: t('service.name')) do |header| %>
       <% case try(:current_namespace) %>
       <% when 'support_interface' %>
         <% header.navigation_item(

--- a/app/views/layouts/teacher_email.text.erb
+++ b/app/views/layouts/teacher_email.text.erb
@@ -4,5 +4,5 @@
 
 Call the Teaching Regulation Agency, and have your National Insurance number ready:
 
-Telephone: <%= t('tra.tel') %>
+Telephone: <%= t('service.tel') %>
 Monday to Friday, 9am to 5pm (except public holidays)

--- a/app/views/pages/helpdesk_request_submitted.html.erb
+++ b/app/views/pages/helpdesk_request_submitted.html.erb
@@ -20,7 +20,7 @@
     </p>
 
     <ul class="govuk-list">
-      <li>Telephone: <%= t('tra.tel') %></li>
+      <li>Telephone: <%= t('service.tel') %></li>
       <li>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</li>
     </ul>
 

--- a/app/views/pages/longer_than_normal.html.erb
+++ b/app/views/pages/longer_than_normal.html.erb
@@ -16,7 +16,7 @@
       Call the Teaching Regulation Agency, and have your National Insurance number ready:
     </p>
     <ul class="govuk-list">
-      <li>Telephone: <%= t('tra.tel') %></li>
+      <li>Telephone: <%= t('service.tel') %></li>
       <li>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</li>
     </ul>
     <%= govuk_button_link_to 'Continue', name_path %>

--- a/app/views/pages/performance.html.erb
+++ b/app/views/pages/performance.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl">
-        <%= t('tra.service_name') %>
+        <%= t('service.name') %>
       </span>
       Performance dashboard
     </h1>
@@ -51,7 +51,7 @@
 
     <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Visit this service</h2>
     <p class="govuk-heading-m">
-      <%= govuk_link_to t('tra.service_name'), start_path %>
+      <%= govuk_link_to t('service.name'), start_path %>
     </p>
 
     <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Ministerial department:</h3>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('tra.service_name') %>
+      <%= t('service.name') %>
     </h1>
   </div>
 </div>
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Find a lost TRN by phone</h2>
     <p class="govuk-body">Call the Teaching Regulation Agency, and have your National Insurance number ready:</p>
     <ul class="govuk-list">
-      <li>Telephone: <%= t('tra.tel') %></li>
+      <li>Telephone: <%= t('service.tel') %></li>
       <li>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</li>
     </ul>
   </div>

--- a/app/views/static/accessibility.md
+++ b/app/views/static/accessibility.md
@@ -1,10 +1,10 @@
 <% content_for :page_title, 'Accessibility statement' %>
 
-# Accessibility statement for <%= t('tra.service_name') %>
+# Accessibility statement for <%= t('service.name') %>
 
-This page only contains information about the <%= t('tra.service_name') %>
-service, available at: <a href="<%= t('tra.url') %>" class="govuk-link
-govuk-link--no-visited-state"> <%= t('tra.url') %> </a>
+This page only contains information about the <%= t('service.name') %>
+service, available at: <a href="<%= t('service.url') %>" class="govuk-link
+govuk-link--no-visited-state"> <%= t('service.url') %> </a>
 
 ## Using this service
 
@@ -34,8 +34,8 @@ version 2.2 AA standard](https://www.w3.org/TR/WCAG22/).
 ## Feedback and contact information
 
 If you have difficulty using this service, email: <a href="mailto:<%=
-t('tra.email') %>" class="govuk-link govuk-link--no-visited-state"><%=
-t('tra.email') %></a>
+t('service.email') %>" class="govuk-link govuk-link--no-visited-state"><%=
+t('service.email') %></a>
 
 As part of providing this service, we may need to send you messages or
 documents. We'll ask you how you want us to send messages or documents to you,
@@ -47,8 +47,8 @@ audio recording or braille.
 We’re always looking to improve the accessibility of this service.
 
 If you find any problems that are not listed on this page or think we’re not
-meeting accessibility requirements, email: <a href="mailto:<%= t('tra.email')
-%>" class="govuk-link govuk-link--no-visited-state"><%= t('tra.email') %></a>
+meeting accessibility requirements, email: <a href="mailto:<%= t('service.email')
+%>" class="govuk-link govuk-link--no-visited-state"><%= t('service.email') %></a>
 
 ## Enforcement procedure
 

--- a/app/views/static/cookies.md
+++ b/app/views/static/cookies.md
@@ -5,13 +5,13 @@
 Cookies are small files saved on your phone, tablet or computer when you visit
 a website.
 
-We use cookies to make the <%= t('tra.service_name') %> service work and
+We use cookies to make the <%= t('service.name') %> service work and
 collect information about how you use our service.
 
 ## Essential cookies
 
 Essential cookies keep your information secure while you use the <%=
-t('tra.service_name') %> service. We do not need to ask permission to use them.
+t('service.name') %> service. We do not need to ask permission to use them.
 
 <table class="govuk-table">
   <caption class="govuk-visually-hidden">Essential cookies</caption>

--- a/app/views/support_interface/validation_errors/index.html.erb
+++ b/app/views/support_interface/validation_errors/index.html.erb
@@ -4,13 +4,13 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl">
-        <%= t('tra.service_name') %>
+        <%= t('service.name') %>
       </span>
       Validation errors
     </h1>
 
     <div class="app-!-border-top-1 govuk-!-padding-top-2">
-      <%= govuk_table do |table| 
+      <%= govuk_table do |table|
             table.head do |head|
               head.row do |row|
                 row.cell(header: true, text: 'Form')

--- a/app/views/teacher_mailer/delayed_information_received.erb
+++ b/app/views/teacher_mailer/delayed_information_received.erb
@@ -12,7 +12,7 @@ We aim to respond in 5 working days.
 
 Call the Teaching Regulation Agency and give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>.
 
-Telephone: <%= t('tra.tel') %>
+Telephone: <%= t('service.tel') %>
 Monday to Thursday, 9am to 5pm, Friday 9am to 4.30pm (except public holidays)
 
 # If you’ve already called our helpline

--- a/app/views/teacher_mailer/information_received.erb
+++ b/app/views/teacher_mailer/information_received.erb
@@ -10,5 +10,5 @@ We aim to respond in 5 working days.
 
 Call the Teaching Regulation Agency and give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>.
 
-Telephone: <%= t('tra.tel') %>
+Telephone: <%= t('service.tel') %>
 Monday to Thursday, 9am to 5pm, Friday 9am to 4.30pm (except public holidays)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,9 @@
 en:
-  tra:
-    tel: 020 7593 5394
-    service_name: Find a lost teacher reference number (TRN)
-    url: https://find-a-lost-trn.education.gov.uk/
+  service:
     email: qts.enquiries@education.gov.uk
+    name: Find a lost teacher reference number (TRN)
+    tel: 020 7593 5394
+    url: https://find-a-lost-trn.education.gov.uk/
 
   notification_banner:
     info: Information

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -569,7 +569,7 @@ RSpec.describe 'TRN requests', type: :system do
 
   def then_i_see_the_home_page
     expect(page).to have_current_path(start_path)
-    expect(page).to have_content(I18n.t('tra.service_name'))
+    expect(page).to have_content(I18n.t('service.name'))
   end
 
   def then_i_see_the_itt_provider_page


### PR DESCRIPTION
`service.*` is used by the `rails-template` because it's more generic.

When we added the 429 page, it contained `service.email` which was `tra.email` in our service. I figured we should be consistent across projects.