### PR TITLE
Add a daily check for the Zendesk connection

### DIFF
--- a/app/jobs/zendesk_health_job.rb
+++ b/app/jobs/zendesk_health_job.rb
@@ -1,0 +1,16 @@
+class ZendeskHealthJob < ApplicationJob
+  include Rails.application.routes.url_helpers
+
+  def perform
+    return unless FeatureFlag.active?(:zendesk_health_check)
+
+    tickets_created =
+      TrnRequest.with_zendesk_ticket.where(checked_at: 24.hours.ago...).count
+    return if tickets_created.positive?
+
+    url = root_url(host: ENV.fetch("HOSTING_DOMAIN"))
+    SlackClient.create_message(
+      "No Zendesk tickets created in the last 24 hours on #{url}"
+    )
+  end
+end

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -2,6 +2,8 @@
 class TrnRequest < ApplicationRecord
   has_many :trn_responses, dependent: :destroy
 
+  scope :with_zendesk_ticket, -> { where.not(zendesk_ticket_id: nil) }
+
   def answers_checked=(value)
     return unless value
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -12,7 +12,9 @@ class FeatureFlag
     Feature.find_or_initialize_by(name:)
   end
 
-  PERMANENT_SETTINGS = [].freeze
+  PERMANENT_SETTINGS = [
+    [:zendesk_health_check, "Check Zendesk health", "Felix Clack"]
+  ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
     [:dqt_api_always_timeout, "Always time-out the DQT API", "Felix Clack"],

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,7 @@
 performance_alert:
   cron: "0 9 * * MON"
   class: "PerformanceAlertJob"
+
+zendesk_health_alert:
+  cron: "0 10 * * *"
+  class: "ZendeskHealthJob"

--- a/spec/jobs/zendesk_health_job_spec.rb
+++ b/spec/jobs/zendesk_health_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ZendeskHealthJob, type: :job do
+  describe "#perform" do
+    subject(:perform) { described_class.new.perform }
+
+    before { allow(SlackClient).to receive(:create_message) }
+
+    context "when the feature flag is active" do
+      before { FeatureFlag.activate(:zendesk_health_check) }
+
+      after { FeatureFlag.deactivate(:zendesk_health_check) }
+
+      context "when there have been no TRN requests with a Zendesk ticket ID in the last 24 hours" do
+        it "sends an alert about no Zendesk tickets as a Slack message" do
+          perform
+          expect(SlackClient).to have_received(:create_message).with(
+            "No Zendesk tickets created in the last 24 hours on http://test/"
+          )
+        end
+      end
+
+      context "when there is a TRN request with a Zendesk ticket ID in the last 24 hours" do
+        before do
+          create(:trn_request, :has_zendesk_ticket, checked_at: Time.current)
+        end
+
+        it "no-ops" do
+          perform
+          expect(SlackClient).not_to have_received(:create_message)
+        end
+      end
+    end
+
+    context "when the feature flag is inactive" do
+      before { FeatureFlag.deactivate(:zendesk_health_check) }
+
+      it "no-ops" do
+        perform
+        expect(SlackClient).not_to have_received(:create_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
A recent incident highlighted that we don't have a good alerting process
around the connection to the Zendesk API.

We decided to add a daily check to make sure the connection is working.

This solution isn't a definitive solution, but it is a start. We are
relying on the presence of a TRN request with a Zendesk ticket ID as a
proxy for the health of the connection.

The assumption is that if we have been able to create at least one
one ticket in the past 24 hours, then the connection is working.

### Checklist

- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
