### PR TITLE
Display usage duration percentiles on the performance page

### DIFF
--- a/app/assets/stylesheets/main.sass.scss
+++ b/app/assets/stylesheets/main.sass.scss
@@ -51,6 +51,14 @@ $govuk-new-link-styles: true;
   }
 }
 
+.app-performance-table-total-row {
+  td,
+  th {
+    border-top: 2px solid $govuk-border-colour;
+    border-bottom: none;
+  }
+}
+
 .app-p0 {
   padding: 0;
 }

--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -15,6 +15,6 @@ class PerformanceController < ApplicationController
 
     @requests_over_last_n_days, @live_service_data = stats.live_service_usage
     @trns_found, @submission_data = stats.submission_results
-    @duration_usage = stats.duration_usage
+    @duration_averages, @duration_usage = stats.duration_usage
   end
 end

--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -15,5 +15,6 @@ class PerformanceController < ApplicationController
 
     @requests_over_last_n_days, @live_service_data = stats.live_service_usage
     @trns_found, @submission_data = stats.submission_results
+    @duration_usage = stats.duration_usage
   end
 end

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -63,6 +63,12 @@
             row.cell { data_row[3] }
           end
         end
+        body.row(classes: 'app-performance-table-total-row') do |row|
+          row.cell(header: true) { 'Average over last '+ @since_text }
+          row.cell { @duration_averages[0] }
+          row.cell { @duration_averages[1] }
+          row.cell { @duration_averages[2] }
+        end
      end; end %>
 </div>
 

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -43,6 +43,29 @@
   <%= govuk_table(rows: @submission_data, classes: 'app-performance-table') %>
 </div>
 
+<div class="app-!-border-top-1 govuk-!-padding-top-2">
+  <%= govuk_table(classes: 'app-performance-table') do |table|
+      table.caption(size: 'm', text: 'How quickly did users get their TRN ' + @since_text)
+
+      table.head do |head|
+      head.row do |row|
+      row.cell(header: true, text: 'Date')
+      row.cell(header: true) { '90% of users<br>got their TRN within'.html_safe }
+      row.cell(header: true) { '75% of users<br>got their TRN within'.html_safe }
+      row.cell(header: true) { '50% of users<br>got their TRN within'.html_safe }
+
+      end; end; table.body do |body|
+        @duration_usage.each do |data_row|
+          body.row do |row|
+            row.cell { data_row[0] }
+            row.cell { data_row[1] }
+            row.cell { data_row[2] }
+            row.cell { data_row[3] }
+          end
+        end
+     end; end %>
+</div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-heading-m">

--- a/spec/lib/performance_stats_spec.rb
+++ b/spec/lib/performance_stats_spec.rb
@@ -119,13 +119,10 @@ RSpec.describe PerformanceStats do
         )
       end
 
-      data = described_class.new(last_day).duration_usage
+      averages, data = described_class.new(last_day).duration_usage
       expect(data.size).to eq 1
-      expect(data).to eq(
-        [
-          ["12 May", "4 minutes", "3 minutes", "2 minutes"]
-        ]
-      )
+      expect(data).to eq([["12 May", "4 minutes", "3 minutes", "2 minutes"]])
+      expect(averages).to eq(["4 minutes", "3 minutes", "2 minutes"])
     end
   end
 

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe "Performance", type: :system do
     given_there_are_a_few_trns
     when_i_visit_the_performance_page
     then_i_see_the_live_stats
+    and_i_see_the_usage_duration
 
     when_i_visit_the_performance_page_since_launch
     then_i_see_the_live_stats_since_launch
+    and_i_see_the_usage_duration_since_launch
   end
 
   private
@@ -24,7 +26,13 @@ RSpec.describe "Performance", type: :system do
 
   def given_there_are_a_few_trns
     (0..8).each.with_index do |n, i|
-      (i + 1).times { create(:trn_request, created_at: n.days.ago) }
+      (i + 1).times do
+        create(
+          :trn_request,
+          created_at: n.days.ago,
+          checked_at: n.days.ago + 3.minutes
+        )
+      end
     end
   end
 
@@ -38,6 +46,11 @@ RSpec.describe "Performance", type: :system do
     expect(page).to have_content("06 May\t7")
   end
 
+  def and_i_see_the_usage_duration
+    expect(page).to have_content("12 May\t3 minutes\t3 minutes\t3 minutes")
+    expect(page).to have_content("06 May\t3 minutes\t3 minutes\t3 minutes")
+  end
+
   def when_i_visit_the_performance_page_since_launch
     visit performance_path(since_launch: true)
   end
@@ -46,5 +59,10 @@ RSpec.describe "Performance", type: :system do
     expect(page).to have_content("45\nrequests since launch")
     expect(page).to have_content("12 May\t1")
     expect(page).to have_content("04 May\t9")
+  end
+
+  def and_i_see_the_usage_duration_since_launch
+    expect(page).to have_content("12 May\t3 minutes\t3 minutes\t3 minutes")
+    expect(page).to have_content("04 May\t3 minutes\t3 minutes\t3 minutes")
   end
 end


### PR DESCRIPTION
### Context

We want to iterate the performance dashboard [to a new design](https://find-a-lost-trn-prototype.herokuapp.com/performance).

### Changes proposed in this pull request

Add the "How quickly did users get their TRN (last 7 days)" panel from the new design to the performance page.

The implementation is heavily influences by the [equivalent implementation in the Apply for QTS service](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/app/lib/performance_stats.rb#L84).

### Guidance to review

#### Screenshot

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/23801/177153710-6896fd18-89f8-40db-93b8-5a89927a1b4a.png">

#### Impelementation

The Apply for QTS uses the `percentile_cont` PG SQL aggregation function. In this implementation, I went for `percentile_disc` because that seemed more appropriate to what we want to display.

To illustrate this with an example:

* given we have 4 TRN requests, that take 4, 3, 2 and 2 minutes
* when using the `percentile_disc` aggregation function, the 90, 75 and 50 percentiles are "4 minutes", "3 minutes" and "2 minutes" respectively.
* when using the `percentile_cont` aggregation function, the 90, 75 and 50 percentiles are "3 minutes and 42 seconds", "3 minutes and 15 seconds", "2 minutes and 30 seconds" respectively.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
