### PR TITLE
Use form submit for "Continue without NI"

### DIFF
--- a/app/controllers/ni_number_controller.rb
+++ b/app/controllers/ni_number_controller.rb
@@ -8,7 +8,11 @@ class NiNumberController < ApplicationController
 
   def update
     @ni_number = NiNumberForm.new(trn_request:)
-    if @ni_number.update(ni_number_params)
+    if ni_number_not_known?
+      redirect_to(
+        (session[:form_complete] ? check_answers_path : itt_provider_path)
+      )
+    elsif @ni_number.update(ni_number_params)
       begin
         find_trn_using_api unless @trn_request.trn
 
@@ -29,6 +33,10 @@ class NiNumberController < ApplicationController
 
   def ni_number_params
     params.require(:ni_number_form).permit(:ni_number)
+  end
+
+  def ni_number_not_known?
+    params.require(:submit) == "ni_number_not_known"
   end
 
   def find_trn_using_api

--- a/app/views/ni_number/edit.html.erb
+++ b/app/views/ni_number/edit.html.erb
@@ -12,6 +12,8 @@
             required: true
           ) %>
 
+      <%= f.govuk_submit 'Submit', prevent_double_click: false, class: 'govuk-visually-hidden', name: 'submit', value: 'hidden_submit', tabindex: '-1' %>
+
       <%= govuk_details(summary_text: "I don’t know my National Insurance number") do %>
         <p class="govuk-body">
           You can <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/lost-national-insurance-number">find a lost National Insurance number</a>.
@@ -21,10 +23,10 @@
           Or you can continue without it, but we are less likely to find your TRN.
         </p>
 
-        <%= govuk_button_link_to 'Continue without it', session[:form_complete] ? check_answers_path : itt_provider_path, secondary: true %>
+        <%= f.govuk_submit 'Continue without it', prevent_double_click: false, secondary: true, name: 'submit', value: 'ni_number_not_known' %>
       <% end %>
 
-      <%= f.govuk_submit prevent_double_click: false %>
+      <%= f.govuk_submit prevent_double_click: false, name: 'submit', value: 'submit' %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
We previously used a link to handle the case where users don't know their NI number. The downside to this is that a link performs a GET request, and we shouldn't mutate any server-side state via GETs.

The current approach for handling the "Continue without it" works around this limitation in the `EnforceQuestionOrder` concern, but we're changing the way that works to make it easier to reorder steps.

This commit switches the "Continue without it" button to instead use a `govuk_submit` with a specific `name` and `value`. When the value is `ni_number_not_known`, we can fork in the controller and redirect the user to the appropriate path.

Because submitting a form with the keyboard (Alt+Enter) will default to submitting it via the first Submit button encountered, I had to add another hidden submit button earlier in the element order. I labelled it "Submit" instead of "Continue" to make it distinct for Capybara. It's visually hidden by default, and it's also not a part of the tab order.

I added `name/value`s to all 3 of the buttons as such:

- "Submit": `submit => hidden_submit`
- "Continue without it": `submit => ni_number_not_known`
- "Continue": `submit => submit`

https://trello.com/c/lzByFgP4