### PR TITLE
Duration usage dashboard fixes

### DIFF
--- a/app/lib/performance_stats.rb
+++ b/app/lib/performance_stats.rb
@@ -69,6 +69,7 @@ class PerformanceStats
     percentiles_by_day =
       @trn_requests
         .where.not(checked_at: nil)
+        .where.not(trn: nil)
         .group("1")
         .pluck(
           Arel.sql("date_trunc('day', created_at) AS day"),
@@ -87,6 +88,7 @@ class PerformanceStats
     average_percentiles =
       @trn_requests
         .where.not(checked_at: nil)
+        .where.not(trn: nil)
         .pick(
           Arel.sql(
             "percentile_disc(0.90) within group (order by (checked_at - created_at) asc) as percentile_90"

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -64,7 +64,7 @@
           end
         end
         body.row(classes: 'app-performance-table-total-row') do |row|
-          row.cell(header: true) { 'Average over last '+ @since_text }
+          row.cell(header: true) { 'Average '+ @since_text }
           row.cell { @duration_averages[0] }
           row.cell { @duration_averages[1] }
           row.cell { @duration_averages[2] }

--- a/spec/factories/trn_request.rb
+++ b/spec/factories/trn_request.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
 
     trait :has_trn do
       checked_at { Faker::Date.backward(days: 14) }
-      trn { Faker::Number.number(7) }
+      trn { Faker::Number.number(digits: 7) }
     end
 
     trait :has_zendesk_ticket do

--- a/spec/lib/performance_stats_spec.rb
+++ b/spec/lib/performance_stats_spec.rb
@@ -108,16 +108,25 @@ RSpec.describe PerformanceStats do
   end
 
   describe "#duration_usage" do
-    it "calculates duration results" do
+    it "calculates duration results for requests that returned TRNs" do
+      # requests where the user found TRNs
       durations_in_seconds = [240, 180, 120, 120]
       durations_in_seconds.each do |duration|
         create(
           :trn_request,
+          :has_trn,
           created_at: Time.zone.today.beginning_of_day,
-          checked_at: Time.zone.today.beginning_of_day + duration.seconds,
-          trn: "1234567"
+          checked_at: Time.zone.today.beginning_of_day + duration.seconds
         )
       end
+
+      # requests where the TRN wasn't found
+      create(
+        :trn_request,
+        created_at: Time.zone.today.beginning_of_day,
+        checked_at: Time.zone.today.beginning_of_day + 6.minutes,
+        trn: nil
+      )
 
       averages, data = described_class.new(last_day).duration_usage
       expect(data.size).to eq 1

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Performance", type: :system do
   def and_i_see_the_usage_duration
     expect(page).to have_content("12 May\t3 minutes\t3 minutes\t3 minutes")
     expect(page).to have_content("06 May\t3 minutes\t3 minutes\t3 minutes")
+    expect(page).to have_content("Average over the last 7 days\t3 minutes\t3 minutes\t3 minutes")
   end
 
   def when_i_visit_the_performance_page_since_launch
@@ -64,5 +65,6 @@ RSpec.describe "Performance", type: :system do
   def and_i_see_the_usage_duration_since_launch
     expect(page).to have_content("12 May\t3 minutes\t3 minutes\t3 minutes")
     expect(page).to have_content("04 May\t3 minutes\t3 minutes\t3 minutes")
+    expect(page).to have_content("Average since launch\t3 minutes\t3 minutes\t3 minutes")
   end
 end

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Performance", type: :system do
       (i + 1).times do
         create(
           :trn_request,
+          :has_trn,
           created_at: n.days.ago,
           checked_at: n.days.ago + 3.minutes
         )
@@ -49,7 +50,9 @@ RSpec.describe "Performance", type: :system do
   def and_i_see_the_usage_duration
     expect(page).to have_content("12 May\t3 minutes\t3 minutes\t3 minutes")
     expect(page).to have_content("06 May\t3 minutes\t3 minutes\t3 minutes")
-    expect(page).to have_content("Average over the last 7 days\t3 minutes\t3 minutes\t3 minutes")
+    expect(page).to have_content(
+      "Average over the last 7 days\t3 minutes\t3 minutes\t3 minutes"
+    )
   end
 
   def when_i_visit_the_performance_page_since_launch
@@ -65,6 +68,8 @@ RSpec.describe "Performance", type: :system do
   def and_i_see_the_usage_duration_since_launch
     expect(page).to have_content("12 May\t3 minutes\t3 minutes\t3 minutes")
     expect(page).to have_content("04 May\t3 minutes\t3 minutes\t3 minutes")
-    expect(page).to have_content("Average since launch\t3 minutes\t3 minutes\t3 minutes")
+    expect(page).to have_content(
+      "Average since launch\t3 minutes\t3 minutes\t3 minutes"
+    )
   end
 end


### PR DESCRIPTION
### Context

PR #247 added a new panel to `/performance` to track how long TRN requests took. Unfortunately it had a couple of bugs with it, which I found while testing on Dev.

### Changes proposed in this pull request

* Fix the duplicate label for average duration
* Only count successfully found TRN requests when calculating duration

### Checklist

- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
