### PR TITLE
Fix non-month words in DateOfBirthForm

### DIFF
--- a/app/forms/date_of_birth_form.rb
+++ b/app/forms/date_of_birth_form.rb
@@ -42,8 +42,8 @@ class DateOfBirthForm
       return false
     end
 
-    month = Date.parse(date_fields[1]).month if month.zero? &&
-      date_fields[1].length.positive?
+    month_is_a_word = month.zero? && date_fields[1].length.positive?
+    month = word_to_month(date_fields[1]) if month_is_a_word
 
     if month.zero?
       errors.add(:date_of_birth, t("missing_month"))
@@ -118,5 +118,15 @@ class DateOfBirthForm
     }
 
     words[field.downcase.to_sym] || field
+  end
+
+  # Attempts to convert Jan, Feb, etc to month numbers. Returns 0 otherwise.
+  def word_to_month(raw_month)
+    begin
+      month = Date.parse(raw_month).month
+    rescue Date::Error
+      month = 0
+    end
+    month
   end
 end

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -263,5 +263,29 @@ RSpec.describe DateOfBirthForm, type: :model do
         expect { update! }.to change(ValidationError, :count).by(1)
       end
     end
+
+    context "with a word as a month" do
+      let(:params) do
+        {
+          "date_of_birth(1i)" => "1990",
+          "date_of_birth(2i)" => "Potatoes",
+          "date_of_birth(3i)" => "1"
+        }
+      end
+
+      it { is_expected.to be_falsy }
+
+      it "adds an error" do
+        update!
+        expect(date_of_birth_form.errors[:date_of_birth]).to eq(
+          ["Enter a month for your date of birth, formatted as a number"]
+        )
+      end
+
+      it "logs a validation error" do
+        FeatureFlag.activate(:log_validation_errors)
+        expect { update! }.to change(ValidationError, :count).by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Words other than Jan/Feb/Mar would cause the form to break.
