### PR TITLE
Explicitly depend on view_component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "sidekiq"
 gem "sidekiq-cron", "~> 1.6"
 gem "sprockets-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+gem "view_component"
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,6 +488,7 @@ DEPENDENCIES
   timecop
   tzinfo-data
   vcr (~> 6.1)
+  view_component
   web-console
   webmock (~> 3.14)
 


### PR DESCRIPTION
### Context

We have a couple of view components in the codebase that rely on the `view_component` gem. Currently, that gem is pulled into the app indirectly view the `govuk_components` gem.

### Changes proposed in this pull request

Declare an explicit runtime dependency on `view_component` in `Gemfile`. It's highly unlikely that we'll ever be taking out `govuk_components` as a dependency but it's useful for new devs to see the dependency explicitly as an indicator that we use view components.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
