### PR TITLE
Performance page: fix incorrect duration averages calculation

### DIFF
--- a/app/lib/performance_stats.rb
+++ b/app/lib/performance_stats.rb
@@ -87,6 +87,7 @@ class PerformanceStats
 
     average_percentiles =
       @trn_requests
+        .unscope(:group)
         .where.not(checked_at: nil)
         .where.not(trn: nil)
         .pick(


### PR DESCRIPTION
### Context

The row for "Average over the last 7 days" on the [performance page](https://find-a-lost-trn.education.gov.uk/performance) is showing incorrect data. It shows percentiles for one of the days, instead of a true average.

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/23801/178239459-77c9bc61-890e-4106-8c5a-b844c0bb1ba8.png">

### Changes proposed in this pull request

Fix the grouping on the percentiles query.

The 'pick' method assumes the query returns only one row. However
the query was returning a row per day because of the wrong grouping,
so the average was wrong.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
