### PR TITLE
Performance page: fix how abandonments and no-matches are counted

### DIFF
--- a/app/lib/performance_stats.rb
+++ b/app/lib/performance_stats.rb
@@ -42,13 +42,13 @@ class PerformanceStats
         .select(
           Arel.sql("date_trunc('day', created_at) AS day"),
           Arel.sql(
-            "sum(case when checked_at is not null and trn is not null then 1 else 0 end) as cnt_trn_found"
+            "sum(case when trn is not null then 1 else 0 end) as cnt_trn_found"
           ),
           Arel.sql(
-            "sum(case when checked_at is not null and trn is null then 1 else 0 end) as cnt_no_match"
+            "sum(case when zendesk_ticket_id is not null then 1 else 0 end) as cnt_no_match"
           ),
           Arel.sql(
-            "sum(case when checked_at is null then 1 else 0 end) as cnt_did_not_finish"
+            "sum(case when trn is null and zendesk_ticket_id is null then 1 else 0 end) as cnt_did_not_finish"
           ),
           Arel.sql("count(*) as total")
         )


### PR DESCRIPTION
### Context

#263 introduced the big tiles into the performance page, and defined 3 types of user outcomes:

- TRN found
- No match (support ticket raised)
- abandonment (all other requests)

In that PR, users who didn't match **and** didn't go to support were being counted incorrectly.

### Changes proposed in this pull request

Fix (and hopefully simplify the code around) how users are counted on the performance page.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
