### PR TITLE
Performance page: add a monthly rollup of requests

### DIFF
--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class PerformanceController < ApplicationController
-  LAUNCH_DATE = Date.new(2022, 5, 4).beginning_of_day
-
   def index
-    stats = PerformanceStats.new(1.week.ago.beginning_of_day..Time.zone.now)
+    stats = PerformanceStats.new
 
     @total_requests_by_day, @request_counts_by_day = stats.request_counts_by_day
     @duration_averages, @duration_usage = stats.duration_usage

--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -1,19 +1,10 @@
 # frozen_string_literal: true
 
 class PerformanceController < ApplicationController
+  LAUNCH_DATE = Date.new(2022, 5, 4).beginning_of_day
+
   def index
-    time_period = 1.week.ago.beginning_of_day..Time.zone.now
-    @since_text = "over the last 7 days"
-    @short_since_text = "last 7 days"
-
-    if params.key? :since_launch
-      launch_date = Date.new(2022, 5, 4).beginning_of_day
-      time_period = launch_date..Time.zone.now
-      @since_text = "since launch"
-      @short_since_text = "since launch"
-    end
-
-    stats = PerformanceStats.new(time_period)
+    stats = PerformanceStats.new(1.week.ago.beginning_of_day..Time.zone.now)
 
     @total_requests_by_day, @request_counts_by_day = stats.request_counts_by_day
     @duration_averages, @duration_usage = stats.duration_usage

--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -5,6 +5,8 @@ class PerformanceController < ApplicationController
     stats = PerformanceStats.new
 
     @total_requests_by_day, @request_counts_by_day = stats.request_counts_by_day
+    @total_requests_by_month, @request_counts_by_month =
+      stats.request_counts_by_month
     @duration_averages, @duration_usage = stats.duration_usage
   end
 end

--- a/app/lib/performance_stats.rb
+++ b/app/lib/performance_stats.rb
@@ -2,21 +2,15 @@
 class PerformanceStats
   include ActionView::Helpers::NumberHelper
 
-  def initialize(time_period)
-    unless time_period.is_a? Range
-      raise ArgumentError, "time_period is not a Range"
-    end
-
-    number_of_days_in_period =
-      ((Time.zone.now.beginning_of_day - time_period.first) / 1.day).to_i
+  def initialize
+    time_period = (1.week.ago.beginning_of_day..Time.zone.now)
 
     @trn_requests =
       TrnRequest.where(created_at: time_period).group(
         "date_trunc('day', created_at)"
       )
 
-    @last_n_days =
-      (0..number_of_days_in_period).map { |n| n.days.ago.beginning_of_day.utc }
+    @last_n_days = (0..7).map { |n| n.days.ago.beginning_of_day.utc }
 
     calculate_request_counts_by_day
     calculate_duration_usage

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -11,12 +11,12 @@
   </div>
 </div>
 
-<h2 class="govuk-heading-m"><%= @short_since_text.capitalize %></h2>
+<h2 class="govuk-heading-m">Last 7 days</h2>
 
 <div class="govuk-!-margin-bottom-4">
   <%= render TileComponent.new(
                count: @total_requests_by_day[:total],
-               label: "requests #{@since_text}",
+               label: "requests in the last 7 days",
                colour: :blue) %>
 </div>
 
@@ -53,13 +53,13 @@
   </div>
 </div>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-7">TRN requests by day (<%= @short_since_text %>)</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-7">TRN requests by day (last 7 days)</h2>
 
-<%= render TrnRequestsPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_day, total_grouped_requests: @total_requests_by_day, since: @short_since_text) %>
+<%= render TrnRequestsPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_day, total_grouped_requests: @total_requests_by_day, since: "last 7 days") %>
 
 <div class="govuk-!-margin-top-7">
   <%= govuk_table(classes: 'app-performance-table') do |table|
-      table.caption(size: 'm', text: "How quickly did users get their TRN (#{@short_since_text})")
+      table.caption(size: 'm', text: "How quickly did users get their TRN (last 7 days)")
 
       table.head do |head|
       head.row do |row|
@@ -78,7 +78,7 @@
           end
         end
         body.row(classes: 'app-performance-table-total-row') do |row|
-          row.cell(header: true) { 'Average ('+ @short_since_text + ')' }
+          row.cell(header: true) { 'Average (last 7 days)' }
           row.cell { @duration_averages[0] }
           row.cell { @duration_averages[1] }
           row.cell { @duration_averages[2] }

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -57,6 +57,10 @@
 
 <%= render TrnRequestsPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_day, total_grouped_requests: @total_requests_by_day, since: "last 7 days") %>
 
+<h2 class="govuk-heading-m govuk-!-margin-top-7">TRN requests by month (last 12 months)</h2>
+
+<%= render TrnRequestsPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_month, total_grouped_requests: @total_requests_by_month, since: "last 12 months") %>
+
 <div class="govuk-!-margin-top-7">
   <%= govuk_table(classes: 'app-performance-table') do |table|
       table.caption(size: 'm', text: "How quickly did users get their TRN (last 7 days)")

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -3,3 +3,6 @@ Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
 
 Time::DATE_FORMATS[:day_and_month] = "%-d %B"
 Date::DATE_FORMATS[:day_and_month] = "%-d %B"
+
+Time::DATE_FORMATS[:month_and_year] = "%B %Y"
+Date::DATE_FORMATS[:month_and_year] = "%B %Y"

--- a/spec/lib/performance_stats_spec.rb
+++ b/spec/lib/performance_stats_spec.rb
@@ -6,17 +6,6 @@ RSpec.describe PerformanceStats do
 
   after { Timecop.return }
 
-  let(:last_7_days_and_today) { 1.week.ago.beginning_of_day..Time.zone.now }
-
-  describe "without params" do
-    it "asks for a time_period parameter" do
-      expect { described_class.new(nil) }.to raise_error(
-        ArgumentError,
-        "time_period is not a Range"
-      )
-    end
-  end
-
   describe "#request_counts_by_day" do
     it "calculates found, not found and abandoned requests by day" do
       create_list(:trn_request, 2, :has_trn, created_at: 2.hours.ago) # counts against 12 May
@@ -41,8 +30,7 @@ RSpec.describe PerformanceStats do
         created_at: 1.month.ago + 2.hours
       ) # counts against April, should not affect the counts as it falls outside the window
 
-      totals, counts_by_day =
-        described_class.new(last_7_days_and_today).request_counts_by_day
+      totals, counts_by_day = described_class.new.request_counts_by_day
       expect(totals).to eq(
         { total: 9, cnt_did_not_finish: 4, cnt_no_match: 3, cnt_trn_found: 2 }
       )
@@ -133,7 +121,7 @@ RSpec.describe PerformanceStats do
         zendesk_ticket_id: nil
       )
 
-      totals, = described_class.new(last_7_days_and_today).request_counts_by_day
+      totals, = described_class.new.request_counts_by_day
 
       expect(totals).to eq(
         { total: 1, cnt_did_not_finish: 1, cnt_no_match: 0, cnt_trn_found: 0 }
@@ -162,7 +150,7 @@ RSpec.describe PerformanceStats do
         trn: nil
       )
 
-      averages, data = described_class.new(last_7_days_and_today).duration_usage
+      averages, data = described_class.new.duration_usage
       expect(data.first).to eq(
         ["12 May", "4 minutes", "3 minutes", "2 minutes"]
       )

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe "Performance", type: :system do
     when_i_visit_the_performance_page
     then_i_see_the_live_stats
     and_i_see_the_usage_duration
-
-    when_i_visit_the_performance_page_since_launch
-    then_i_see_the_live_stats_since_launch
-    and_i_see_the_usage_duration_since_launch
   end
 
   private
@@ -42,7 +38,7 @@ RSpec.describe "Performance", type: :system do
   end
 
   def then_i_see_the_live_stats
-    expect(page).to have_content("36\nrequests over the last 7 days")
+    expect(page).to have_content("36\nrequests in the last 7 days")
     expect(page).to have_content("12 May\t1")
     expect(page).to have_content("6 May\t7")
   end
@@ -52,24 +48,6 @@ RSpec.describe "Performance", type: :system do
     expect(page).to have_content("6 May\t3 minutes\t3 minutes\t3 minutes")
     expect(page).to have_content(
       "Average (last 7 days)\t3 minutes\t3 minutes\t3 minutes"
-    )
-  end
-
-  def when_i_visit_the_performance_page_since_launch
-    visit performance_path(since_launch: true)
-  end
-
-  def then_i_see_the_live_stats_since_launch
-    expect(page).to have_content("45\nrequests since launch")
-    expect(page).to have_content("12 May\t1")
-    expect(page).to have_content("4 May\t9")
-  end
-
-  def and_i_see_the_usage_duration_since_launch
-    expect(page).to have_content("12 May\t3 minutes\t3 minutes\t3 minutes")
-    expect(page).to have_content("4 May\t3 minutes\t3 minutes\t3 minutes")
-    expect(page).to have_content(
-      "Average (since launch)\t3 minutes\t3 minutes\t3 minutes"
     )
   end
 end


### PR DESCRIPTION
### Context

The team has a need to see historical performance of the service, so they can see the effect of their changes over time. Currently this need is met by going to `/performance?since_launch`, which shows daily stats since launch.

The new [performance page designs](https://find-a-lost-trn-prototype.herokuapp.com/performance) meet the same need with a monthly rollup.

Trello: https://trello.com/c/uuopi3dY/415-iterate-the-performance-dashboard

### Changes proposed in this pull request

* Remove the `since_launch` functionality
* Add the monthly rollup panel, in line with the designs

<img width="746" alt="image" src="https://user-images.githubusercontent.com/23801/178701090-4a7c0ae0-6861-4713-9014-0f4d5d8f7eac.png">

### Guidance to review

Best reviewed commit by commit.

I've made the `PerformanceStats` class more encapsulated/less configurable, because with the removal of the `since_launch` functionality it doesn't need to retain much flexibility.

The current implementation means that if there aren't any requests for a given month, the row won't appear in the rollup table (as opposed to the month appearing with a zero row). This isn't going to be an issue in production (since we'll always have requests in every month) but could potentially mean a sparser table on test environments (although it's not even likely to be an issue there either).

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
