### PR TITLE
Performance page copy tweaks

### DIFF
--- a/app/lib/performance_stats.rb
+++ b/app/lib/performance_stats.rb
@@ -67,7 +67,7 @@ class PerformanceStats
               cnt_no_match: 0,
               cnt_did_not_finish: 0
             }
-        [day.to_fs(:day_and_month), requests]
+        [day.to_fs(:weekday_day_and_month), requests]
       end
 
     @total_requests_by_day =
@@ -173,7 +173,7 @@ class PerformanceStats
     @duration_data =
       @last_n_days.map do |day|
         percentiles = percentiles_by_day[day] || [0, 0, 0]
-        [day.to_fs(:day_and_month)] +
+        [day.to_fs(:weekday_day_and_month)] +
           percentiles.map do |value|
             ActiveSupport::Duration.build(value.to_i).inspect
           end

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -11,12 +11,12 @@
   </div>
 </div>
 
-<h2 class="govuk-heading-m">Last 7 days</h2>
+<h2 class="govuk-heading-m">Today and the previous 7 days</h2>
 
 <div class="govuk-!-margin-bottom-4">
   <%= render TileComponent.new(
                count: @total_requests_by_day[:total],
-               label: "requests in the last 7 days",
+               label: "requests today and the previous 7 days",
                colour: :blue) %>
 </div>
 
@@ -53,17 +53,17 @@
   </div>
 </div>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-7">TRN requests by day (last 7 days)</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-7">TRN requests by day</h2>
 
-<%= render TrnRequestsPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_day, total_grouped_requests: @total_requests_by_day, since: "last 7 days") %>
+<%= render TrnRequestsPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_day, total_grouped_requests: @total_requests_by_day, since: "today and the previous 7 days") %>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-7">TRN requests by month (last 12 months)</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-7">TRN requests by month</h2>
 
-<%= render TrnRequestsPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_month, total_grouped_requests: @total_requests_by_month, since: "last 12 months") %>
+<%= render TrnRequestsPerformanceTableComponent.new(grouped_request_counts: @request_counts_by_month, total_grouped_requests: @total_requests_by_month, since: "this month and the last 12 months") %>
 
 <div class="govuk-!-margin-top-7">
   <%= govuk_table(classes: 'app-performance-table') do |table|
-      table.caption(size: 'm', text: "How quickly did users get their TRN (last 7 days)")
+      table.caption(size: 'm', text: "How quickly did users get their TRN (today and the previous 7 days)")
 
       table.head do |head|
       head.row do |row|
@@ -82,7 +82,7 @@
           end
         end
         body.row(classes: 'app-performance-table-total-row') do |row|
-          row.cell(header: true) { 'Average (last 7 days)' }
+          row.cell(header: true) { 'Average (today and the last 7 days)' }
           row.cell { @duration_averages[0] }
           row.cell { @duration_averages[1] }
           row.cell { @duration_averages[2] }

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
 
-Time::DATE_FORMATS[:day_and_month] = "%-d %B"
-Date::DATE_FORMATS[:day_and_month] = "%-d %B"
+Time::DATE_FORMATS[:weekday_day_and_month] = "%A %-d %B"
+Date::DATE_FORMATS[:weekday_day_and_month] = "%A %-d %B"
 
 Time::DATE_FORMATS[:month_and_year] = "%B %Y"
 Date::DATE_FORMATS[:month_and_year] = "%B %Y"

--- a/spec/lib/performance_stats_spec.rb
+++ b/spec/lib/performance_stats_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PerformanceStats do
       expect(counts_by_day).to eq(
         [
           [
-            "12 May",
+            "Thursday 12 May",
             {
               cnt_trn_found: 2,
               cnt_no_match: 0,
@@ -47,7 +47,7 @@ RSpec.describe PerformanceStats do
             }
           ],
           [
-            "11 May",
+            "Wednesday 11 May",
             {
               cnt_trn_found: 0,
               cnt_no_match: 3,
@@ -56,7 +56,7 @@ RSpec.describe PerformanceStats do
             }
           ],
           [
-            "10 May",
+            "Tuesday 10 May",
             {
               cnt_trn_found: 0,
               cnt_no_match: 0,
@@ -65,7 +65,7 @@ RSpec.describe PerformanceStats do
             }
           ],
           [
-            "9 May",
+            "Monday 9 May",
             {
               cnt_trn_found: 0,
               cnt_no_match: 0,
@@ -74,7 +74,7 @@ RSpec.describe PerformanceStats do
             }
           ],
           [
-            "8 May",
+            "Sunday 8 May",
             {
               cnt_trn_found: 0,
               cnt_no_match: 0,
@@ -83,7 +83,7 @@ RSpec.describe PerformanceStats do
             }
           ],
           [
-            "7 May",
+            "Saturday 7 May",
             {
               cnt_trn_found: 0,
               cnt_no_match: 0,
@@ -92,7 +92,7 @@ RSpec.describe PerformanceStats do
             }
           ],
           [
-            "6 May",
+            "Friday 6 May",
             {
               cnt_trn_found: 0,
               cnt_no_match: 0,
@@ -101,7 +101,7 @@ RSpec.describe PerformanceStats do
             }
           ],
           [
-            "5 May",
+            "Thursday 5 May",
             {
               cnt_trn_found: 0,
               cnt_no_match: 0,
@@ -251,7 +251,7 @@ RSpec.describe PerformanceStats do
 
       averages, data = described_class.new.duration_usage
       expect(data.first).to eq(
-        ["12 May", "4 minutes", "3 minutes", "2 minutes"]
+        ["Thursday 12 May", "4 minutes", "3 minutes", "2 minutes"]
       )
       expect(averages).to eq(["4 minutes", "3 minutes", "2 minutes"])
     end

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Performance", type: :system do
   end
 
   def then_i_see_the_live_stats
-    expect(page).to have_content("36\nrequests in the last 7 days")
+    expect(page).to have_content("36\nrequests today and the previous 7 days")
     expect(page).to have_content("12 May\t1")
     expect(page).to have_content("6 May\t7")
   end
@@ -47,7 +47,7 @@ RSpec.describe "Performance", type: :system do
     expect(page).to have_content("12 May\t3 minutes\t3 minutes\t3 minutes")
     expect(page).to have_content("6 May\t3 minutes\t3 minutes\t3 minutes")
     expect(page).to have_content(
-      "Average (last 7 days)\t3 minutes\t3 minutes\t3 minutes"
+      "Average (today and the last 7 days)\t3 minutes\t3 minutes\t3 minutes"
     )
   end
 end


### PR DESCRIPTION
### Context

To better reflect what's happening with the service right now, the performance page displays:

* the last 7 days' data **as well as** today's data
* the last 12 months' data **as well as** this month's data

This wasn't really clear from the labels.

### Changes proposed in this pull request

Make the headings and labels clearer.
Also display the weekday in the "7 day" views, so it's easier to see when the weekend was.

![screencapture-localhost-3000-performance-2022-07-13-13_20_19](https://user-images.githubusercontent.com/23801/178732563-5b0377cb-c98f-4fee-836a-5ca34fae874d.png)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
