### PR TITLE
Avoid loading Rails for the smoke test

### DIFF
--- a/bin/smoke
+++ b/bin/smoke
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bundle exec rspec spec/system/smoke_spec.rb --tag smoke_test

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
-require "faker"
-require "shoulda-matchers"
-require "rails_helper"
+require "spec_helper"
+require "capybara/rspec"
+require "capybara/cuprite"
 
-RSpec.describe "Smoke test", type: :system, smoke_test: true do
+Capybara.javascript_driver = :cuprite
+
+RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
   it "works as expected" do
     when_i_am_authorized_as_a_support_user
     when_i_visit_the_start_page
@@ -94,10 +96,9 @@ RSpec.describe "Smoke test", type: :system, smoke_test: true do
   end
 
   def when_i_am_authorized_as_a_support_user
-    page.driver.browser.network.authorize(
-      user: ENV["SUPPORT_USERNAME"],
-      password: ENV["SUPPORT_PASSWORD"],
-      &:continue
+    page.driver.basic_authorize(
+      ENV["SUPPORT_USERNAME"],
+      ENV["SUPPORT_PASSWORD"]
     )
   end
 
@@ -147,6 +148,6 @@ RSpec.describe "Smoke test", type: :system, smoke_test: true do
   end
 
   def when_i_visit_the_start_page
-    page.driver.browser.go_to(root_url(host: ENV["HOSTING_DOMAIN"]))
+    page.visit("#{ENV["HOSTING_DOMAIN"]}/start")
   end
 end


### PR DESCRIPTION
There's an issue when the smoke test is called in a hosted environment,
it tries to load Rails but fails.

We don't want to load the application in the smoke test as we are
trying to test the hosted version.

This change switches the smoke test to not load the application.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
