### PR TITLE
Performance page: fix double counting in TRN request classification

### DIFF
--- a/spec/lib/performance_stats_spec.rb
+++ b/spec/lib/performance_stats_spec.rb
@@ -127,6 +127,16 @@ RSpec.describe PerformanceStats do
         { total: 1, cnt_did_not_finish: 1, cnt_no_match: 0, cnt_trn_found: 0 }
       )
     end
+
+    it "counts a user who raised a zendesk ticket at the end and the helpdesk found their TRN as a 'no match'" do
+      create(:trn_request, :has_trn, zendesk_ticket_id: 42)
+
+      totals, = described_class.new.request_counts_by_day
+
+      expect(totals).to eq(
+        { total: 1, cnt_did_not_finish: 0, cnt_no_match: 1, cnt_trn_found: 0 }
+      )
+    end
   end
 
   describe "#request_counts_by_month" do
@@ -224,6 +234,16 @@ RSpec.describe PerformanceStats do
             }
           ]
         ]
+      )
+    end
+
+    it "counts a user who raised a zendesk ticket at the end and the helpdesk found their TRN as a 'no match'" do
+      create(:trn_request, :has_trn, zendesk_ticket_id: 42)
+
+      totals, = described_class.new.request_counts_by_month
+
+      expect(totals).to eq(
+        { total: 1, cnt_did_not_finish: 0, cnt_no_match: 1, cnt_trn_found: 0 }
       )
     end
   end


### PR DESCRIPTION
## What's the issue?

This commit fixes a double-counting bug in the "TRN requests by day" and the "TRN requests by month" sections on the performance page.

![image](https://user-images.githubusercontent.com/23801/179075297-14fa2ec1-1c28-4266-8e18-8ef7c56f5c01.png)

In the example above, for July 2022, the sum of the "TRN found", "No match" and "Did not finish" columns is 3,122 requests, but the total column shows 2,931 requests.

## Root cause

For a TRN request that was initially unsuccessful, a Zendesk ticket ID will be populated. Later, when the helpdesk finds the TRN for this user, the TRN will also be populated on the record via the background Zendesk scanning job.

These requests were being double-counted in both the "TRN found" and "No match" categories.
