### PR TITLE
General Refactor and Documentation Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :development do
   gem "rubocop-govuk", require: false
   gem "solargraph", require: false
   gem "solargraph-rails", require: false
-  gem "syntax_tree", "~> 3.0", require: false
+  gem "syntax_tree", "~> 3.2", require: false
   gem "syntax_tree-haml", "~> 1.2", require: false
   gem "syntax_tree-rbs", "~> 0.5.0", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.7-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.7-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.7-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
@@ -391,7 +393,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     strscan (3.0.3)
-    syntax_tree (3.0.1)
+    syntax_tree (3.2.0)
       prettier_print
     syntax_tree-haml (1.2.0)
       haml (>= 5.2)
@@ -440,6 +442,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -482,7 +485,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sprockets-rails
-  syntax_tree (~> 3.0)
+  syntax_tree (~> 3.2)
   syntax_tree-haml (~> 1.2)
   syntax_tree-rbs (~> 0.5.0)
   timecop

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Run the application on `http://localhost:3000`:
 bin/dev
 ```
 
+### Basic Auth
+
+Due to the `Service open` feature flag which is set to `false` by default across all environments except Production, you will be asked to sign in with basic auth. You can find credentials in the .env._environment_ file stored in the ENV variables `SUPPORT_USERNAME` and `SUPPORT_PASSWORD`. You can toggle the `Service open` feature flag to `true` when developing locally to switch off basic auth.
+
 ### Notify
 
 If you want to test and simulate sending emails locally, you need to be added
@@ -139,6 +143,8 @@ GOVUK_NOTIFY_API_KEY=theo__local_test-abcefgh-1234-abcdefgh
 
 When you send an email locally, the email should appear in the message log in
 the Notify dashboard in the `API integration` section.
+
+_Note:_ You can set `GOVUK_NOTIFY_API_KEY=fake-key` when running locally if you don't need to use Notify.
 
 ### Docker
 
@@ -162,6 +168,14 @@ bin/lint
 
 To run the tests (requires Chrome due to
 [cuprite](https://github.com/rubycdp/cuprite)):
+
+To compile assets up front (needed by the end to end tests):
+
+```bash
+bin/rails assets:precompile
+```
+
+And then:
 
 ```bash
 bin/test

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,10 @@ module FindALostTrn
     config.active_job.queue_adapter = :sidekiq
 
     config.exceptions_app = routes
+
+    config.action_mailer.notify_settings =
+      ENV.fetch("GOVUK_NOTIFY_API_KEY") do
+        raise "'GOVUK_NOTIFY_API_KEY' should be configured in .env.*environment* file. Please refer to https://github.com/DFE-Digital/find-a-lost-trn/#notify"
+      end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,9 +70,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify
-  config.action_mailer.notify_settings = {
-    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY")
-  }
 
   config.active_job.queue_adapter = :sidekiq
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,7 +90,4 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify
-  config.action_mailer.notify_settings = {
-    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY")
-  }
 end

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --target=ie11 --bundle --sourcemap --outdir=app/assets/builds",
-    "build:css": "sass ./app/assets/stylesheets/main.sass.scss ./app/assets/builds/main.css --no-source-map --load-path=node_modules",
+    "build:css": "sass ./app/assets/stylesheets/main.sass.scss ./app/assets/builds/main.css --no-source-map --quiet-deps --load-path=node_modules",
     "lint": "eslint --ext .js,.ts,.tsx ./app/javascript",
     "preinstall": "mkdir -p public/assets/fonts public/assets/images",
     "postinstall": "cp -R node_modules/govuk-frontend/govuk/assets/fonts/. public/assets/fonts && cp -R node_modules/govuk-frontend/govuk/assets/images/. public/assets/images"


### PR DESCRIPTION
### Context

We do not catch missing env vars earlier in the app loading hence we get failures during initialisation without useful error messages with help on how to fix. Also the documentation for testing and running the app is missing a few bits and bobs

### Changes proposed in this pull request

- Update app initialisation to catch missing env vars earlier than later with a clearer failure message and reference to appropriate README sections
- Add precompile script to test section of readme
- Updated build css script to quiet warnings
- Added README section for handling basic auth where feature flag for service open is set to false

### Guidance to review

Verify documentation is accurate and useful
Review error message for missing env var to ensure it is clear

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
