### PR TITLE
Run matrix job sequentially

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency: deploy_${{ matrix.environment }}
     strategy:
+      max-parallel: 1
       matrix:
         environment: [dev, test, preprod]
     environment:


### PR DESCRIPTION
### Context

When running the matrix job on push to main, each job should run after
one another. This makes sures that deployment in the higher environments
happens after smoke test pass.
