### PR TITLE
Throw a better message if Notify key is missing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,14 @@ module FindALostTrn
     config.active_job.queue_adapter = :sidekiq
 
     config.exceptions_app = routes
+
+    config.action_mailer.notify_settings = {
+      api_key:
+        ENV.fetch("GOVUK_NOTIFY_API_KEY") do
+          raise "'GOVUK_NOTIFY_API_KEY' should be configured in " \
+                  ".env.*environment* file. Please refer to " \
+                  "https://github.com/DFE-Digital/find-a-lost-trn/#notify"
+        end
+    }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,9 +70,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify
-  config.action_mailer.notify_settings = {
-    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY")
-  }
 
   config.active_job.queue_adapter = :sidekiq
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,7 +90,4 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify
-  config.action_mailer.notify_settings = {
-    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY")
-  }
 end


### PR DESCRIPTION
Previously was done in https://github.com/DFE-Digital/find-a-lost-trn/pull/287, but that implementation included a bug that wasn't detected in the review: the value for `notify_settings` must be a hash with an `api_key` field.

Tested locally; Notify sends emails successfully with the new initializer code:

![image](https://user-images.githubusercontent.com/1650875/180237647-159dd2ca-a0ca-47a6-a256-a69f881ce080.png)
