### PR TITLE
Updated ITT Provider form to use auto complete

### DIFF
--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -21,7 +21,7 @@ runs:
       if: ${{ inputs.skip-ruby == 'false' }}
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true
+        bundler-cache: false
 
     - name: Set up Node
       if: ${{ inputs.skip-node == 'false' }}

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,9 @@ gem "sprockets-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "view_component"
 
-gem 'dfe-autocomplete', require: 'dfe/autocomplete', github: 'DFE-Digital/dfe-autocomplete'
+gem "dfe-autocomplete",
+    require: "dfe/autocomplete",
+    github: "DFE-Digital/dfe-autocomplete"
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ gem "view_component"
 
 gem "dfe-autocomplete",
     require: "dfe/autocomplete",
-    github: "DFE-Digital/dfe-autocomplete"
+    github: "DFE-Digital/dfe-autocomplete",
+    ref: "be98ad823fac28af718da4c2053c6510852edfdd"
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "sprockets-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "view_component"
 
+gem 'dfe-autocomplete', require: 'dfe/autocomplete', github: 'DFE-Digital/dfe-autocomplete'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/DFE-Digital/dfe-autocomplete.git
+  revision: 4c8a507927e286d58e4db97e4b4c24bcd6841d86
+  specs:
+    dfe-autocomplete (0.1.0)
+      actionview (>= 7.0.2.3)
+      activemodel (>= 7.0.2.3)
+      govuk-components
+      rails (>= 7.0.2.3)
+      view_component
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -455,6 +466,7 @@ DEPENDENCIES
   cssbundling-rails
   cuprite (~> 0.13)
   debug
+  dfe-autocomplete!
   dotenv-rails
   factory_bot_rails
   faker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-autocomplete.git
   revision: be98ad823fac28af718da4c2053c6510852edfdd
+  ref: be98ad823fac28af718da4c2053c6510852edfdd
   specs:
     dfe-autocomplete (0.1.0)
       actionview (>= 7.0.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-autocomplete.git
-  revision: 4c8a507927e286d58e4db97e4b4c24bcd6841d86
+  revision: be98ad823fac28af718da4c2053c6510852edfdd
   specs:
     dfe-autocomplete (0.1.0)
       actionview (>= 7.0.2.3)

--- a/app/assets/stylesheets/main.sass.scss
+++ b/app/assets/stylesheets/main.sass.scss
@@ -4,6 +4,7 @@ $govuk-new-link-styles: true;
 @import "govuk-frontend/govuk/all";
 @import "_card";
 @import "_performance-table";
+@import "dfe-autocomplete/src/dfe-autocomplete";
 
 .app-\!-inherit-colour {
   color: inherit;

--- a/app/controllers/itt_providers_controller.rb
+++ b/app/controllers/itt_providers_controller.rb
@@ -3,6 +3,8 @@ class IttProvidersController < ApplicationController
   include EnforceQuestionOrder
 
   def edit
+    set_itt_provider_options if FeatureFlag.active?(:use_dqt_api_itt_providers)
+
     @itt_provider_form = IttProviderForm.new(trn_request:).assign_form_values
   end
 
@@ -11,6 +13,7 @@ class IttProvidersController < ApplicationController
     if @itt_provider_form.save
       next_question
     else
+      set_itt_provider_options if FeatureFlag.active?(:use_dqt_api_itt_providers)
       render :edit
     end
   end
@@ -22,5 +25,15 @@ class IttProvidersController < ApplicationController
       .require(:itt_provider_form)
       .permit(:itt_provider_enrolled, :itt_provider_name)
       .merge(trn_request:)
+  end
+
+  def set_itt_provider_options
+    @itt_provider_options ||= DqtApi.get_itt_providers.map do |itt_provider|
+      OpenStruct.new(name: itt_provider['providerName'], value: itt_provider['ukprn'])
+    end
+  rescue DqtApi::ApiError,
+         Faraday::ConnectionFailed,
+         Faraday::TimeoutError
+    @itt_provider_options ||= []
   end
 end

--- a/app/controllers/itt_providers_controller.rb
+++ b/app/controllers/itt_providers_controller.rb
@@ -13,7 +13,9 @@ class IttProvidersController < ApplicationController
     if @itt_provider_form.save
       next_question
     else
-      set_itt_provider_options if FeatureFlag.active?(:use_dqt_api_itt_providers)
+      if FeatureFlag.active?(:use_dqt_api_itt_providers)
+        set_itt_provider_options
+      end
       render :edit
     end
   end
@@ -28,12 +30,14 @@ class IttProvidersController < ApplicationController
   end
 
   def set_itt_provider_options
-    @itt_provider_options ||= DqtApi.get_itt_providers.map do |itt_provider|
-      OpenStruct.new(name: itt_provider['providerName'], value: itt_provider['ukprn'])
-    end
-  rescue DqtApi::ApiError,
-         Faraday::ConnectionFailed,
-         Faraday::TimeoutError
+    @itt_provider_options ||=
+      DqtApi.get_itt_providers.map do |itt_provider|
+        OpenStruct.new(
+          name: itt_provider["providerName"],
+          value: itt_provider["ukprn"]
+        )
+      end
+  rescue DqtApi::ApiError, Faraday::ConnectionFailed, Faraday::TimeoutError
     @itt_provider_options ||= []
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  include DfE::Autocomplete::ApplicationHelper
+
   def back_link_url(back = url_for(:back))
     if session[:form_complete] &&
          [check_answers_path, itt_provider_path].exclude?(request.path)

--- a/app/javascript/main.js
+++ b/app/javascript/main.js
@@ -1,3 +1,5 @@
 import { initAll } from "govuk-frontend";
+import dfeAutocomplete from 'dfe-autocomplete'
 
 initAll();
+dfeAutocomplete({});

--- a/app/javascript/main.js
+++ b/app/javascript/main.js
@@ -1,5 +1,5 @@
 import { initAll } from "govuk-frontend";
-import dfeAutocomplete from 'dfe-autocomplete'
+import dfeAutocomplete from "dfe-autocomplete";
 
 initAll();
 dfeAutocomplete({});

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -37,8 +37,7 @@ class DqtApi
   end
 
   def self.get_itt_providers
-    response =
-      new.client.get("/v2/itt-providers", {} )
+    response = new.client.get("/v2/itt-providers", {})
     raise ApiError unless response.status == 200
 
     return [] unless response.body.key?("ittProviders")

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -36,6 +36,15 @@ class DqtApi
     response.body
   end
 
+  def self.get_itt_providers
+    response =
+      new.client.get("/v2/itt-providers", {} )
+    raise ApiError unless response.status == 200
+
+    return [] unless response.body.key?("ittProviders")
+    response.body["ittProviders"]
+  end
+
   def self.trn_request_params(trn_request)
     {
       dateOfBirth: trn_request.date_of_birth,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,7 +21,11 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:use_dqt_api_itt_providers, "Use autocomplete from DQT API results", "Richard da Silva"],
+    [
+      :use_dqt_api_itt_providers,
+      "Use autocomplete from DQT API results",
+      "Richard da Silva"
+    ],
     [:dqt_api_always_timeout, "Always time-out the DQT API", "Felix Clack"],
     [:log_validation_errors, "Log validation errors", "Felix Clack"],
     [

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,6 +21,7 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
+    [:use_dqt_api_itt_providers, "Use autocomplete from DQT API results", "Richard da Silva"],
     [:dqt_api_always_timeout, "Always time-out the DQT API", "Felix Clack"],
     [:log_validation_errors, "Log validation errors", "Felix Clack"],
     [

--- a/app/views/itt_providers/edit.html.erb
+++ b/app/views/itt_providers/edit.html.erb
@@ -7,11 +7,27 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset(:itt_provider_enrolled, legend: { tag: 'h1', size: 'xl', text: 'Did a university, SCITT or school award your QTS?' }) do %>
         <%= f.govuk_radio_button :itt_provider_enrolled, true, label: { text: 'Yes' }, link_errors: true do %>
-          <%= f.govuk_text_field(:itt_provider_name,
+          <% if FeatureFlag.active?(:use_dqt_api_itt_providers) %>
+            <%= render DfE::Autocomplete::View.new(
+              f,
+              attribute_name: :itt_provider_name,
+              form_field: f.govuk_select(
+                :itt_provider_name,
+                options_for_select(
+                  dfe_autocomplete_options(@itt_provider_options, synonyms_fields: %i[suggestion_synonyms match_synonyms]),
+                  f.object.itt_provider_name,
+                ),
+                label: { text: 'Where did you get your QTS?', class: 'govuk-label govuk-label--s' },
+                hint: { text: 'Your university, SCITT, school or other training provider' }, 
+              )
+            ) %>
+          <% else %>
+            <%= f.govuk_text_field(:itt_provider_name,
                 hint: { text: 'Your university, SCITT, school or other training provider' },
                 label: { text: 'Where did you get your QTS?', class: 'govuk-label govuk-label--s' },
-            )
-          %>
+              )
+            %>
+          <% end %>
         <% end %>
         <%= f.govuk_radio_button :itt_provider_enrolled, false, label: { text: 'No, I was awarded QTS another way' } %>
       <% end %>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "esbuild": "^0.14.50",
     "govuk-frontend": "^4.0.1",
-    "sass": "^1.54.0"
+    "sass": "^1.54.0",
+    "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --target=ie11 --bundle --sourcemap --outdir=app/assets/builds",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,6 +87,7 @@ RSpec.configure do |config|
 
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper
+  config.include DfE::Autocomplete::ApplicationHelper
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+accessible-autocomplete@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz#e295256c8d268b97c5ab456a1cb084b553ed3eb0"
+  integrity sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==
+  dependencies:
+    preact "^8.3.1"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -234,6 +241,12 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+"dfe-autocomplete@github:DFE-Digital/dfe-autocomplete":
+  version "0.0.1"
+  resolved "https://codeload.github.com/DFE-Digital/dfe-autocomplete/tar.gz/4c8a507927e286d58e4db97e4b4c24bcd6841d86"
+  dependencies:
+    accessible-autocomplete "^2.0.4"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -1099,6 +1112,11 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+preact@^8.3.1:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
+  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
### Context

The ITT provider field field needs to be changed from a text field to an auto complete.

### Changes proposed in this pull request

This pull request updates the ITT providers text field to use an auto complete using the DfE Autocomplete (https://github.com/DFE-Digital/dfe-autocomplete)

### Guidance to review

The changes are used behind a feature flag called `use_dqt_api_itt_providers`.

This is not a final pull request and is only used to show current progress before making any further design and implementation decisions.
