### PR TITLE
Migrate Find to use new Azure resources

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
 
   backend "azurerm" {
-    container_name = "fmtrn-tfstate"
+    container_name = "faltrn-tfstate"
   }
 
   required_providers {

--- a/terraform/workspace_variables/dev.backend.tfvars
+++ b/terraform/workspace_variables/dev.backend.tfvars
@@ -1,3 +1,3 @@
-storage_account_name = "s165d01tfstate"
+storage_account_name = "s165d01faltrntfstatedv"
 key                  = "dev.tfstate"
-resource_group_name  = "s165d01-rg"
+resource_group_name  = "s165d01-faltrn-dv-rg"

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -1,7 +1,7 @@
 {
   "environment_name": "dev",
-  "key_vault_name": "s165d01-kv",
-  "resource_group_name": "s165d01-rg",
+  "key_vault_name": "s165d01-faltrn-dv-kv",
+  "resource_group_name": "s165d01-faltrn-dv-rg",
   "logging_service_name": "flt-logit-ssl-drain-dev",
   "hosting_environment_name": "development",
   "paas_space": "tra-dev",

--- a/terraform/workspace_variables/preprod.backend.tfvars
+++ b/terraform/workspace_variables/preprod.backend.tfvars
@@ -1,3 +1,3 @@
-storage_account_name = "s165t01preprodtfstate"
+storage_account_name = "s165t01faltrntfstatepp"
 key                  = "preprod.tfstate"
-resource_group_name  = "s165t01-preprod-rg"
+resource_group_name  = "s165t01-faltrn-pp-rg"

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -1,7 +1,7 @@
 {
   "environment_name": "preprod",
-  "key_vault_name": "s165t01-preprod-kv",
-  "resource_group_name": "s165t01-preprod-rg",
+  "key_vault_name": "s165t01-faltrn-pp-kv",
+  "resource_group_name": "s165t01-faltrn-pp-rg",
   "flt_instances": 2,
   "logging_service_name": "flt-logit-ssl-drain-preprod",
   "hosting_environment_name": "preprod",

--- a/terraform/workspace_variables/production.backend.tfvars
+++ b/terraform/workspace_variables/production.backend.tfvars
@@ -1,3 +1,3 @@
-storage_account_name = "s165p01tfstate"
+storage_account_name = "s165p01faltrntfstatepd"
 key                  = "production.tfstate"
-resource_group_name  = "s165p01-rg"
+resource_group_name  = "s165p01-faltrn-pd-rg"

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -1,7 +1,7 @@
 {
   "environment_name": "production",
-  "key_vault_name": "s165p01-kv",
-  "resource_group_name": "s165p01-rg",
+  "key_vault_name": "s165p01-faltrn-pd-kv",
+  "resource_group_name": "s165p01-faltrn-pd-rg",
   "flt_instances": 2,
   "logging_service_name": "flt-logit-ssl-drain-production",
   "hosting_environment_name": "production",

--- a/terraform/workspace_variables/review.backend.tfvars
+++ b/terraform/workspace_variables/review.backend.tfvars
@@ -1,3 +1,3 @@
-storage_account_name = "s165d01tfstate"
+storage_account_name = "s165d01faltrntfstatedv"
 # The key is provided dynamically for each review app via the Makefile
-resource_group_name  = "s165d01-rg"
+resource_group_name  = "s165d01-faltrn-dv-rg"

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -1,7 +1,7 @@
 {
   "environment_name": "review",
-  "key_vault_name": "s165d01-kv",
-  "resource_group_name": "s165d01-rg",
+  "key_vault_name": "s165d01-faltrn-dv-kv",
+  "resource_group_name": "s165d01-faltrn-dv-rg",
   "logging_service_name": "flt-logit-ssl-drain-review",
   "enable_external_logging": false,
   "hosting_environment_name": "review",

--- a/terraform/workspace_variables/test.backend.tfvars
+++ b/terraform/workspace_variables/test.backend.tfvars
@@ -1,3 +1,3 @@
-storage_account_name = "s165t01tfstate"
+storage_account_name = "s165t01faltrntfstatets"
 key                  = "test.tfstate"
-resource_group_name  = "s165t01-rg"
+resource_group_name  = "s165t01-faltrn-ts-rg"

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -1,7 +1,7 @@
 {
   "environment_name": "test",
-  "key_vault_name": "s165t01-kv",
-  "resource_group_name": "s165t01-rg",
+  "key_vault_name": "s165t01-faltrn-ts-kv",
+  "resource_group_name": "s165t01-faltrn-ts-rg",
   "logging_service_name": "flt-logit-ssl-drain-test",
   "hosting_environment_name": "development",
   "paas_space": "tra-test",


### PR DESCRIPTION
### Context

Find a Lost TRN currently use a shared Key Vault and Terraform storage account for CICD pipeline. TRA Digital came up with new standards which uses Key Vault and Storage accounts per service. This PR adds the modification to the pipeline files to migrate to the new standards.

### Trello card

https://trello.com/c/p67nB51g