### PR TITLE
Fix ITT provider autocomplete JS error

### DIFF
--- a/app/javascript/main.js
+++ b/app/javascript/main.js
@@ -7,9 +7,12 @@ dfeAutocomplete({ autoselect: false });
 // In order to allow the autocomplete to work as a free text field, we need to
 // prevent the select element (that has the same name as the input field) from
 // being submitted.
-function disableDfeAutocompleteSelect() {
-  document.querySelector(
+function disableIttProviderSelect() {
+  var $ittProviderSelect = document.querySelector(
     'select[name="itt_provider_form[itt_provider_name]"'
-  ).name = "";
+  );
+  if (!$ittProviderSelect) return;
+
+  $ittProviderSelect.name = "";
 }
-disableDfeAutocompleteSelect();
+disableIttProviderSelect();


### PR DESCRIPTION
On pages where this element doesn't exist, this throws a JS error.
