### PR TITLE
Allow users to prefer not to specify a previous name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,5 @@ RUN bundle exec rails assets:precompile && \
     rm -rf tmp/* log/* node_modules /tmp/*
 
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && \
+    bundle exec rails data:migrate && \
     bundle exec rails server -b 0.0.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "3.1.1"
 
 gem "bootsnap", require: false
 gem "cssbundling-rails"
+gem "data_migrate"
 gem "devise"
 gem "devise_invitable"
 gem "faraday", "~> 1.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,9 @@ GEM
     cuprite (0.13)
       capybara (>= 2.1, < 4)
       ferrum (~> 0.11.0)
+    data_migrate (8.1.0)
+      activerecord (>= 5.0)
+      railties (>= 5.0)
     debug (1.6.1)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
@@ -480,6 +483,7 @@ DEPENDENCIES
   capybara-email
   cssbundling-rails
   cuprite (~> 0.13)
+  data_migrate
   debug
   devise
   devise_invitable

--- a/app/forms/name_form.rb
+++ b/app/forms/name_form.rb
@@ -12,9 +12,9 @@ class NameForm
 
   validates :first_name, presence: true, length: { maximum: 255 }
   validates :last_name, presence: true, length: { maximum: 255 }
-  validates :name_changed, absence: { if: :no_previous_names? }
   validates :previous_first_name, length: { maximum: 255 }
   validates :previous_last_name, length: { maximum: 255 }
+  validate :name_change
 
   delegate :email?, :first_name, :last_name, to: :trn_request, allow_nil: true
 
@@ -23,30 +23,55 @@ class NameForm
   end
 
   def name_changed
-    return @name_changed unless @name_changed.nil?
+    @trn_request_name_changed ||= trn_request&.name_changed
 
-    @name_changed ||=
-      previous_first_name.present? || previous_last_name.present?
+    # Do not select a radio option for name_changed if the first name and last name have not already been
+    # entered and Yes or No has not already been selected. This is to avoid pre-selecting the Prefer option
+    # when the form has yet to be filled in
+    if @name_changed.nil? && @trn_request_name_changed.nil? &&
+         first_name.blank? && last_name.blank?
+      return nil
+    end
+
+    # No option has been selected after the form has been submitted
+    return nil if errors.include?(:name_changed)
+
+    # The form has been submitted, return the selected option
+    return @name_changed if @name_changed.present?
+
+    # When returning the to the form use the value of the trn record
+    @trn_request_name_changed.nil? ? "prefer" : @trn_request_name_changed
   end
 
-  def no_previous_names?
-    previous_first_name.blank? && previous_last_name.blank?
+  def get_name_changed
+    @name_changed != "prefer" ? @name_changed : nil
   end
 
   def previous_first_name
-    return nil if !@name_changed.nil? && !@name_changed
+    return nil if @name_changed != "true" && trn_request&.name_changed.blank?
 
     @previous_first_name ||= trn_request&.previous_first_name
   end
 
   def previous_last_name
-    return nil if !@name_changed.nil? && !@name_changed
+    return nil if @name_changed != "true" && trn_request&.name_changed.blank?
 
     @previous_last_name ||= trn_request&.previous_last_name
   end
 
   def last_name
     @last_name ||= trn_request&.last_name
+  end
+
+  def name_change
+    return if @name_changed.present?
+
+    errors.add(
+      :name_changed,
+      I18n.t(
+        "activemodel.errors.models.name_form.attributes.name_changed.present"
+      )
+    )
   end
 
   def save
@@ -57,6 +82,7 @@ class NameForm
 
     trn_request.first_name = first_name
     trn_request.last_name = last_name
+    trn_request.name_changed = get_name_changed
     trn_request.previous_first_name = previous_first_name
     trn_request.previous_last_name = previous_last_name
     trn_request.save!

--- a/app/views/name/edit.html.erb
+++ b/app/views/name/edit.html.erb
@@ -18,11 +18,16 @@
         required: true
       ) %>
 
-  <%= f.govuk_check_boxes_fieldset :name_changed, legend: nil do %>
-    <%= f.govuk_check_box :name_changed, "true", label: { text: 'I’ve changed my name since I received my TRN' }, link_errors: true, multiple: false do %>
-      <%= f.govuk_text_field(:previous_first_name, label: { text: 'Previous first name' }) %>
-      <%= f.govuk_text_field(:previous_last_name, label: { text: 'Previous last name' }) %>
+  <%= f.govuk_radio_buttons_fieldset :name_changed, legend: { size: 'm', text: 'Have you ever changed your name?' } do %>
+    <%= f.govuk_radio_button :name_changed, false, label: { text: "No, I've not changed my name" }, link_errors: true %>
+    <%= f.govuk_radio_button :name_changed, true, label: { text: "Yes, I've changed my name" } do %>
+      <p class="govuk-body">You don't have to tell us your previous name, but it will help us identify you.</p>
+      <p class="govuk-body">If we cannot match your current name against our records, we'll try to match your previous name.</p>
+      <p class="govuk-body">If you changed your name more than once, please tell us your most recent previous name.</p>
+      <%= f.govuk_text_field(:previous_first_name, label: { size: 's', text: 'Previous first name (optional)' }) %>
+      <%= f.govuk_text_field(:previous_last_name, label: { size: 's', text: 'Previous last name (optional)' }) %>
     <% end %>
+    <%= f.govuk_radio_button :name_changed, "prefer", label: { text: 'Prefer not to say' } %>
   <% end %>
   <%= f.govuk_submit prevent_double_click: false %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
               blank: Enter your previous last name
               too_long: Enter a previous last name that is less than 255 letters long
             name_changed:
-              present: Enter a previous first name or last name
+              present: Tell us if you have changed your name
         ni_number_form:
           attributes:
             ni_number:

--- a/db/data/20220802124734_update_name_changed_field_for_trn_requests.rb
+++ b/db/data/20220802124734_update_name_changed_field_for_trn_requests.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class UpdateNameChangedFieldForTrnRequests < ActiveRecord::Migration[7.0]
+  def up
+    ApplicationRecord.transaction do
+      TrnRequest.find_each do |trn_request|
+        # Set name changed to true if a previous name has already been entered
+        trn_request.update!(name_changed: true) if trn_request.previous_first_name.present? ||
+                                                   trn_request.previous_last_name.present?
+      end
+    end
+  end
+
+  def down
+    # By default user has not specified whether name has been changed
+    TrnRequest.update_all(name_changed: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20_220_802_124_734)

--- a/spec/factories/trn_request.rb
+++ b/spec/factories/trn_request.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     trait :has_previous_name do
       previous_first_name { Faker::Name.first_name }
       previous_last_name { Faker::Name.last_name }
+      name_changed { true }
     end
 
     trait :has_trn do

--- a/spec/system/active_sanctions_spec.rb
+++ b/spec/system/active_sanctions_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe "TRN requests", type: :system do
   def when_i_fill_in_the_name_form
     fill_in "First name", with: "Audrey"
     fill_in "Last name", with: "Coady"
+    choose "No, I've not changed my name", visible: false
     when_i_press_continue
   end
 

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -147,6 +147,43 @@ RSpec.describe "TRN requests", type: :system do
     then_i_see_the_updated_name
   end
 
+  it "changing my previous name" do
+    given_i_have_completed_a_trn_request
+    when_i_press_change_name
+    then_i_see_the_existing_name
+
+    when_i_enter_a_previous_name
+    then_i_see_the_updated_previous_name
+  end
+
+  it "changed my previous name but prefer not to specify" do
+    given_i_have_completed_a_trn_request
+    when_i_press_change_name
+    then_i_see_the_existing_name
+
+    when_i_prefer_not_to_specify_a_previous_name
+    then_i_do_not_see_a_previous_name
+  end
+
+  it "when I do not specify if my name has changed" do
+    given_i_am_on_the_home_page
+    when_i_press_the_start_button
+    then_i_see_the_check_trn_page
+
+    when_i_confirm_i_have_a_trn_number
+    then_i_see_the_ask_questions_page
+
+    when_i_press_continue
+    then_i_see_the_email_page
+
+    when_i_fill_in_my_email_address
+    and_i_press_continue
+    then_i_see_the_name_page
+
+    when_i_fill_in_the_name_form_without_specifying_if_my_name_has_changed
+    then_i_see_a_validation_error
+  end
+
   it "changing my NI number" do
     given_i_have_completed_a_trn_request
     when_i_press_change_ni_number
@@ -602,10 +639,6 @@ RSpec.describe "TRN requests", type: :system do
     expect(page).to have_content("We’ve sent it to")
   end
 
-  def then_i_see_a_missing_previous_name_error
-    expect(page).to have_content("Enter a previous first name or last name")
-  end
-
   def then_i_see_the_ask_questions_page
     expect(page).to have_current_path("/ask-questions")
     expect(page.driver.browser.current_title).to start_with(
@@ -783,6 +816,15 @@ RSpec.describe "TRN requests", type: :system do
     expect(page).to have_content("Kevin Smith")
   end
 
+  def then_i_see_the_updated_previous_name
+    expect(page).to have_content("Previous name")
+    expect(page).to have_content("Kev Jones")
+  end
+
+  def then_i_do_not_see_a_previous_name
+    expect(page).to_not have_content("Previous name")
+  end
+
   def then_i_see_the_updated_ni_number
     expect(page).to have_content("AA 12 34 56 A")
   end
@@ -867,14 +909,30 @@ RSpec.describe "TRN requests", type: :system do
   def when_i_enter_a_new_name
     fill_in "First name", with: "Kevin"
     fill_in "Last name", with: "Smith"
-    check "I’ve changed my name since I received my TRN", visible: false
+    choose "No, I've not changed my name", visible: false
     when_i_press_continue
-    then_i_see_a_missing_previous_name_error
-    fill_in "Previous last name", with: "Evans"
+  end
+
+  def when_i_enter_a_previous_name
+    choose "Yes, I've changed my name", visible: false
+    fill_in "Previous first name (optional)", with: "Kev"
+    fill_in "Previous last name (optional)", with: "Jones"
+    when_i_press_continue
+  end
+
+  def when_i_prefer_not_to_specify_a_previous_name
+    choose "Prefer not to say", visible: false
     when_i_press_continue
   end
 
   def when_i_fill_in_the_name_form
+    fill_in "First name", with: "Kevin"
+    fill_in "Last name", with: "E"
+    choose "No, I've not changed my name", visible: false
+    when_i_press_continue
+  end
+
+  def when_i_fill_in_the_name_form_without_specifying_if_my_name_has_changed
     fill_in "First name", with: "Kevin"
     fill_in "Last name", with: "E"
     when_i_press_continue

--- a/spec/system/zendesk_tickets_spec.rb
+++ b/spec/system/zendesk_tickets_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe "Zendesk ticket syncing", type: :system do
 
     fill_in "First name", with: "Not"
     fill_in "Last name", with: "Valid"
+    choose "No, I've not changed my name", visible: false
     click_on "Continue"
 
     fill_in "Day", with: "01"


### PR DESCRIPTION
### Context

The name form currently requires users to specify their previous name if they have indicated that have had a previous name. It is required for the name form to allow users to indicate that they have had a previous name but not specify it if that is their preference.

### Changes proposed in this pull request

Changes the name form by changing the previous name checkbox to radio buttons and adds a third option to allow users that have had a previous name to specify that they prefer to not add a previous name.

### Guidance to review

This pull request requires a new field called 'name_changed' to be created in the database for trn requests. This is provided in another pull request.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
