### PR TITLE
Add name changed field to trn requests

### DIFF
--- a/db/migrate/20220802124733_add_name_changed_to_trn_requests.rb
+++ b/db/migrate/20220802124733_add_name_changed_to_trn_requests.rb
@@ -1,0 +1,5 @@
+class AddNameChangedToTrnRequests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trn_requests, :name_changed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_29_143332) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_02_124733) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,6 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_29_143332) do
     t.integer "zendesk_ticket_id"
     t.boolean "awarded_qts"
     t.boolean "has_active_sanctions"
+    t.boolean "name_changed"
   end
 
   create_table "trn_responses", force: :cascade do |t|


### PR DESCRIPTION
### Context

Due to changes to the trn requests name form, a new boolean field is required to save the status of a trn request name change status. The status of this field needs to be updated for all previous trn requests.

### Changes proposed in this pull request

This pull request contains a database migration to add the new field. It also contains a data migration to update the status of the new field for all previous trn requests. In order to run the data migration a new 'data-migrate' gem has been installed and added to the Docker configuration.

### Guidance to review

This pull request is required before changes to the trn requests name form can be deployed. The form changes are at https://github.com/DFE-Digital/find-a-lost-trn/pull/320 

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
