### PR TITLE
Use /health/all endpoint for healthchecks

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -64,7 +64,7 @@ resource "cloudfoundry_app" "app" {
   strategy                   = "blue-green"
   environment                = local.app_environment_variables
   health_check_type          = "http"
-  health_check_http_endpoint = "/health"
+  health_check_http_endpoint = "/health/all"
   dynamic "routes" {
     for_each = local.flt_routes
     content {


### PR DESCRIPTION
/health only checks if the application has managed to boot up:

![image](https://user-images.githubusercontent.com/1650875/182121515-859911f6-1aef-4384-b839-2f7e18b2341c.png)

/health/all checks other things, including our custom checks:

![image](https://user-images.githubusercontent.com/1650875/182121570-9388dd0e-f03b-497f-943e-955213cb2410.png)
