### PR TITLE
Add an OKComputer check for Notify

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,4 +1,5 @@
 require_relative "../../lib/ok_computer_checks/zendesk_check"
+require_relative "../../lib/ok_computer_checks/notify_check"
 
 OkComputer.logger = Rails.logger
 OkComputer.mount_at = "health"
@@ -14,5 +15,6 @@ end
 
 OkComputer::Registry.register "version", OkComputer::AppVersionCheck.new
 OkComputer::Registry.register "zendesk", OkComputerChecks::ZendeskCheck.new
+OkComputer::Registry.register "notify", OkComputerChecks::NotifyCheck.new
 
 OkComputer.make_optional %w[version]

--- a/lib/ok_computer_checks/notify_check.rb
+++ b/lib/ok_computer_checks/notify_check.rb
@@ -1,0 +1,21 @@
+module OkComputerChecks
+  class NotifyCheck < OkComputer::Check
+    TEST_EMAIL = "simulate-delivered@notifications.service.gov.uk".freeze
+
+    def check
+      client = Notifications::Client.new(ENV.fetch("GOVUK_NOTIFY_API_KEY"))
+      client.send_email(
+        email_address: TEST_EMAIL,
+        personalisation: {
+          body: "Test",
+          subject: "Test"
+        },
+        template_id: ApplicationMailer::GENERIC_NOTIFY_TEMPLATE
+      )
+      mark_message "Notify is connected"
+    rescue StandardError => e
+      mark_failure
+      mark_message e.message
+    end
+  end
+end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -15,4 +15,12 @@ RSpec.describe "Health check", type: :request do
     get "/health/zendesk"
     expect(response).to have_http_status(:ok)
   end
+
+  it "checks Notify integration health" do
+    allow(Notifications::Client).to receive(:new).and_return(
+      double(:client, send_email: true)
+    )
+    get "/health/notify"
+    expect(response).to have_http_status(:ok)
+  end
 end


### PR DESCRIPTION
We want to check the health of the Notify integration as part of the
overall system health check.

There doesn't appear to be an endpoint specifically for testing the
connection, so I opted to follow the guidance for creating a smoke test.

Notify has special handling for specigic smoke testing email addresses.
This allows us to test the API integration without sending a real email.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
