### PR TITLE
Use devise for support authentication

### DIFF
--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -3,7 +3,6 @@ module SupportInterface
   class SupportInterfaceController < ApplicationController
     layout "support_layout"
 
-    http_basic_authenticate_with name: ENV.fetch("SUPPORT_USERNAME", nil),
-                                 password: ENV.fetch("SUPPORT_PASSWORD", nil)
+    before_action :authenticate_staff!
   end
 end

--- a/app/lib/anonymous_support_user.rb
+++ b/app/lib/anonymous_support_user.rb
@@ -1,0 +1,9 @@
+class AnonymousSupportUser
+  def has_invitations_left?
+    true
+  end
+
+  def devise_scope
+    :staff
+  end
+end

--- a/app/lib/staff_http_basic_auth_strategy.rb
+++ b/app/lib/staff_http_basic_auth_strategy.rb
@@ -1,0 +1,50 @@
+class StaffHttpBasicAuthStrategy < Warden::Strategies::Base
+  def valid?
+    FeatureFlag.active?(:staff_http_basic_auth) || !Staff.exists?
+  end
+
+  def store?
+    false
+  end
+
+  def authenticate!
+    auth = Rack::Auth::Basic::Request.new(env)
+
+    return success!(ANONYMOUS_SUPPORT_USER) if credentials_valid?(auth)
+
+    custom!(
+      [
+        401,
+        {
+          "Content-Type" => "text/plain",
+          "Content-Length" => "0",
+          "WWW-Authenticate" => "Basic realm=\"Application\""
+        },
+        []
+      ]
+    )
+  end
+
+  private
+
+  SUPPORT_USERNAME =
+    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_USERNAME", "test"))
+  SUPPORT_PASSWORD =
+    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_PASSWORD", "test"))
+
+  ANONYMOUS_SUPPORT_USER = AnonymousSupportUser.new
+
+  def credentials_valid?(auth)
+    return false unless auth.provided? && auth.basic? && auth.credentials
+
+    valid_comparison?(SUPPORT_USERNAME, auth.credentials.first) &&
+      valid_comparison?(SUPPORT_PASSWORD, auth.credentials.last)
+  end
+
+  def valid_comparison?(correct_value, given_value)
+    ActiveSupport::SecurityUtils.secure_compare(
+      Digest::SHA256.hexdigest(given_value),
+      correct_value
+    )
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -17,6 +17,13 @@ class FeatureFlag
       :slack_alerts,
       "Enable Slack alerts and notifications for this environment",
       "Felix Clack"
+    ],
+    [
+      :staff_http_basic_auth,
+      "Allow signing in as a staff user using HTTP Basic authentication. " \
+        "This is useful before staff users have been created, but should " \
+        "otherwise be inactive.",
+      "Theodor Vararu"
     ]
   ].freeze
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -321,10 +321,10 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.strategies.add(:staff_http_basic_auth, StaffHttpBasicAuthStrategy)
+    manager.default_strategies(scope: :staff).unshift :staff_http_basic_auth
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/spec/factories/features.rb
+++ b/spec/factories/features.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: features
+#
+#  id         :bigint           not null, primary key
+#  active     :boolean          default(FALSE), not null
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_features_on_name  (name) UNIQUE
+#
+FactoryBot.define do
+  factory :feature do
+    name { "feature" }
+    active { false }
+
+    trait :active do
+      active { true }
+    end
+  end
+end

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -1,0 +1,49 @@
+# == Schema Information
+#
+# Table name: staff
+#
+#  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  failed_attempts        :integer          default(0), not null
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invitations_count      :integer          default(0)
+#  invited_by_type        :string
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
+#  locked_at              :datetime
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  sign_in_count          :integer          default(0), not null
+#  unconfirmed_email      :string
+#  unlock_token           :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  invited_by_id          :bigint
+#
+# Indexes
+#
+#  index_staff_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_staff_on_email                 (email) UNIQUE
+#  index_staff_on_invitation_token      (invitation_token) UNIQUE
+#  index_staff_on_invited_by            (invited_by_type,invited_by_id)
+#  index_staff_on_invited_by_id         (invited_by_id)
+#  index_staff_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_staff_on_unlock_token          (unlock_token) UNIQUE
+#
+FactoryBot.define do
+  factory :staff do
+    email { "test@example.org" }
+    password { "example" }
+  end
+end

--- a/spec/lib/staff_http_basic_auth_strategy_spec.rb
+++ b/spec/lib/staff_http_basic_auth_strategy_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe StaffHttpBasicAuthStrategy do
+  subject(:staff_http_basic_auth_strategy) { described_class.new(env) }
+
+  let(:env) { {} }
+
+  describe "#valid?" do
+    subject(:valid?) { staff_http_basic_auth_strategy.valid? }
+
+    context "with staff users" do
+      before { create(:staff) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when feature is active" do
+      before { create(:feature, :active, name: "staff_http_basic_auth") }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when there are no staff users" do
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe "#store?" do
+    subject(:store?) { staff_http_basic_auth_strategy.store? }
+
+    it { is_expected.to eq(false) }
+  end
+
+  describe "#authenticate!" do
+    before { staff_http_basic_auth_strategy.authenticate! }
+
+    it "should halt the strategy" do
+      expect(staff_http_basic_auth_strategy.halted?).to eq(true)
+    end
+
+    it "should not be successful" do
+      expect(staff_http_basic_auth_strategy.successful?).to eq(false)
+      expect(staff_http_basic_auth_strategy.custom_response).to eq(
+        [
+          401,
+          {
+            "Content-Length" => "0",
+            "Content-Type" => "text/plain",
+            "WWW-Authenticate" => "Basic realm=\"Application\""
+          },
+          []
+        ]
+      )
+    end
+
+    context "with valid credentials" do
+      let(:env) do
+        { "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("test:test")}" }
+      end
+
+      it "should be successful" do
+        expect(staff_http_basic_auth_strategy.successful?).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This removes the previous basic auth implementation from the routes and instead replaces it with a custom Devise strategy.

It's mostly copied over from the one that Apply uses: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/166

### Changes proposed in this pull request

See commits.

### Guidance to review

This does not currently implement the staff invitation interfaces, those are coming in a follow-up PR.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
