### PR TITLE
Add an integration test for Notify

### DIFF
--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ApplicationMailer, type: :mailer do
+  describe ".notify_email" do
+    subject(:notify_email) { described_class.notify_email(headers) }
+
+    let(:headers) { {} }
+
+    before do
+      ActionMailer::Base.add_delivery_method(
+        :notify,
+        Mail::Notify::DeliveryMethod
+      )
+      ActionMailer::Base.delivery_method = :notify
+      ActionMailer::Base.notify_settings = { api_key: }
+    end
+
+    context "when the API key is blank" do
+      let(:api_key) { "" }
+
+      it "raises an error" do
+        expect { notify_email.deliver! }.to raise_error(
+          ArgumentError,
+          "You must specify an API key"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to ensure that the Notify integration fails early if it is
misconfigured.

### Context

Include relevant motivation and context.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
