### PR TITLE
Unlock teacher self service portal account

### DIFF
--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -27,7 +27,11 @@ class DqtApi
 
     raise NoResults if results.size.zero?
 
-    results.first
+    teacher_account = results.first
+
+    DqtApi.unlock_teacher!(teacher_account)
+
+    teacher_account
   end
 
   def self.find_teacher!(date_of_birth:, trn:)

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -44,6 +44,24 @@ class DqtApi
     response.body["ittProviders"]
   end
 
+  def self.unlock_teacher!(teacher_account)
+    if FeatureFlag.active?(:unlock_teachers_self_service_portal_account)
+      begin
+        response =
+          new.client.put(
+            "/v2/unlock-teacher/#{teacher_account.fetch(:uid)}",
+            {}
+          )
+        raise ApiError, response.reason_phrase unless response.success?
+      rescue KeyError,
+             ApiError,
+             Faraday::ConnectionFailed,
+             Faraday::TimeoutError => e
+        Sentry.capture_exception(e)
+      end
+    end
+  end
+
   def self.trn_request_params(trn_request)
     {
       dateOfBirth: trn_request.date_of_birth,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -55,6 +55,11 @@ class FeatureFlag
       :match_on_email,
       "Matching is done at the date of birth step instead of the NI step",
       "Ransom Voke Anighoro"
+    ],
+    [
+      :unlock_teachers_self_service_portal_account,
+      "Unlock a teacher's self service portal account if their TRN is found",
+      "Ransom Voke Anighoro"
     ]
   ].freeze
 

--- a/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_found/1_2_1_1.yml
+++ b/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_found/1_2_1_1.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/f7891223-7661-e411-8047-005056822391
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Authorization:
+      - Bearer <BEARER_TOKEN_REDACTED>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 02 Aug 2022 21:47:09 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Rate-Limit-Limit:
+      - 60s
+      X-Rate-Limit-Remaining:
+      - '299'
+      X-Rate-Limit-Reset:
+      - '2022-08-02T21:48:00.0000000Z'
+      X-Vcap-Request-Id:
+      - ed2a066c-13b5-43a4-6be8-618d844681d9
+      X-Xss-Protection:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 2eb19ccd40bc3ab33c9eed96d984c41e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - LHR61-P2
+      X-Amz-Cf-Id:
+      - JaFQ_jo-S4rrF7mhGgmnTfeK8d7BnBoj3LcRFHCcRThcDehV5ImasQ==
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Tue, 02 Aug 2022 21:47:09 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_found/1_2_1_1.yml
+++ b/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_found/1_2_1_1.yml
@@ -1,59 +1,59 @@
 ---
 http_interactions:
-- request:
-    method: put
-    uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/f7891223-7661-e411-8047-005056822391
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      User-Agent:
-      - Faraday v1.10.0
-      Authorization:
-      - Bearer <BEARER_TOKEN_REDACTED>
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 02 Aug 2022 21:47:09 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Rate-Limit-Limit:
-      - 60s
-      X-Rate-Limit-Remaining:
-      - '299'
-      X-Rate-Limit-Reset:
-      - '2022-08-02T21:48:00.0000000Z'
-      X-Vcap-Request-Id:
-      - ed2a066c-13b5-43a4-6be8-618d844681d9
-      X-Xss-Protection:
-      - '0'
-      X-Cache:
-      - Error from cloudfront
-      Via:
-      - 1.1 2eb19ccd40bc3ab33c9eed96d984c41e.cloudfront.net (CloudFront)
-      X-Amz-Cf-Pop:
-      - LHR61-P2
-      X-Amz-Cf-Id:
-      - JaFQ_jo-S4rrF7mhGgmnTfeK8d7BnBoj3LcRFHCcRThcDehV5ImasQ==
-    body:
-      encoding: UTF-8
-      string: ''
-  recorded_at: Tue, 02 Aug 2022 21:47:09 GMT
+  - request:
+      method: put
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/f7891223-7661-e411-8047-005056822391
+      body:
+        encoding: UTF-8
+        string: "{}"
+      headers:
+        User-Agent:
+          - Faraday v1.10.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 401
+        message: Unauthorized
+      headers:
+        Content-Length:
+          - "0"
+        Connection:
+          - keep-alive
+        Date:
+          - Tue, 02 Aug 2022 21:47:09 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-02T21:48:00.0000000Z"
+        X-Vcap-Request-Id:
+          - ed2a066c-13b5-43a4-6be8-618d844681d9
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Error from cloudfront
+        Via:
+          - 1.1 2eb19ccd40bc3ab33c9eed96d984c41e.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - JaFQ_jo-S4rrF7mhGgmnTfeK8d7BnBoj3LcRFHCcRThcDehV5ImasQ==
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Tue, 02 Aug 2022 21:47:09 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_not_found/1_2_2_1.yml
+++ b/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_not_found/1_2_2_1.yml
@@ -1,62 +1,63 @@
 ---
 http_interactions:
-- request:
-    method: put
-    uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/f6891223-7661-e431-8047-005056822391
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      User-Agent:
-      - Faraday v1.10.0
-      Authorization:
-      - Bearer <BEARER_TOKEN_REDACTED>
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - application/problem+json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 02 Aug 2022 21:46:12 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Rate-Limit-Limit:
-      - 60s
-      X-Rate-Limit-Remaining:
-      - '298'
-      X-Rate-Limit-Reset:
-      - '2022-08-02T21:47:00.0000000Z'
-      X-Vcap-Request-Id:
-      - 16dd3060-d8b6-4f11-714d-229e6d075512
-      X-Xss-Protection:
-      - '0'
-      X-Cache:
-      - Error from cloudfront
-      Via:
-      - 1.1 2d58292dbdc9e6483e90b0792b8c3584.cloudfront.net (CloudFront)
-      X-Amz-Cf-Pop:
-      - LHR61-P2
-      X-Amz-Cf-Id:
-      - HE-f9PSokQRXKDAuqyitaGpMC99ZNGlHEvBQbgH0bnhVi_3FLL9EcA==
-    body:
-      encoding: UTF-8
-      string: '{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.4","title":"Not
-        Found","status":404,"traceId":"00-baa428e169866be42620851d3bd20d59-83da8f6b690baf97-00"}'
-  recorded_at: Tue, 02 Aug 2022 21:46:12 GMT
+  - request:
+      method: put
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/f6891223-7661-e431-8047-005056822391
+      body:
+        encoding: UTF-8
+        string: "{}"
+      headers:
+        User-Agent:
+          - Faraday v1.10.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 404
+        message: Not Found
+      headers:
+        Content-Type:
+          - application/problem+json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Tue, 02 Aug 2022 21:46:12 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "298"
+        X-Rate-Limit-Reset:
+          - "2022-08-02T21:47:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 16dd3060-d8b6-4f11-714d-229e6d075512
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Error from cloudfront
+        Via:
+          - 1.1 2d58292dbdc9e6483e90b0792b8c3584.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - HE-f9PSokQRXKDAuqyitaGpMC99ZNGlHEvBQbgH0bnhVi_3FLL9EcA==
+      body:
+        encoding: UTF-8
+        string:
+          '{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.4","title":"Not
+          Found","status":404,"traceId":"00-baa428e169866be42620851d3bd20d59-83da8f6b690baf97-00"}'
+    recorded_at: Tue, 02 Aug 2022 21:46:12 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_not_found/1_2_2_1.yml
+++ b/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_not_found/1_2_2_1.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/f6891223-7661-e431-8047-005056822391
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Authorization:
+      - Bearer <BEARER_TOKEN_REDACTED>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 02 Aug 2022 21:46:12 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Rate-Limit-Limit:
+      - 60s
+      X-Rate-Limit-Remaining:
+      - '298'
+      X-Rate-Limit-Reset:
+      - '2022-08-02T21:47:00.0000000Z'
+      X-Vcap-Request-Id:
+      - 16dd3060-d8b6-4f11-714d-229e6d075512
+      X-Xss-Protection:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 2d58292dbdc9e6483e90b0792b8c3584.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - LHR61-P2
+      X-Amz-Cf-Id:
+      - HE-f9PSokQRXKDAuqyitaGpMC99ZNGlHEvBQbgH0bnhVi_3FLL9EcA==
+    body:
+      encoding: UTF-8
+      string: '{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.4","title":"Not
+        Found","status":404,"traceId":"00-baa428e169866be42620851d3bd20d59-83da8f6b690baf97-00"}'
+  recorded_at: Tue, 02 Aug 2022 21:46:12 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_not_valid/1_2_3_1.yml
+++ b/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_not_valid/1_2_3_1.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/a-non-matching-uid
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Authorization:
+      - Bearer <BEARER_TOKEN_REDACTED>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 02 Aug 2022 21:46:12 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Rate-Limit-Limit:
+      - 60s
+      X-Rate-Limit-Remaining:
+      - '297'
+      X-Rate-Limit-Reset:
+      - '2022-08-02T21:47:00.0000000Z'
+      X-Vcap-Request-Id:
+      - 8ac74cd5-72cc-4cbe-6800-fd8df671c2c5
+      X-Xss-Protection:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 fc5742d412f28df527dddbda8097bfe2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - LHR61-P2
+      X-Amz-Cf-Id:
+      - 5kIR1_IXuwc-S9TbxP-FQfcZo4N4_nO26wRtsfPJIni6vN3LymexFw==
+    body:
+      encoding: UTF-8
+      string: '{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.1","title":"One
+        or more validation errors occurred.","status":400,"traceId":"00-690d909bdba689d67aa21b6cdc72aa1b-6a1b2419c529497c-00","errors":{"teacherId":["The
+        value ''a-non-matching-uid'' is not valid for TeacherId."]}}'
+  recorded_at: Tue, 02 Aug 2022 21:46:12 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_not_valid/1_2_3_1.yml
+++ b/spec/cassettes/DqtApi/_unlock_teacher_/when_teacher_ID_is_not_valid/1_2_3_1.yml
@@ -1,63 +1,64 @@
 ---
 http_interactions:
-- request:
-    method: put
-    uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/a-non-matching-uid
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      User-Agent:
-      - Faraday v1.10.0
-      Authorization:
-      - Bearer <BEARER_TOKEN_REDACTED>
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Content-Type:
-      - application/problem+json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 02 Aug 2022 21:46:12 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Rate-Limit-Limit:
-      - 60s
-      X-Rate-Limit-Remaining:
-      - '297'
-      X-Rate-Limit-Reset:
-      - '2022-08-02T21:47:00.0000000Z'
-      X-Vcap-Request-Id:
-      - 8ac74cd5-72cc-4cbe-6800-fd8df671c2c5
-      X-Xss-Protection:
-      - '0'
-      X-Cache:
-      - Error from cloudfront
-      Via:
-      - 1.1 fc5742d412f28df527dddbda8097bfe2.cloudfront.net (CloudFront)
-      X-Amz-Cf-Pop:
-      - LHR61-P2
-      X-Amz-Cf-Id:
-      - 5kIR1_IXuwc-S9TbxP-FQfcZo4N4_nO26wRtsfPJIni6vN3LymexFw==
-    body:
-      encoding: UTF-8
-      string: '{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.1","title":"One
-        or more validation errors occurred.","status":400,"traceId":"00-690d909bdba689d67aa21b6cdc72aa1b-6a1b2419c529497c-00","errors":{"teacherId":["The
-        value ''a-non-matching-uid'' is not valid for TeacherId."]}}'
-  recorded_at: Tue, 02 Aug 2022 21:46:12 GMT
+  - request:
+      method: put
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/unlock-teacher/a-non-matching-uid
+      body:
+        encoding: UTF-8
+        string: "{}"
+      headers:
+        User-Agent:
+          - Faraday v1.10.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 400
+        message: Bad Request
+      headers:
+        Content-Type:
+          - application/problem+json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Tue, 02 Aug 2022 21:46:12 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "297"
+        X-Rate-Limit-Reset:
+          - "2022-08-02T21:47:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 8ac74cd5-72cc-4cbe-6800-fd8df671c2c5
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Error from cloudfront
+        Via:
+          - 1.1 fc5742d412f28df527dddbda8097bfe2.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - 5kIR1_IXuwc-S9TbxP-FQfcZo4N4_nO26wRtsfPJIni6vN3LymexFw==
+      body:
+        encoding: UTF-8
+        string:
+          '{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.1","title":"One
+          or more validation errors occurred.","status":400,"traceId":"00-690d909bdba689d67aa21b6cdc72aa1b-6a1b2419c529497c-00","errors":{"teacherId":["The
+          value ''a-non-matching-uid'' is not valid for TeacherId."]}}'
+    recorded_at: Tue, 02 Aug 2022 21:46:12 GMT
 recorded_with: VCR 6.1.0

--- a/spec/services/dqt_api_spec.rb
+++ b/spec/services/dqt_api_spec.rb
@@ -85,4 +85,60 @@ RSpec.describe DqtApi do
       end
     end
   end
+
+  describe ".unlock_teacher!" do
+    before do
+      FeatureFlag.activate(:unlock_teachers_self_service_portal_account)
+    end
+    after do
+      FeatureFlag.deactivate(:unlock_teachers_self_service_portal_account)
+    end
+
+    subject(:unlock_teacher!) do
+      described_class.unlock_teacher!(teacher_account)
+    end
+    let(:uid) { "f7891223-7661-e411-8047-005056822391" }
+    let(:teacher_account_base) do
+      {
+        trn: "2921020",
+        emailAddresses: ["anonymous@anonymousdomain.org.net.co.uk"],
+        firstName: "Kevin",
+        lastName: "Evans",
+        dateOfBirth: "1990-01-01",
+        nationalInsuranceNumber: "AA123456A",
+        uid:
+      }
+    end
+    let(:teacher_account) { teacher_account_base }
+
+    context "when teacher ID is found", vcr: true do
+      it { is_expected.to be_nil }
+    end
+
+    context "when teacher ID is not found", vcr: true do
+      let(:uid) { "f6891223-7661-e431-8047-005056822391" }
+      it { is_expected.to be_nil }
+    end
+
+    context "when teacher ID is not valid", vcr: true do
+      let(:uid) { "a-non-matching-uid" }
+      it { is_expected.to be_nil }
+    end
+
+    context "when uid key is not present" do
+      let(:teacher_account) { teacher_account_base.except(:uid) }
+      it { is_expected.to be_nil }
+    end
+
+    context "when the API returns a timeout error" do
+      it "handles timeout error gracefully" do
+        VCR.turned_off do
+          allow_any_instance_of(Faraday::Connection).to receive(:put).and_raise(
+            Faraday::TimeoutError
+          )
+          expect { unlock_teacher! }.not_to raise_error
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

In the manual support process, a support agent would unlock a user's Teacher Self Service Portal Account when they request their TRN.

We want to do the same for users when they receive a TRN via Find a lost TRN.

[Trello card](https://trello.com/c/YVXdflHt/579-unlock-a-teachers-self-service-portal-account-when-we-find-their-trn)

### Changes proposed in this pull request

- There is a feature flag to turn this feature on or off
- Implement API call to the https://qualified-teachers-api-tech-docs.london.cloudapps.digital/#v2-unlock-teacher-teacherid end point
- Handle error states and degrade gracefully in the `unlock_teacher!` method to prevent breaking `find_trn!` call in the situation it finds a TRN. Log errors to Sentry

### Guidance to review

- Ensure new cassettes are accurate
- Ensure existing tests do not require any changes
- Ensure happy (Successful request) and sad (Api Error, Timeouts e.t.c) paths are covered
- Test on review

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
