### PR TITLE
Fix unlock teacher method

### DIFF
--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -53,14 +53,11 @@ class DqtApi
       begin
         response =
           new.client.put(
-            "/v2/unlock-teacher/#{teacher_account.fetch(:uid)}",
+            "/v2/unlock-teacher/#{teacher_account.fetch("uid")}",
             {}
           )
         raise ApiError, response.reason_phrase unless response.success?
-      rescue KeyError,
-             ApiError,
-             Faraday::ConnectionFailed,
-             Faraday::TimeoutError => e
+      rescue ApiError, Faraday::ConnectionFailed, Faraday::TimeoutError => e
         Sentry.capture_exception(e)
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,7 @@ require "view_component/test_helpers"
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
+    timeout: 10,
     process_timeout: 30,
     window_size: [1200, 800]
   )

--- a/spec/services/dqt_api_spec.rb
+++ b/spec/services/dqt_api_spec.rb
@@ -100,13 +100,13 @@ RSpec.describe DqtApi do
     let(:uid) { "f7891223-7661-e411-8047-005056822391" }
     let(:teacher_account_base) do
       {
-        trn: "2921020",
-        emailAddresses: ["anonymous@anonymousdomain.org.net.co.uk"],
-        firstName: "Kevin",
-        lastName: "Evans",
-        dateOfBirth: "1990-01-01",
-        nationalInsuranceNumber: "AA123456A",
-        uid:
+        "trn" => "2921020",
+        "emailAddresses" => ["anonymous@anonymousdomain.org.net.co.uk"],
+        "firstName" => "Kevin",
+        "lastName" => "Evans",
+        "dateOfBirth" => "1990-01-01",
+        "nationalInsuranceNumber" => "AA123456A",
+        "uid" => uid
       }
     end
     let(:teacher_account) { teacher_account_base }
@@ -122,11 +122,6 @@ RSpec.describe DqtApi do
 
     context "when teacher ID is not valid", vcr: true do
       let(:uid) { "a-non-matching-uid" }
-      it { is_expected.to be_nil }
-    end
-
-    context "when uid key is not present" do
-      let(:teacher_account) { teacher_account_base.except(:uid) }
       it { is_expected.to be_nil }
     end
 

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
   def when_i_fill_in_the_name_form
     fill_in "First name", with: "Kevin"
     fill_in "Last name", with: "E"
+    choose "No, I've not changed my name", visible: false
     when_i_press_continue
   end
 


### PR DESCRIPTION
Our test stubs were using a hash that contains symbols as keys instead of strings. We were also swallowing the KeyError on the assumption that the API wouldn't always return `uid`s, but that assumption isn't correct.

This updates the test stubs and removes the old test.

Paired with @ransom4real.