### PR TITLE
Fix smoke test random port issue

### DIFF
--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -4,6 +4,7 @@ require "capybara/rspec"
 require "capybara/cuprite"
 
 Capybara.javascript_driver = :cuprite
+Capybara.always_include_port = false
 
 RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
   it "works as expected" do


### PR DESCRIPTION
The smoke tests can time out as capybara seems to randomly add a port at the end of the url.

See https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/311/commits/fc63cc921b8fedc6e24bde742067a014dbbf239a
