### PR TITLE
Do not run docker job for production deploys using a non-main branch

### DIFF
--- a/.github/workflows/actions/build-docker/action.yml
+++ b/.github/workflows/actions/build-docker/action.yml
@@ -25,13 +25,13 @@ runs:
       run: |
         echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
       env:
-        CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+        CONTAINER_REGISTRY: ghcr.io
       shell: bash
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
-        registry: ${{ env.CONTAINER_REGISTRY }}
+        registry: ghcr.io
         username: ${{ inputs.github_username }}
         password: ${{ inputs.github_token }}
 

--- a/.github/workflows/actions/build-docker/action.yml
+++ b/.github/workflows/actions/build-docker/action.yml
@@ -1,0 +1,44 @@
+name: Docker build and push
+
+inputs:
+  github_username:
+    description: GitHub Container Registry username
+    required: true
+  github_token:
+    description: GitHub Container Registry token
+    required: true
+
+outputs:
+  docker_image_tag:
+    description: Docker Container tag
+    value: ${{ steps.image.outputs.tag }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Docker image tag
+      id: image
+      run: |
+        echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
+      env:
+        CONTAINER_REGISTRY: ghcr.io
+      shell: bash
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.github_username }}
+        password: ${{ inputs.github_token }}
+
+    - name: Docker build & push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.image.outputs.tag }}
+

--- a/.github/workflows/actions/build-docker/action.yml
+++ b/.github/workflows/actions/build-docker/action.yml
@@ -25,13 +25,13 @@ runs:
       run: |
         echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
       env:
-        CONTAINER_REGISTRY: ghcr.io
+        CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
       shell: bash
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
-        registry: ghcr.io
+        registry: ${{ env.CONTAINER_REGISTRY }}
         username: ${{ inputs.github_username }}
         password: ${{ inputs.github_token }}
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,137 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+    types:
+      - labeled
+      - synchronize
+      - reopened
+      - opened
+      - converted_to_draft
+
+env:
+  CONTAINER_REGISTRY: ghcr.io
+
+jobs:
+  docker:
+    name: Docker build and push
+    if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      docker_image: ${{ steps.dockerimage.outputs.docker_image_tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/workflows/actions/build-docker
+        id: dockerimage
+        with:
+          github_username: ${{ github.actor }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy_review:
+    name: Deploy to review environment
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: [docker]
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'deploy')
+    environment:
+      name: review
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/workflows/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: review
+          docker_image: ${{ needs.docker.docker_image }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          terraform_vars: workspace_variables/review.tfvars.json
+          pr_id: ${{ github.event.pull_request.number }}
+
+      - name: Post sticky pull request comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            Review app deployed to ${{ steps.deploy.outputs.environment_url }}
+
+      - uses: ./.github/workflows/actions/smoke-test
+        id: smoke-test
+        with:
+          environment: review
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+  deploy_nonprod:
+    name: Deploy to ${{ matrix.environment }} environment
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_${{ matrix.environment }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        environment: [dev, test, preprod]
+    environment:
+      name: ${{ matrix.environment }}
+      url: ${{ steps.deploy.outputs.environment_url }}
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker image tag
+        id: image
+        run: |
+          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
+        env:
+          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+        shell: bash
+
+      - uses: ./.github/workflows/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: ${{ matrix.environment }}
+          docker_image: ${{ steps.image.outputs.tag }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          terraform_vars: workspace_variables/${{ matrix.environment }}.tfvars.json
+      - uses: ./.github/workflows/actions/smoke-test
+        id: smoke-test
+        with:
+          environment: ${{ matrix.environment }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+  deploy_production:
+    name: Deploy to production environment
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.environment_url }}
+    concurrency: deploy_production
+
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker image tag
+        id: image
+        run: |
+          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
+        env:
+          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+        shell: bash
+
+      - uses: ./.github/workflows/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: production
+          docker_image: ${{ steps.image.outputs.tag }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          terraform_vars: workspace_variables/production.tfvars.json

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,7 +48,7 @@ jobs:
         id: deploy
         with:
           environment_name: review
-          docker_image: ${{ needs.docker.outputs.docker_image }}
+          docker_image: ${{ needs.docker.docker_image }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           terraform_vars: workspace_variables/review.tfvars.json
           pr_id: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,7 +48,7 @@ jobs:
         id: deploy
         with:
           environment_name: review
-          docker_image: ${{ needs.docker.docker_image }}
+          docker_image: ${{ needs.docker.outputs.docker_image }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           terraform_vars: workspace_variables/review.tfvars.json
           pr_id: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,144 +13,17 @@ on:
           - test
           - preprod
           - production
-  push:
-    branches:
-      - main
+      sha:
+        description: Commit sha to be deployed
+        required: true
 
-  pull_request:
-    branches:
-      - main
-    types:
-      - labeled
-      - synchronize
-      - reopened
-      - opened
-      - converted_to_draft
 env:
   CONTAINER_REGISTRY: ghcr.io
 
 jobs:
-  docker:
-    name: Docker build and push
-    if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    outputs:
-      docker_image: ${{ steps.image.outputs.docker_image_tag }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/workflows/actions/build-docker
-        id: image
-        with:
-          github_username: ${{ github.actor }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  docker_main_only:
-    name: Docker build and push for main branch only
-    if: (contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request') && github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    outputs:
-      docker_image: ${{ steps.image.outputs.docker_image_tag }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/workflows/actions/build-docker
-        id: image
-        with:
-          github_username: ${{ github.actor }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy_review:
-    name: Deploy to review environment
-    concurrency: deploy_review_${{ github.event.pull_request.number }}
-    needs: [docker]
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'deploy')
-    environment:
-      name: review
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/workflows/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: review
-          docker_image: ${{ needs.docker.outputs.docker_image }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/review.tfvars.json
-          pr_id: ${{ github.event.pull_request.number }}
-
-      - name: Post sticky pull request comment
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: |
-            Review app deployed to ${{ steps.deploy.outputs.environment_url }}
-
-      - uses: ./.github/workflows/actions/smoke-test
-        id: smoke-test
-        with:
-          environment: review
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
-  deploy_nonprod:
-    name: Deploy to ${{ matrix.environment }} environment
-    runs-on: ubuntu-latest
-    needs: [docker_main_only]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    concurrency: deploy_${{ matrix.environment }}
-    strategy:
-      max-parallel: 1
-      matrix:
-        environment: [dev, test, preprod]
-    environment:
-      name: ${{ matrix.environment }}
-      url: ${{ steps.deploy.outputs.environment_url }}
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/workflows/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: ${{ matrix.environment }}
-          docker_image: ${{ needs.docker_main_only.outputs.docker_image_tag }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/${{ matrix.environment }}.tfvars.json
-      - uses: ./.github/workflows/actions/smoke-test
-        id: smoke-test
-        with:
-          environment: ${{ matrix.environment }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
-  deploy_production:
-    name: Deploy to production environment
-    needs: [docker_main_only, deploy_nonprod]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    environment:
-      name: production
-      url: ${{ steps.deploy.outputs.environment_url }}
-    concurrency: deploy_production
-
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/workflows/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: production
-          docker_image: ${{ needs.docker_main_only.outputs.docker_image_tag }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/production.tfvars.json
-
   deploy_environment:
     name: Deploy to ${{ github.event.inputs.environment }} environment
     runs-on: ubuntu-latest
-    needs: [docker_main_only]
     if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
     environment:
       name: ${{ github.event.inputs.environment }}
@@ -163,10 +36,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Docker image tag
+        id: image
+        run: |
+          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$INPUT_GITHUB_SHA
+        env:
+          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+          INPUT_GITHUB_SHA: ${{ inputs.sha }}
+        shell: bash
+
       - uses: ./.github/workflows/actions/deploy-environment
         id: deploy
         with:
           environment_name: ${{ github.event.inputs.environment }}
-          docker_image: ${{ needs.docker_main_only.outputs.docker_image_tag }}
+          docker_image: ${{ steps.image.outputs.tag }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           terraform_vars: workspace_variables/${{ github.event.inputs.environment }}.tfvars.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,29 +35,28 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     outputs:
-      docker_image: ${{ steps.image.outputs.tag }}
+      docker_image: ${{ steps.image.outputs.docker_image_tag }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Docker image tag
+      - uses: actions/checkout@v3
+      - uses: ./.github/workflows/actions/build-docker
         id: image
-        run: |
-          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
         with:
-          registry: ${{ env.CONTAINER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          github_username: ${{ github.actor }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker build & push
-        uses: docker/build-push-action@v3
+  docker_main_only:
+    name: Docker build and push for main branch only
+    if: (contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request') && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      docker_image: ${{ steps.image.outputs.docker_image_tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/workflows/actions/build-docker
+        id: image
         with:
-          context: .
-          push: true
-          tags: ${{ steps.image.outputs.tag }}
+          github_username: ${{ github.actor }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_review:
     name: Deploy to review environment
@@ -95,7 +94,7 @@ jobs:
   deploy_nonprod:
     name: Deploy to ${{ matrix.environment }} environment
     runs-on: ubuntu-latest
-    needs: [docker]
+    needs: [docker_main_only]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency: deploy_${{ matrix.environment }}
     strategy:
@@ -115,7 +114,7 @@ jobs:
         id: deploy
         with:
           environment_name: ${{ matrix.environment }}
-          docker_image: ${{ needs.docker.outputs.docker_image }}
+          docker_image: ${{ needs.docker_main_only.outputs.docker_image_tag }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           terraform_vars: workspace_variables/${{ matrix.environment }}.tfvars.json
       - uses: ./.github/workflows/actions/smoke-test
@@ -126,7 +125,7 @@ jobs:
 
   deploy_production:
     name: Deploy to production environment
-    needs: [docker, deploy_nonprod]
+    needs: [docker_main_only, deploy_nonprod]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
@@ -144,14 +143,14 @@ jobs:
         id: deploy
         with:
           environment_name: production
-          docker_image: ${{ needs.docker.outputs.docker_image }}
+          docker_image: ${{ needs.docker_main_only.outputs.docker_image_tag }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           terraform_vars: workspace_variables/production.tfvars.json
 
   deploy_environment:
     name: Deploy to ${{ github.event.inputs.environment }} environment
     runs-on: ubuntu-latest
-    needs: [docker]
+    needs: [docker_main_only]
     if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
     environment:
       name: ${{ github.event.inputs.environment }}
@@ -168,6 +167,6 @@ jobs:
         id: deploy
         with:
           environment_name: ${{ github.event.inputs.environment }}
-          docker_image: ${{ needs.docker.outputs.docker_image }}
+          docker_image: ${{ needs.docker_main_only.outputs.docker_image_tag }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           terraform_vars: workspace_variables/${{ github.event.inputs.environment }}.tfvars.json


### PR DESCRIPTION
### Context

The GitHub production deployment jobs need the docker job to be completed prior to starting the deployment. The ‘needs’ option does not check if job conditionals have been met before running it jobs.

### Changes proposed in this pull request

 This PR adds a new docker job, to be used during production deploys, that can only be run if using the main branch.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
