### PR TITLE
Match against DQT after NINO question, even when email match is enabled.

### DIFF
--- a/app/controllers/ni_number_controller.rb
+++ b/app/controllers/ni_number_controller.rb
@@ -14,16 +14,14 @@ class NiNumberController < ApplicationController
       session[:ni_number_not_known] = true
       next_question
     elsif @ni_number.update(ni_number_params)
-      unless FeatureFlag.active?(:match_on_email)
-        begin
-          find_trn_using_api unless @trn_request.trn
-        rescue DqtApi::ApiError,
-               Faraday::ConnectionFailed,
-               Faraday::TimeoutError,
-               DqtApi::TooManyResults,
-               DqtApi::NoResults
-          # Do nothing.
-        end
+      begin
+        find_trn_using_api unless @trn_request.trn
+      rescue DqtApi::ApiError,
+             Faraday::ConnectionFailed,
+             Faraday::TimeoutError,
+             DqtApi::TooManyResults,
+             DqtApi::NoResults
+        # Do nothing.
       end
       next_question
     else


### PR DESCRIPTION
### Context

This is a suspected bug, relating to matching on email ([Trello](https://trello.com/c/h59LbSMJ/560-match-on-email)).

When email matching is enabled, the current behaviour skips a lookup to DQT API after the NINO question.

This forces a user to have to unnecessarily answer the ITT question, even in the case when they'd get a match with name, DOB and NINO.

### Changes proposed in this pull request

Change the logic to always match against DQT API after the NINO question, irrespective of whether email matching is enabled or not.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
