### PR TITLE
Support unencrypted data

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,5 +51,7 @@ module FindALostTrn
                   "https://github.com/DFE-Digital/find-a-lost-trn/#notify"
         end
     }
+
+    config.active_record.encryption.support_unencrypted_data = true
   end
 end


### PR DESCRIPTION
The addition of encrypted DB fields is causing an issue on production
with older data that is still unencrypted.

Rails has a configuration value to allow support of unencrypted data.

We can enable this while we encrypt the older data.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
