### PR TITLE
Move docker build manual workflow

### DIFF
--- a/.github/workflows/actions/build-docker/action.yml
+++ b/.github/workflows/actions/build-docker/action.yml
@@ -1,0 +1,43 @@
+name: Docker build and push
+
+inputs:
+  github_username:
+    description: GitHub Container Registry username
+    required: true
+  github_token:
+    description: GitHub Container Registry token
+    required: true
+
+outputs:
+  docker_image_tag:
+    description: Docker Container tag
+    value: ${{ steps.image.outputs.tag }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Docker image tag
+      id: image
+      run: |
+        echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
+      env:
+        CONTAINER_REGISTRY: ghcr.io
+      shell: bash
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.github_username }}
+        password: ${{ inputs.github_token }}
+
+    - name: Docker build & push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.image.outputs.tag }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,136 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+    types:
+      - labeled
+      - synchronize
+      - reopened
+      - opened
+      - converted_to_draft
+
+env:
+  CONTAINER_REGISTRY: ghcr.io
+
+jobs:
+  docker:
+    name: Docker build and push
+    if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      docker_image: ${{ steps.dockerimage.outputs.docker_image_tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/workflows/actions/build-docker
+        id: dockerimage
+        with:
+          github_username: ${{ github.actor }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy_review:
+    name: Deploy to review environment
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: [docker]
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'deploy')
+    environment:
+      name: review
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/workflows/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: review
+          docker_image: ${{ needs.docker.outputs.docker_image }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          terraform_vars: workspace_variables/review.tfvars.json
+          pr_id: ${{ github.event.pull_request.number }}
+
+      - name: Post sticky pull request comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            Review app deployed to ${{ steps.deploy.outputs.environment_url }}
+      - uses: ./.github/workflows/actions/smoke-test
+        id: smoke-test
+        with:
+          environment: review
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+  deploy_nonprod:
+    name: Deploy to ${{ matrix.environment }} environment
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_${{ matrix.environment }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        environment: [dev, test, preprod]
+    environment:
+      name: ${{ matrix.environment }}
+      url: ${{ steps.deploy.outputs.environment_url }}
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker image tag
+        id: image
+        run: |
+          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
+        env:
+          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+        shell: bash
+
+      - uses: ./.github/workflows/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: ${{ matrix.environment }}
+          docker_image: ${{ steps.image.outputs.tag }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          terraform_vars: workspace_variables/${{ matrix.environment }}.tfvars.json
+      - uses: ./.github/workflows/actions/smoke-test
+        id: smoke-test
+        with:
+          environment: ${{ matrix.environment }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+  deploy_production:
+    name: Deploy to production environment
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.environment_url }}
+    concurrency: deploy_production
+
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker image tag
+        id: image
+        run: |
+          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
+        env:
+          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+        shell: bash
+
+      - uses: ./.github/workflows/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: production
+          docker_image: ${{ steps.image.outputs.tag }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          terraform_vars: workspace_variables/production.tfvars.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,4 @@
 name: Deploy
-
 on:
   workflow_dispatch:
     inputs:
@@ -13,161 +12,35 @@ on:
           - test
           - preprod
           - production
-  push:
-    branches:
-      - main
-
-  pull_request:
-    branches:
-      - main
-    types:
-      - labeled
-      - synchronize
-      - reopened
-      - opened
-      - converted_to_draft
+      sha:
+        description: Commit sha to be deployed
+        required: true
 env:
   CONTAINER_REGISTRY: ghcr.io
 
 jobs:
-  docker:
-    name: Docker build and push
-    if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request'
+  deploy_environment:
+    name: Deploy to ${{ github.event.inputs.environment }} environment
     runs-on: ubuntu-latest
-    outputs:
-      docker_image: ${{ steps.image.outputs.tag }}
+    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+    environment:
+      name: ${{ github.event.inputs.environment }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Docker image tag
         id: image
         run: |
-          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.CONTAINER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker build & push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.image.outputs.tag }}
-
-  deploy_review:
-    name: Deploy to review environment
-    concurrency: deploy_review_${{ github.event.pull_request.number }}
-    needs: [docker]
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'deploy')
-    environment:
-      name: review
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/workflows/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: review
-          docker_image: ${{ needs.docker.outputs.docker_image }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/review.tfvars.json
-          pr_id: ${{ github.event.pull_request.number }}
-
-      - name: Post sticky pull request comment
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: |
-            Review app deployed to ${{ steps.deploy.outputs.environment_url }}
-
-      - uses: ./.github/workflows/actions/smoke-test
-        id: smoke-test
-        with:
-          environment: review
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
-  deploy_nonprod:
-    name: Deploy to ${{ matrix.environment }} environment
-    runs-on: ubuntu-latest
-    needs: [docker]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    concurrency: deploy_${{ matrix.environment }}
-    strategy:
-      max-parallel: 1
-      matrix:
-        environment: [dev, test, preprod]
-    environment:
-      name: ${{ matrix.environment }}
-      url: ${{ steps.deploy.outputs.environment_url }}
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/workflows/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: ${{ matrix.environment }}
-          docker_image: ${{ needs.docker.outputs.docker_image }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/${{ matrix.environment }}.tfvars.json
-      - uses: ./.github/workflows/actions/smoke-test
-        id: smoke-test
-        with:
-          environment: ${{ matrix.environment }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
-  deploy_production:
-    name: Deploy to production environment
-    needs: [docker, deploy_nonprod]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    environment:
-      name: production
-      url: ${{ steps.deploy.outputs.environment_url }}
-    concurrency: deploy_production
-
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/workflows/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: production
-          docker_image: ${{ needs.docker.outputs.docker_image }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/production.tfvars.json
-
-  deploy_environment:
-    name: Deploy to ${{ github.event.inputs.environment }} environment
-    runs-on: ubuntu-latest
-    needs: [docker]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
-    environment:
-      name: ${{ github.event.inputs.environment }}
-      url: ${{ steps.deploy.outputs.environment_url }}
-    concurrency: deploy_${{ github.event.inputs.environment }}
-
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
-
-    steps:
-      - uses: actions/checkout@v3
+          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$INPUT_GITHUB_SHA
+        env:
+          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+          INPUT_GITHUB_SHA: ${{ inputs.sha }}
+        shell: bash
 
       - uses: ./.github/workflows/actions/deploy-environment
         id: deploy
         with:
           environment_name: ${{ github.event.inputs.environment }}
-          docker_image: ${{ needs.docker.outputs.docker_image }}
+          docker_image: ${{ steps.image.outputs.tag }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           terraform_vars: workspace_variables/${{ github.event.inputs.environment }}.tfvars.json


### PR DESCRIPTION
### Context

Move manual deployment to separate workflow. This is needed so that manual deployment can happen with pre-built docker image. This PR also removes the dependency for CD deployments on build job. CD deployments should also use pre-built image
