### PR TITLE
Send emails in development using file method

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,22 +130,7 @@ Due to the `Service open` feature flag which is set to `false` by default across
 
 ### Notify
 
-If you want to test and simulate sending emails locally, you need to be added
-to the TRA digital Notify account. Then, go to
-`API integration > API keys > Create an API key` and create a new key, such as
-`Myname - local test` and set the type to `Test - pretends to send messages`.
-
-Add this key to your local development secrets:
-
-```bash
-$ vim .env.development.local
-GOVUK_NOTIFY_API_KEY=theo__local_test-abcefgh-1234-abcdefgh
-```
-
-When you send an email locally, the email should appear in the message log in
-the Notify dashboard in the `API integration` section.
-
-_Note:_ You can set `GOVUK_NOTIFY_API_KEY=fake-key` when running locally if you don't need to use Notify.
+Notify emails are printed in `tail -f log/development.log` in local dev.
 
 ### Docker
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,13 +65,11 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  # Do not raise errors in development for mail delivery.
-  config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
-  config.action_mailer.delivery_method = :notify
 
   config.active_job.queue_adapter = :sidekiq
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :file
+  config.action_mailer.raise_delivery_errors = true
 end


### PR DESCRIPTION
This allows us to more easily read the contents of emails which have been sent using the application, and raises errors if they fail to send.

This also removes the need for us to specify a Notify key in dev.

See https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/171/commits/2e3fc3cedbe0aa3071ee00f9dd2e1a8249850de8