### PR TITLE
Fix missing dependency for production CD

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -112,6 +112,7 @@ jobs:
       name: production
       url: ${{ steps.deploy.outputs.environment_url }}
     concurrency: deploy_production
+    needs: [deploy_nonprod]
 
     outputs:
       environment_url: ${{ steps.deploy.outputs.environment_url }}


### PR DESCRIPTION
### Context

Production deployment should only run after non-production deployments and
smoke test passing. This commit adds a needs condition on production.