### PR TITLE
Rename workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Manual deployment
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
### Context

Deploy workflow name is already used for CD workflow. This PR
renames the workflow so it's easily identified from Github Actions tab.
