### PR TITLE
Create a new endpoint for Identity

### DIFF
--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class IdentityController < ApplicationController
+  def create
+    unless FeatureFlag.active?(:identity_open)
+      raise IdentityEndpointOffError,
+            "Could not access the get an identity endpoint because the " \
+              ":identity_open feature flag is off"
+    end
+
+    head :no_content
+  end
+
+  class IdentityEndpointOffError < StandardError
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,6 +29,11 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = [
     [
+      :identity_open,
+      "Allow access to the get an identity endpoint",
+      "Richard da Silva"
+    ],
+    [
       :use_dqt_api_itt_providers,
       "Use autocomplete from DQT API results",
       "Richard da Silva"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,8 @@ Rails.application.routes.draw do
 
   get "/performance", to: "performance#index"
 
+  post "/identity", to: "identity#create"
+
   scope via: :all do
     get "/404", to: "errors#not_found"
     get "/422", to: "errors#unprocessable_entity"

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Identity", type: :system do
+  before do
+    given_the_service_is_open
+    given_the_identity_endpoint_is_open
+  end
+
+  after { deactivate_feature_flags }
+
+  it "using the identity endpoint returns no content" do
+    and_i_access_the_identity_endpoint
+    then_i_see_no_content
+  end
+
+  private
+
+  def and_i_access_the_identity_endpoint
+    post identity_path
+  end
+
+  def then_i_see_no_content
+    expect(response).to have_http_status(:no_content)
+  end
+
+  def deactivate_feature_flags
+    FeatureFlag.deactivate(:service_open)
+    FeatureFlag.deactivate(:identity_open)
+  end
+
+  def given_the_service_is_open
+    FeatureFlag.activate(:service_open)
+  end
+
+  def given_the_identity_endpoint_is_open
+    FeatureFlag.activate(:identity_open)
+  end
+end


### PR DESCRIPTION
### Context

Get an Identity will hand over users to Find. A new endpoint is therefore required within find to handle redirects to from Identity.

### Changes proposed in this pull request

Adds an initial new route and controller for the Identity endpoint. Access is controlled using the :identity_open feature flag.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
