### PR TITLE
Add needs condition for CD jobs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -70,6 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency: deploy_${{ matrix.environment }}
+    needs: [docker]
     strategy:
       max-parallel: 1
       matrix:
@@ -112,7 +113,7 @@ jobs:
       name: production
       url: ${{ steps.deploy.outputs.environment_url }}
     concurrency: deploy_production
-    needs: [deploy_nonprod]
+    needs: [docker, deploy_nonprod]
 
     outputs:
       environment_url: ${{ steps.deploy.outputs.environment_url }}


### PR DESCRIPTION
### Context

Docker image build and push currently runs in parallel to the CD deployment jobs. Adding needs to deployment creates dependency on build output. This PR adds the needs condition to deploy_nonprod and deploy_production jobs.