### PR TITLE
Add task to ignore_concurrent_migration_exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ RUN bundle exec rails assets:precompile && \
     rm -rf tmp/* log/* node_modules /tmp/*
 
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && \
-    bundle exec rails data:migrate && \
+    bundle exec rails data:migrate:ignore_concurrent_migration_exceptions && \
     bundle exec rails server -b 0.0.0.0

--- a/lib/tasks/ignore_concurrent_migration_exceptions.rake
+++ b/lib/tasks/ignore_concurrent_migration_exceptions.rake
@@ -9,3 +9,14 @@ namespace :db do
     end
   end
 end
+
+namespace :data do
+  namespace :migrate do
+    desc "data:migrate but ignores ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["data:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end


### PR DESCRIPTION
Data migration scripts can fail to run in Production due to `ActiveRecord::ConcurrentMigrationError`: https://sentry.io/organizations/dfe-teacher-services/issues/3489505983/?project=6275068&referrer=slack

This adds a task that's similar to the one we have for regular migrations.
