### PR TITLE
Add staff management interface to Support

### DIFF
--- a/app/controllers/staff/invitations_controller.rb
+++ b/app/controllers/staff/invitations_controller.rb
@@ -38,7 +38,11 @@ class Staff::InvitationsController < Devise::InvitationsController
     end
   end
 
+  def after_invite_path_for(inviter, invitee)
+    invitee.is_a?(Staff) ? support_interface_staff_index_path : super
+  end
+
   def after_accept_path_for(resource)
-    resource.is_a?(Staff) ? support_interface_path : super
+    resource.is_a?(Staff) ? support_interface_staff_index_path : super
   end
 end

--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class StaffController < SupportInterfaceController
+    def index
+      @staff = Staff.all
+    end
+  end
+end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -42,6 +42,11 @@
           href: support_interface_features_path,
           active: current_page?(support_interface_features_path)
         ) %>
+         <% header.navigation_item(
+          text: "Staff",
+          href: support_interface_staff_index_path,
+          active: request.path.start_with?("/support/staff")
+        ) %>
         <% header.navigation_item(
           text: "Sidekiq",
           href: support_interface_sidekiq_web_path

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, 'Staff' %>
+
+<h1 class="govuk-heading-l">Staff</h1>
+
+<p class="govuk-body">
+  <%= govuk_button_link_to 'Invite staff user', new_staff_invitation_path %>
+</p>
+
+<% @staff.find_each do |staff| %>
+  <h2 class="govuk-heading-m"><%= staff.email %></h2>
+
+  <%= govuk_summary_list do |summary_list|
+    summary_list.row do |row|
+      row.key { 'Created at' }
+      row.value { staff.created_at.to_s }
+    end
+
+    if staff.created_by_invite?
+      summary_list.row do |row|
+        row.key { 'Invitation status' }
+
+        row.value do
+          if staff.invitation_accepted?
+             govuk_tag(text: "Accepted", colour: "green")
+          else
+            govuk_tag(text: "Not accepted", colour: "red")
+          end
+        end
+      end
+
+      summary_list.row do |row|
+        row.key { 'Invited at' }
+        row.value { staff.invitation_sent_at.to_s }
+      end
+    end
+
+    summary_list.row do |row|
+      row.key { 'Last signed in at' }
+      row.value { staff.last_sign_in_at.to_s }
+    end
+  end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
       resource :zendesk_sync, only: [:create], controller: "zendesk_sync"
     end
 
+    resources :staff, only: %i[index]
+
     devise_scope :staff do
       authenticate :staff do
         mount Sidekiq::Web, at: "sidekiq"


### PR DESCRIPTION
This allows us to invite people from the team, and removes the need to rely on basic auth for the support section.

Based on https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/169

![image](https://user-images.githubusercontent.com/1650875/183877781-7eaccffe-1582-4964-b646-66c59b532a4f.png)
