### PR TITLE
Fix mail host in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,9 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = {
+    host: HostingEnvironment.host,
+    protocol: "https"
+  }
   config.action_mailer.delivery_method = :notify
 end


### PR DESCRIPTION
We forgot to define this as part of configuring the mailer, and it's necessary for Devise mails to send successfully, so that Devise can write links correctly in the email body.
