### PR TITLE
Unlock teacher job update

### DIFF
--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -27,7 +27,7 @@ class DqtApi
 
     teacher_account = results.first
 
-    UnlockTeacherAccountJob.set(wait: 5.minutes).perform_later(teacher_account)
+    UnlockTeacherAccountJob.perform_later(teacher_account)
 
     teacher_account
   end


### PR DESCRIPTION
### Context

[Trello Card](https://trello.com/c/YVXdflHt)

We do not need a 5 minute deferment period before running this job. Also Action Jobs run with exponential backoff

### Changes proposed in this pull request

Remove the 5 minute wait before running this job

### Guidance to review

Ensure there is no implicit deferment period

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
