### PR TITLE
Add data migration to bin/setup 

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -28,6 +28,9 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
+  puts "\n== Running data migrations =="
+  system! "bin/rails db:migrate:with_data"
+
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20_220_802_124_734)
+DataMigrate::Data.define(version: 20_220_809_085_018)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_095822) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "features", force: :cascade do |t|
     t.string "name", null: false
     t.boolean "active", default: false, null: false


### PR DESCRIPTION
We should run all recent data migrations when setting up locally.

I also had to commit some changes to `schema.rb` and update the timestamp for the data migrations.