### PR TITLE
Remove the Zendesk integration feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -50,11 +50,6 @@ class FeatureFlag
       "Theodor Vararu"
     ],
     [
-      :zendesk_integration,
-      "Submit tickets to Zendesk on behalf of users at the end of the journey",
-      "Theodor Vararu"
-    ],
-    [
       :unlock_teachers_self_service_portal_account,
       "Unlock a teacher's self service portal account if their TRN is found",
       "Ransom Voke Anighoro"

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -2,22 +2,14 @@
 
 class ZendeskService
   def self.create_ticket!(trn_request)
-    unless FeatureFlag.active?(:zendesk_integration)
-      raise ZendeskOffError,
-            "Could not create a Zendesk ticket because the " \
-              ":zendesk_integration feature flag is off"
-    end
-
-    begin
-      ticket = GDS_ZENDESK_CLIENT.ticket.create!(ticket_template(trn_request))
-      trn_request.update!(zendesk_ticket_id: ticket.id)
-    rescue ZendeskAPI::Error::RecordInvalid => e
-      Sentry.capture_exception(e, contexts: { errors: e.errors })
-      raise CreateError, "Could not create Zendesk ticket"
-    rescue ZendeskAPI::Error::NetworkError => e
-      Sentry.capture_exception(e, contexts: { errors: e.errors })
-      raise ConnectionError, "Could not connect to Zendesk"
-    end
+    ticket = GDS_ZENDESK_CLIENT.ticket.create!(ticket_template(trn_request))
+    trn_request.update!(zendesk_ticket_id: ticket.id)
+  rescue ZendeskAPI::Error::RecordInvalid => e
+    Sentry.capture_exception(e, contexts: { errors: e.errors })
+    raise CreateError, "Could not create Zendesk ticket"
+  rescue ZendeskAPI::Error::NetworkError => e
+    Sentry.capture_exception(e, contexts: { errors: e.errors })
+    raise ConnectionError, "Could not connect to Zendesk"
   end
 
   def self.find_ticket(id)

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -4,17 +4,15 @@ require "rails_helper"
 RSpec.describe FeatureFlag do
   describe ".activate" do
     it "activates a feature" do
-      expect { described_class.activate("zendesk_integration") }.to(
-        change { described_class.active?("zendesk_integration") }.from(
-          false
-        ).to(true)
+      expect { described_class.activate("slack_alerts") }.to(
+        change { described_class.active?("slack_alerts") }.from(false).to(true)
       )
     end
 
     it "records the change in the database" do
-      feature = Feature.create_or_find_by!(name: "zendesk_integration")
+      feature = Feature.create_or_find_by!(name: "slack_alerts")
       feature.update!(active: false)
-      expect { described_class.activate("zendesk_integration") }.to(
+      expect { described_class.activate("slack_alerts") }.to(
         change { feature.reload.active }.from(false).to(true)
       )
     end
@@ -23,18 +21,16 @@ RSpec.describe FeatureFlag do
   describe ".deactivate" do
     it "deactivates a feature" do
       # To avoid flakey tests where activation/deactivation happens at the same time
-      travel(5.minutes) { described_class.activate("zendesk_integration") }
-      expect { described_class.deactivate("zendesk_integration") }.to(
-        change { described_class.active?("zendesk_integration") }.from(true).to(
-          false
-        )
+      travel(5.minutes) { described_class.activate("slack_alerts") }
+      expect { described_class.deactivate("slack_alerts") }.to(
+        change { described_class.active?("slack_alerts") }.from(true).to(false)
       )
     end
 
     it "records the change in the database" do
-      feature = Feature.create_or_find_by!(name: "zendesk_integration")
+      feature = Feature.create_or_find_by!(name: "slack_alerts")
       feature.update!(active: true)
-      expect { described_class.deactivate("zendesk_integration") }.to(
+      expect { described_class.deactivate("slack_alerts") }.to(
         change { feature.reload.active }.from(true).to(false)
       )
     end

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -22,102 +22,81 @@ RSpec.describe ZendeskService do
     end
   end
 
-  context "when feature flag is off" do
-    before { FeatureFlag.deactivate(:zendesk_integration) }
+  describe ".create_ticket!" do
+    subject(:create_ticket!) { described_class.create_ticket!(trn_request) }
 
-    describe ".create_ticket!" do
-      it "does not create a ticket" do
-        allow(ticket_client).to receive(:create!)
-        trn_request = TrnRequest.new
+    let(:trn_request) do
+      build(
+        :trn_request,
+        date_of_birth: 20.years.ago,
+        email: "test@example.com",
+        first_name: "Test",
+        has_ni_number: true,
+        itt_provider_enrolled: true,
+        itt_provider_name: "Big SCITT",
+        last_name: "User",
+        ni_number: "QC123456A",
+        previous_last_name: "Smith"
+      )
+    end
 
-        expect { described_class.create_ticket!(trn_request) }.to raise_error(
-          ZendeskService::ZendeskOffError
-        )
-        expect(ticket_client).not_to have_received(:create!)
+    it "creates a ticket" do
+      allow(ticket_client).to receive(:create!).and_return(
+        ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)
+      )
+
+      create_ticket!
+
+      expect(ticket_client).to have_received(:create!).once.with(
+        {
+          subject: "[Find a lost TRN] Support request from Test User",
+          comment: {
+            value:
+              "A user has submitted a request to find their lost " \
+                "TRN. Their information is:\n" \
+                "\nName: Test User" \
+                "\nEmail: test@example.com" \
+                "\nPrevious name: Test Smith" \
+                "\nDate of birth: #{20.years.ago.strftime("%d %B %Y")}" \
+                "\nNI number: QC123456A" \
+                "\nITT provider: Big SCITT\n"
+          },
+          requester: {
+            email: "test@example.com",
+            name: "Test User"
+          },
+          custom_fields: {
+            id: "4419328659089",
+            value: "request_from_find_a_lost_trn_app"
+          }
+        }
+      )
+      expect(trn_request.zendesk_ticket_id).to eq(42)
+    end
+
+    context "with a TRN Request that breaks Zendesk" do
+      let(:trn_request) do
+        build(:trn_request, :has_itt_provider, first_name: "break_zendesk")
+      end
+
+      it "throws an error when it fails to create a ticket" do
+        expect(Sentry).to receive(:capture_exception)
+        expect { create_ticket! }.to raise_error(ZendeskService::CreateError)
       end
     end
   end
 
-  context "when feature flag is on" do
-    before { FeatureFlag.activate(:zendesk_integration) }
-    after { FeatureFlag.deactivate(:zendesk_integration) }
+  describe ".find_ticket" do
+    subject(:find_ticket) { described_class.find_ticket(ticket_id) }
 
-    describe ".create_ticket!" do
-      subject(:create_ticket!) { described_class.create_ticket!(trn_request) }
+    let(:ticket_id) { 42 }
 
-      let(:trn_request) do
-        build(
-          :trn_request,
-          date_of_birth: 20.years.ago,
-          email: "test@example.com",
-          first_name: "Test",
-          has_ni_number: true,
-          itt_provider_enrolled: true,
-          itt_provider_name: "Big SCITT",
-          last_name: "User",
-          ni_number: "QC123456A",
-          previous_last_name: "Smith"
-        )
-      end
-
-      it "creates a ticket" do
-        allow(ticket_client).to receive(:create!).and_return(
-          ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)
-        )
-
-        create_ticket!
-
-        expect(ticket_client).to have_received(:create!).once.with(
-          {
-            subject: "[Find a lost TRN] Support request from Test User",
-            comment: {
-              value:
-                "A user has submitted a request to find their lost " \
-                  "TRN. Their information is:\n" \
-                  "\nName: Test User" \
-                  "\nEmail: test@example.com" \
-                  "\nPrevious name: Test Smith" \
-                  "\nDate of birth: #{20.years.ago.strftime("%d %B %Y")}" \
-                  "\nNI number: QC123456A" \
-                  "\nITT provider: Big SCITT\n"
-            },
-            requester: {
-              email: "test@example.com",
-              name: "Test User"
-            },
-            custom_fields: {
-              id: "4419328659089",
-              value: "request_from_find_a_lost_trn_app"
-            }
-          }
-        )
-        expect(trn_request.zendesk_ticket_id).to eq(42)
-      end
-
-      context "with a TRN Request that breaks Zendesk" do
-        let(:trn_request) do
-          build(:trn_request, :has_itt_provider, first_name: "break_zendesk")
-        end
-
-        it "throws an error when it fails to create a ticket" do
-          expect(Sentry).to receive(:capture_exception)
-          expect { create_ticket! }.to raise_error(ZendeskService::CreateError)
-        end
-      end
+    before do
+      allow(ticket_client).to receive(:find).and_return(
+        ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)
+      )
     end
 
-    describe ".find_ticket" do
-      subject(:find_ticket) { described_class.find_ticket(ticket_id) }
-
-      let(:ticket_id) { 42 }
-
-      before do
-        allow(ticket_client).to receive(:find).and_return(
-          ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)
-        )
-      end
-
-      it { is_expected.to be_a(ZendeskAPI::Ticket) }
-    end
+    it { is_expected.to be_a(ZendeskAPI::Ticket) }
   end
 end

--- a/spec/system/active_sanctions_spec.rb
+++ b/spec/system/active_sanctions_spec.rb
@@ -2,10 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "TRN requests", type: :system do
-  before do
-    given_the_service_is_open
-    given_the_zendesk_integration_feature_is_enabled
-  end
+  before { given_the_service_is_open }
 
   after { deactivate_feature_flags }
 
@@ -31,15 +28,10 @@ RSpec.describe "TRN requests", type: :system do
 
   def deactivate_feature_flags
     FeatureFlag.deactivate(:service_open)
-    FeatureFlag.deactivate(:zendesk_integration)
   end
 
   def given_the_service_is_open
     FeatureFlag.activate(:service_open)
-  end
-
-  def given_the_zendesk_integration_feature_is_enabled
-    FeatureFlag.activate(:zendesk_integration)
   end
 
   def given_i_am_on_the_home_page

--- a/spec/system/support_spec.rb
+++ b/spec/system/support_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe "Support", type: :system do
     when_i_visit_the_feature_flags_page
     then_i_see_the_feature_flags
 
-    when_i_activate_the_zendesk_feature_flag
-    then_the_zendesk_flag_is_on
+    when_i_activate_the_slack_alerts_feature_flag
+    then_the_slack_alerts_flag_is_on
 
-    when_i_deactivate_the_zendesk_feature_flag
-    then_the_zendesk_flag_is_off
+    when_i_deactivate_the_slack_alerts_feature_flag
+    then_the_slack_alerts_flag_is_off
   end
 
   it "syncing with Zendesk", vcr: true do
@@ -52,12 +52,12 @@ RSpec.describe "Support", type: :system do
     click_on "Features"
   end
 
-  def when_i_activate_the_zendesk_feature_flag
-    click_on "Activate Zendesk integration"
+  def when_i_activate_the_slack_alerts_feature_flag
+    click_on "Activate Slack alerts"
   end
 
-  def when_i_deactivate_the_zendesk_feature_flag
-    click_on "Deactivate Zendesk integration"
+  def when_i_deactivate_the_slack_alerts_feature_flag
+    click_on "Deactivate Slack alerts"
   end
 
   def when_i_press_sync_with_zendesk
@@ -87,14 +87,14 @@ RSpec.describe "Support", type: :system do
     expect(page).to have_content("AA 12 34 56 A")
   end
 
-  def then_the_zendesk_flag_is_on
-    expect(page).to have_content("Feature “Zendesk integration” activated")
-    expect(page).to have_content("Zendesk integration\n- Active")
+  def then_the_slack_alerts_flag_is_on
+    expect(page).to have_content("Feature “Slack alerts” activated")
+    expect(page).to have_content("Slack alerts\n- Active")
   end
 
-  def then_the_zendesk_flag_is_off
-    expect(page).to have_content("Feature “Zendesk integration” deactivated")
-    expect(page).to have_content("Zendesk integration\n- Inactive")
+  def then_the_slack_alerts_flag_is_off
+    expect(page).to have_content("Feature “Slack alerts” deactivated")
+    expect(page).to have_content("Slack alerts\n- Inactive")
   end
 
   def and_there_is_a_trn_request_in_progress

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -2,10 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "TRN requests", type: :system do
-  before do
-    given_the_service_is_open
-    given_the_zendesk_integration_feature_is_enabled
-  end
+  before { given_the_service_is_open }
 
   after { deactivate_feature_flags }
 
@@ -544,7 +541,6 @@ RSpec.describe "TRN requests", type: :system do
     FeatureFlag.deactivate(:processing_delays)
     FeatureFlag.deactivate(:service_open)
     FeatureFlag.deactivate(:use_dqt_api_itt_providers)
-    FeatureFlag.deactivate(:zendesk_integration)
   end
 
   def given_i_am_on_the_home_page
@@ -600,10 +596,6 @@ RSpec.describe "TRN requests", type: :system do
 
   def given_the_use_dqt_api_itt_providers_feature_is_enabled
     FeatureFlag.activate(:use_dqt_api_itt_providers)
-  end
-
-  def given_the_zendesk_integration_feature_is_enabled
-    FeatureFlag.activate(:zendesk_integration)
   end
 
   def given_the_zendesk_connection_is_unavailable

--- a/spec/system/zendesk_tickets_spec.rb
+++ b/spec/system/zendesk_tickets_spec.rb
@@ -2,10 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "Zendesk ticket syncing", type: :system do
-  before do
-    given_the_service_is_open
-    given_the_zendesk_integration_feature_is_enabled
-  end
+  before { given_the_service_is_open }
 
   after { deactivate_feature_flags }
 
@@ -80,15 +77,10 @@ RSpec.describe "Zendesk ticket syncing", type: :system do
 
   def deactivate_feature_flags
     FeatureFlag.deactivate(:service_open)
-    FeatureFlag.deactivate(:zendesk_integration)
   end
 
   def given_the_service_is_open
     FeatureFlag.activate(:service_open)
-  end
-
-  def given_the_zendesk_integration_feature_is_enabled
-    FeatureFlag.activate(:zendesk_integration)
   end
 
   def given_there_is_a_completed_trn_request


### PR DESCRIPTION
The process of leveraging Zendesk to assist with finding TRNs is
integral to how the service operates. It seems unlikely that we'd need
the ability to use the feature flag to disable it in the future.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
