### PR TITLE
 Allow testing from Identity and updated check answers page

### DIFF
--- a/app/components/trn_details_component.html.erb
+++ b/app/components/trn_details_component.html.erb
@@ -4,7 +4,7 @@
   email_row = {
     key: { text: 'Email address' },
     value: { text: email },
-    actions: [{ href: email_path, visually_hidden_text: 'email address' }]
+    actions: @trn_request.from_get_an_identity? ? [] : [{ href: email_path, visually_hidden_text: 'email address' }]
   }
 
   name_row = {

--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -6,6 +6,7 @@ module EnforceQuestionOrder
 
   def redirect_to_next_question
     redirect_to(start_url) and return if start_page_is_required?
+    return if request_from_identity?
     return if all_questions_answered?
     return if previous_question_answered?
 
@@ -18,6 +19,10 @@ module EnforceQuestionOrder
     redirect_to next_question_path
   end
 
+  def redirect_requests_from_identity
+    redirect_to check_answers_path if request_from_identity?
+  end
+
   private
 
   def trn_request
@@ -27,6 +32,10 @@ module EnforceQuestionOrder
 
   def start_page_is_required?
     trn_request.nil? && request.path == "/trn-request"
+  end
+
+  def request_from_identity?
+    trn_request.from_get_an_identity? || request.path == "/identity"
   end
 
   def questions

--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -2,6 +2,8 @@
 class EmailController < ApplicationController
   include EnforceQuestionOrder
 
+  before_action :redirect_requests_from_identity
+
   layout "two_thirds"
 
   def edit

--- a/db/migrate/20220812150721_add_from_get_an_identity_to_trn_requests.rb
+++ b/db/migrate/20220812150721_add_from_get_an_identity_to_trn_requests.rb
@@ -1,0 +1,5 @@
+class AddFromGetAnIdentityToTrnRequests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trn_requests, :from_get_an_identity, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_05_095822) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_12_150721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -81,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_095822) do
     t.boolean "awarded_qts"
     t.boolean "has_active_sanctions"
     t.boolean "name_changed"
+    t.boolean "from_get_an_identity", default: false
   end
 
   create_table "trn_responses", force: :cascade do |t|

--- a/spec/components/trn_details_component_spec.rb
+++ b/spec/components/trn_details_component_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe TrnDetailsComponent, type: :component do
       awarded_qts:,
       date_of_birth: 20.years.ago.to_date,
       email:,
+      from_get_an_identity: false,
       first_name: "Test",
       has_ni_number:,
       itt_provider_enrolled:,
@@ -85,6 +86,16 @@ RSpec.describe TrnDetailsComponent, type: :component do
 
     it "renders change email" do
       expect(component.text).to include("Change email")
+    end
+
+    context "when an email address has been supplied by Identity" do
+      before do
+        allow(trn_request).to receive(:from_get_an_identity).and_return(true)
+      end
+
+      it "does not render change email" do
+        expect(component.text).to_not include("Change email")
+      end
     end
   end
 

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -11,11 +11,18 @@ RSpec.describe "Identity", type: :system do
 
   it "verifies the parameters" do
     and_i_access_the_identity_endpoint_with_parameters
-    then_i_see_no_content
+    then_i_see_the_check_answers_page
   end
 
   it "does not verify with modified parameters" do
     and_i_access_the_identity_endpoint_with_modified_parameters_it_raises_an_error
+  end
+
+  it "does not allow user to change their email" do
+    and_i_access_the_identity_endpoint_with_parameters
+    then_i_see_the_check_answers_page
+    when_i_try_to_go_to_the_email_page
+    then_i_see_the_check_answers_page
   end
 
   private
@@ -46,8 +53,12 @@ RSpec.describe "Identity", type: :system do
     )
   end
 
-  def then_i_see_no_content
-    expect(response).to have_http_status(:no_content)
+  def then_i_see_the_check_answers_page
+    expect(response).to redirect_to("/check-answers")
+  end
+
+  def when_i_try_to_go_to_the_email_page
+    get email_path
   end
 
   def deactivate_feature_flags


### PR DESCRIPTION
### Context

For testing, the Identity endpoint needs to be able to allow requests and redirect to the check answers page. The check answers page does not allow the Identity email to be changed.

### Changes proposed in this pull request

Creates a new TrnRequest using fake data on receipt of a request from Identity to allow testing of the Identity endpoint. Redirects to the check answers page where the email cannot be changed.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
