### PR TITLE
Add ADR for Zendesk ticket deletion

### DIFF
--- a/adr/00009-delete-zendesk-tickets.md
+++ b/adr/00009-delete-zendesk-tickets.md
@@ -1,0 +1,45 @@
+# 9. Delete Zendesk tickets
+
+Date: 2022-08-16
+
+## Status
+
+Accepted
+
+## Context
+
+We need to delete Zendesk tickets that are 6 months or older due to our data
+retention policy. Some of these Zendesk tickets are created by Find, and others
+are created through other means.
+
+Find is in a good position to handle deleting tickets, because it already
+communicates with the Zendesk API and can provide interfaces and jobs to handle
+this task.
+
+We need to delete:
+
+- Tickets
+- That are older than 6 months
+- That are in a `Closed` state
+
+When deleting, we need to retain certain fields for reporting purposes:
+
+- Received date: `.created_at`
+- Closed date: `.updated_at`
+- Enquiry type (Custom field): `.custom_fields.find { |cf| cf.id == 4419328659089 }.value`
+- No action required (Custom field): `.custom_fields.find { |cf| cf.id == 4562126876049 }.value`
+- Group name: `.group.name` (NB: Querying for this is an extra HTTP request)
+
+## Decision
+
+Find will use a background job to delete closed tickets that have not been
+updated in 6 months or more.
+
+Find will retain `DeletedZendeskTickets` as rows in the database containing the
+necessary metadata and allow exporting / reporting of useful data.
+
+## Consequences
+
+- Find becomes an essential part of our data retention policy in a way that
+  isn't immediately obvious
+- We can't change our minds later about what fields we should retain

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -16,6 +16,14 @@ class ZendeskService
     GDS_ZENDESK_CLIENT.ticket.find(id:)
   end
 
+  def self.find_closed_tickets_from_6_months_ago
+    date = 6.months.ago.strftime("%Y-%m-%d")
+    GDS_ZENDESK_CLIENT
+      .zendesk_client
+      .search(query: "updated<#{date} type:ticket status:closed")
+      .fetch
+  end
+
   def self.ticket_template(trn_request)
     {
       subject: "[Find a lost TRN] Support request from #{trn_request.name}",

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -2,6 +2,31 @@
 require "gds_zendesk/client"
 require "gds_zendesk/dummy_client"
 
+class ExtendedDummyClient
+  def initialize(logger)
+    @logger = logger
+  end
+
+  def search(_params)
+    self
+  end
+
+  def fetch
+    [ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)]
+  end
+end
+
+module DummyClientExtensions
+  attr_reader :zendesk_client
+
+  def initialize(options)
+    @logger = options[:logger] || NullLogger.instance
+    @ticket = GDSZendesk::DummyTicket.new(@logger)
+    @users = GDSZendesk::DummyUsers.new(@logger)
+    @zendesk_client = ExtendedDummyClient.new(@logger)
+  end
+end
+
 module DummyTicketExtensions
   def count!
     1
@@ -35,6 +60,10 @@ module DummyTicketExtensions
 end
 
 module GDSZendesk
+  class DummyClient
+    prepend DummyClientExtensions
+  end
+
   class DummyTicket
     prepend DummyTicketExtensions
   end

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 
 RSpec.describe ZendeskService do
   let(:ticket_client) { GDS_ZENDESK_CLIENT.ticket }
+  let(:zendesk_client) { GDS_ZENDESK_CLIENT.zendesk_client }
 
   describe ".ticket_template" do
     it "correctly formats a TRN request with no NI number" do
@@ -98,5 +99,20 @@ RSpec.describe ZendeskService do
     end
 
     it { is_expected.to be_a(ZendeskAPI::Ticket) }
+  end
+
+  describe ".find_closed_tickets_from_6_months_ago" do
+    subject(:find_closed_tickets) do
+      described_class.find_closed_tickets_from_6_months_ago
+    end
+
+    before do
+      allow(zendesk_client).to receive(:search).and_return(zendesk_client)
+      allow(zendesk_client).to receive(:fetch).and_return(
+        [ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)]
+      )
+    end
+
+    it { is_expected.to be_a(Array) }
   end
 end


### PR DESCRIPTION
### Context

This contains an ADR and the start of the Zendesk ticket deletion implementation. 
### Changes proposed in this pull request

Add an ADR and the `find_closed_tickets_from_6_months_ago` method, which is currently unused.

### Guidance to review

Follow-up PRs will build the rest of the functionality.

### Checklist

- [x] Attach to Trello card https://trello.com/c/fOknaOcV/401-zendesk-technical-analysis-of-ticket-deletion-6-months
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
