### PR TITLE
Add g++ as a build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3.1.1-alpine
 
 RUN apk -U upgrade && \
     apk add --update --no-cache gcc git libc6-compat libc-dev make nodejs \
-    postgresql13-dev tzdata yarn
+    postgresql13-dev tzdata yarn g++
 
 RUN echo "Europe/London" > /etc/timezone && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime


### PR DESCRIPTION
There is an issue with the build tools in Alpine 3.1 when trying to
build sassc.

The simplest workaround I could find was to add g++.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
