### PR TITLE
Send the TRN back to Identity and redirect if the initial request was from Identity

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,3 +4,5 @@ HOSTING_ENVIRONMENT_NAME=local
 SUPPORT_PASSWORD=test
 SUPPORT_USERNAME=test
 IDENTITY_SHARED_SECRET_KEY=testkey
+IDENTITY_API_URL=https://s165d01-getanid-dev-auth-server-app.azurewebsites.net
+IDENTITY_API_KEY=testkey

--- a/.env.test
+++ b/.env.test
@@ -8,3 +8,5 @@ SLACK_WEBHOOK_URL=test
 SUPPORT_USERNAME=test
 SUPPORT_PASSWORD=test
 IDENTITY_SHARED_SECRET_KEY=testkey
+IDENTITY_API_URL=https://s165d01-getanid-dev-auth-server-app.azurewebsites.net
+IDENTITY_API_KEY=testkey

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ ENV GOVUK_NOTIFY_API_KEY=TestKey \
     SECRET_KEY_BASE=TestKey \
     ZENDESK_TOKEN=TestToken \
     ZENDESK_USER=TestUser \
-    IDENTITY_SHARED_SECRET_KEY=testkey
+    IDENTITY_SHARED_SECRET_KEY=testkey \
+    IDENTITY_API_URL=http://localhost \
+    IDENTITY_API_KEY=TestKey
 
 WORKDIR /app
 

--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -33,6 +33,8 @@ class IdentityController < ApplicationController
       )
 
     session[:trn_request_id] = @trn_request.id
+    session[:identity_journey_id] = allowed_create_params["journey_id"]
+    session[:identity_redirect_uri] = allowed_create_params["redirect_uri"]
 
     redirect_requests_from_identity
   end

--- a/app/controllers/no_match_controller.rb
+++ b/app/controllers/no_match_controller.rb
@@ -13,9 +13,26 @@ class NoMatchController < ApplicationController
     if @no_match_form.valid? && @no_match_form.try_again?
       redirect_to check_answers_path
     elsif @no_match_form.valid?
-      create_zendesk_ticket
+      if trn_request.from_get_an_identity?
+        begin
+          # Send a request to Get An Identity API with no TRN found
+          IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
 
-      redirect_to helpdesk_request_submitted_path
+          # Send the user back to Get an Identity
+          redirect_to session[:identity_redirect_uri], allow_other_host: true
+        rescue IdentityApi::ApiError,
+               Faraday::ConnectionFailed,
+               Faraday::TimeoutError,
+               ActionController::ActionControllerError => e
+          Sentry.capture_exception(e)
+          # Do not redirect back to Get An Identity
+          render "errors/internal_server_error", status: :internal_server_error
+        end
+      else
+        create_zendesk_ticket
+
+        redirect_to helpdesk_request_submitted_path
+      end
     else
       render :new
     end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,6 +29,11 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = [
     [
+      :identity_api_always_timeout,
+      "Always time-out the Identity API",
+      "Richard da Silva"
+    ],
+    [
       :identity_open,
       "Allow access to the get an identity endpoint",
       "Richard da Silva"

--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+class IdentityApi
+  class ApiError < StandardError
+  end
+
+  FIVE_SECONDS = 5
+
+  def self.submit_trn!(trn_request, journey_id)
+    if FeatureFlag.active?(:identity_api_always_timeout)
+      raise Faraday::TimeoutError, "Time-out feature flag enabled"
+    end
+
+    response =
+      new.client.put(
+        "/api/find-trn/user/#{journey_id}",
+        trn_request_params(trn_request)
+      )
+
+    raise ApiError, response.reason_phrase unless response.status == 204
+
+    response.body
+  end
+
+  def self.trn_request_params(trn_request)
+    {
+      firstName: trn_request.first_name,
+      lastName: trn_request.last_name,
+      trn: trn_request.trn,
+      dateOfBirth: trn_request.date_of_birth&.to_date&.to_s
+    }.compact
+  end
+
+  def client
+    @client ||=
+      Faraday.new(
+        url: ENV.fetch("IDENTITY_API_URL", nil),
+        request: {
+          timeout: FIVE_SECONDS
+        }
+      ) do |faraday|
+        faraday.request :authorization,
+                        "Bearer",
+                        ENV.fetch("IDENTITY_API_KEY", nil)
+        faraday.request :json
+        faraday.response :json
+        faraday.response :logger,
+                         nil,
+                         { bodies: true, headers: true } do |logger|
+          logger.filter(
+            /((given_name|family_name|birthdate|nino|trn)=)([^&]+)/,
+            '\1[REDACTED]'
+          )
+        end
+        faraday.adapter Faraday.default_adapter
+      end
+  end
+end

--- a/spec/cassettes/Identity/redirects_via_the_no_match_page_if_no_trn_is_found.yml
+++ b/spec/cassettes/Identity/redirects_via_the_no_match_page_if_no_trn_is_found.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E&nationalInsuranceNumber=AA123456A
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Fri, 19 Aug 2022 14:51:27 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-19T14:52:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 32d8dcbd-6719-47f8-4bd8-7a02360a0f2d
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 f4d9e5aa78d9bbc69bc2a7f8ca614182.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - LS1udkyfBzl5v7i_32rBPvmUWTtoHKHS32k6AIqSvtHE_xC1RPuqlw==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Fri, 19 Aug 2022 14:51:27 GMT
+  - request:
+      method: put
+      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Fri, 19 Aug 2022 14:51:27 GMT
+        Request-Context:
+          - appId=cid-v1:5aca65be-e52c-472b-8552-a925111002da
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-8uLzfcgnnD9mcHn8Gn07TkG9nPBfeIgB3zEAAzR/YoY='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Fri, 19 Aug 2022 14:51:28 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/redirects_back_to_Get_An_Identity.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/redirects_back_to_Get_An_Identity.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E&nationalInsuranceNumber=AA123456A
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Fri, 19 Aug 2022 16:06:59 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "298"
+        X-Rate-Limit-Reset:
+          - "2022-08-19T16:07:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 84caf59e-b10f-49e3-6d1d-eda5c5b58583
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 08dc6f02f30e8ad9291872e7e3d5b658.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - 0IeN4mTQHrR7VnVwGrUgCH6TiQ0heWSbREGMMfNAybKqczCZNyyEig==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Fri, 19 Aug 2022 16:06:59 GMT
+  - request:
+      method: put
+      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Fri, 19 Aug 2022 14:51:27 GMT
+        Request-Context:
+          - appId=cid-v1:5aca65be-e52c-472b-8552-a925111002da
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-8uLzfcgnnD9mcHn8Gn07TkG9nPBfeIgB3zEAAzR/YoY='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Fri, 19 Aug 2022 14:51:28 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_an_Identity_API_error/redirects_to_the_error_page.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_an_Identity_API_error/redirects_to_the_error_page.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E&nationalInsuranceNumber=AA123456A
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Fri, 19 Aug 2022 16:13:40 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-19T16:14:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 58aea612-5e08-40f8-6926-fc5c81a3727d
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 08dc6f02f30e8ad9291872e7e3d5b658.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - cZKWlqmvsfBKVjr5dhg4I6TGenCwtCMiR98yju2KjCstIqjfj79jWQ==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Fri, 19 Aug 2022 16:13:40 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_no_trn_match/sends_a_blank_trn_to_Get_an_Identity_and_redirects_back_Get_An_Identity.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_no_trn_match/sends_a_blank_trn_to_Get_an_Identity_and_redirects_back_Get_An_Identity.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E&nationalInsuranceNumber=AA123456A
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Fri, 19 Aug 2022 16:40:28 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-19T16:41:00.0000000Z"
+        X-Vcap-Request-Id:
+          - a7786e86-1ed4-4481-4433-787ff0712bf3
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 22e421a47e59010b5e8eb6ae4d4bd7e4.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - JOy5XjEgndej78mZcw0Nhug8oYrJ6VY5uAdrjuGpNyLe-p8XR28KzQ==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Fri, 19 Aug 2022 16:40:28 GMT
+  - request:
+      method: put
+      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01"}'
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Fri, 19 Aug 2022 14:51:27 GMT
+        Request-Context:
+          - appId=cid-v1:5aca65be-e52c-472b-8552-a925111002da
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-8uLzfcgnnD9mcHn8Gn07TkG9nPBfeIgB3zEAAzR/YoY='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Fri, 19 Aug 2022 14:51:28 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/IdentityApi/_submit_trn_/with_a_TRN_request/1_1_1_1.yml
+++ b/spec/cassettes/IdentityApi/_submit_trn_/with_a_TRN_request/1_1_1_1.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+  - request:
+      method: put
+      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Fri, 19 Aug 2022 14:51:27 GMT
+        Request-Context:
+          - appId=cid-v1:5aca65be-e52c-472b-8552-a925111002da
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-8uLzfcgnnD9mcHn8Gn07TkG9nPBfeIgB3zEAAzR/YoY='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Fri, 19 Aug 2022 14:51:28 GMT
+recorded_with: VCR 6.1.0

--- a/spec/services/identity_api_spec.rb
+++ b/spec/services/identity_api_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe IdentityApi do
+  describe ".submit_trn!" do
+    subject(:submit_trn!) do
+      described_class.submit_trn!(
+        trn_request,
+        "9ddccb62-ec13-4ea7-a163-c058a19b8222"
+      )
+    end
+
+    let(:trn_request) do
+      TrnRequest.new(
+        date_of_birth: "1990-01-01",
+        email: "kevin.e@example.com",
+        first_name: "kevin",
+        last_name: "E",
+        ni_number: "AA123456A",
+        trn: "2921020"
+      )
+    end
+
+    context "with a TRN request", vcr: true do
+      it { is_expected.to eq("") }
+    end
+
+    context "when the API returns a timeout error" do
+      before { FeatureFlag.activate(:identity_api_always_timeout) }
+
+      after { FeatureFlag.deactivate(:identity_api_always_timeout) }
+
+      it "raises a timeout error" do
+        VCR.turned_off do
+          expect { submit_trn! }.to raise_error(Faraday::TimeoutError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

After being redirected to Find A TRN from Identity and a TRN has been found, send an API request back to Identity with the TRN and then redirect to the supplied redirect uri.

### Changes proposed in this pull request

Creates a new API call to Identity to send the TRN for an Identity journey. Changes the controller logic to send the TRN back to Identity and redirect instead of continuing the Find A TRN process if the initial request came from Identity. If no matching TRN was found an API request will still be made with no TRN.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
