### PR TITLE
Add zendesk ticket deletion interface

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
     sidekiq-cron (1.7.0)
       fugit (~> 1)
       sidekiq (>= 4.2.1)
-    solargraph (0.45.0)
+    solargraph (0.46.0)
       backport (~> 1.2)
       benchmark
       bundler (>= 1.17.2)

--- a/app/assets/stylesheets/main.sass.scss
+++ b/app/assets/stylesheets/main.sass.scss
@@ -18,6 +18,14 @@ $govuk-new-link-styles: true;
   color: $govuk-link-colour;
 }
 
+.app-\!-font-tabular {
+  @include govuk-font($size: false, $tabular: true);
+}
+
+.app-\!-word-break-all {
+  word-break: break-all;
+}
+
 .app-govuk-related-navigation {
   @include govuk-text-colour;
   border-top: 2px solid $govuk-brand-colour;

--- a/app/controllers/support_interface/zendesk_controller.rb
+++ b/app/controllers/support_interface/zendesk_controller.rb
@@ -1,0 +1,14 @@
+module SupportInterface
+  class ZendeskController < SupportInterfaceController
+    def index
+      @zendesk_tickets =
+        Rails
+          .cache
+          .fetch("zendesk_tickets", expires_in: 1.hour) do
+            ZendeskService.find_closed_tickets_from_6_months_ago.map do |t|
+              ZendeskDeleteRequest.new.from(t)
+            end
+          end
+    end
+  end
+end

--- a/app/controllers/support_interface/zendesk_controller.rb
+++ b/app/controllers/support_interface/zendesk_controller.rb
@@ -25,7 +25,8 @@ module SupportInterface
         )
 
       if @delete_form.valid?
-        flash[:success] = "Successfully deleted #{@ticket_count} tickets"
+        DeleteOldZendeskTicketsJob.perform_later
+        flash[:success] = "Scheduled #{@ticket_count} tickets for deletion"
         redirect_to support_interface_zendesk_path
       else
         render :confirm_deletion

--- a/app/controllers/support_interface/zendesk_controller.rb
+++ b/app/controllers/support_interface/zendesk_controller.rb
@@ -10,5 +10,35 @@ module SupportInterface
             end
           end
     end
+
+    def confirm_deletion
+      @ticket_count = ZendeskService.find_closed_tickets_from_6_months_ago.count
+      @delete_form = ZendeskTicketDeletionForm.new
+    end
+
+    def destroy
+      @ticket_count = ZendeskService.find_closed_tickets_from_6_months_ago.count
+      @delete_form =
+        ZendeskTicketDeletionForm.new(
+          actual_number_of_tickets: @ticket_count.to_s,
+          number_of_tickets: destroy_params
+        )
+
+      if @delete_form.valid?
+        flash[:success] = "Successfully deleted #{@ticket_count} tickets"
+        redirect_to support_interface_zendesk_path
+      else
+        render :confirm_deletion
+      end
+    end
+
+    private
+
+    def destroy_params
+      params
+        .require(:support_interface_zendesk_ticket_deletion_form)
+        .fetch(:number_of_tickets)
+        .strip
+    end
   end
 end

--- a/app/forms/support_interface/zendesk_ticket_deletion_form.rb
+++ b/app/forms/support_interface/zendesk_ticket_deletion_form.rb
@@ -1,0 +1,12 @@
+module SupportInterface
+  class ZendeskTicketDeletionForm
+    include ActiveModel::Model
+
+    attr_accessor :actual_number_of_tickets, :number_of_tickets
+
+    validates :number_of_tickets,
+              comparison: {
+                equal_to: :actual_number_of_tickets
+              }
+  end
+end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -57,6 +57,11 @@
           href: support_interface_validation_errors_path,
           text: 'Validations',
         ) %>
+        <% header.navigation_item(
+          active: request.path.start_with?("/support/zendesk"),
+          href: support_interface_zendesk_path,
+          text: 'Zendesk',
+        ) %>
       <% end %>
     <% end %>
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -33,28 +33,29 @@
       <% case try(:current_namespace) %>
       <% when 'support_interface' %>
         <% header.navigation_item(
-          text: "TRNs",
-          href: support_interface_trn_requests_path,
           active: current_page?(support_interface_trn_requests_path),
+          href: support_interface_trn_requests_path,
+          text: "TRNs",
         ) %>
         <% header.navigation_item(
-          text: "Features",
+          active: current_page?(support_interface_features_path),
           href: support_interface_features_path,
-          active: current_page?(support_interface_features_path)
+          text: "Features",
         ) %>
         <% header.navigation_item(
-          text: "Staff",
+          active: request.path.start_with?("/support/staff"),
           href: support_interface_staff_index_path,
-          active: request.path.start_with?("/support/staff")
+          text: "Staff",
         ) %>
         <% header.navigation_item(
+          active: false,
+          href: support_interface_sidekiq_web_path,
           text: "Sidekiq",
-          href: support_interface_sidekiq_web_path
         ) %>
         <% header.navigation_item(
-          text: 'Validations',
           active: current_page?(support_interface_validation_errors_path),
           href: support_interface_validation_errors_path,
+          text: 'Validations',
         ) %>
       <% end %>
     <% end %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -33,7 +33,7 @@
       <% case try(:current_namespace) %>
       <% when 'support_interface' %>
         <% header.navigation_item(
-          text: "TRN Requests",
+          text: "TRNs",
           href: support_interface_trn_requests_path,
           active: current_page?(support_interface_trn_requests_path),
         ) %>
@@ -42,7 +42,7 @@
           href: support_interface_features_path,
           active: current_page?(support_interface_features_path)
         ) %>
-         <% header.navigation_item(
+        <% header.navigation_item(
           text: "Staff",
           href: support_interface_staff_index_path,
           active: request.path.start_with?("/support/staff")
@@ -52,9 +52,9 @@
           href: support_interface_sidekiq_web_path
         ) %>
         <% header.navigation_item(
+          text: 'Validations',
           active: current_page?(support_interface_validation_errors_path),
           href: support_interface_validation_errors_path,
-          text: 'Validation errors'
         ) %>
       <% end %>
     <% end %>

--- a/app/views/support_interface/zendesk/confirm_deletion.html.erb
+++ b/app/views/support_interface/zendesk/confirm_deletion.html.erb
@@ -7,7 +7,7 @@
       Delete <%= @ticket_count %> Zendesk tickets
     </h1>
 
-    <p>To confirm, type in the number of tickets that will be deleted below.</p>
+    <p>To confirm, enter the number of tickets that will be deleted.</p>
 
     <%= form_with model: @delete_form, url: support_interface_zendesk_confirm_deletion_path do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/support_interface/zendesk/confirm_deletion.html.erb
+++ b/app/views/support_interface/zendesk/confirm_deletion.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "#{'Error: ' if @delete_form.errors.any?}Confirm Zendesk ticket deletion" %>
+<%= content_for :back_link_url, support_interface_zendesk_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Delete <%= @ticket_count %> Zendesk tickets
+    </h1>
+
+    <p>To confirm, type in the number of tickets that will be deleted below.</p>
+
+    <%= form_with model: @delete_form, url: support_interface_zendesk_confirm_deletion_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field(
+        :number_of_tickets,
+        width: 5,
+        label: { tag: 'h2', size: 'm', text: 'Number of tickets to delete' },
+      ) %>
+      <%= f.govuk_submit "Delete #{ @ticket_count } tickets",
+        prevent_double_click: false,
+        warning: true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/zendesk/index.html.erb
+++ b/app/views/support_interface/zendesk/index.html.erb
@@ -43,8 +43,8 @@
           tag.span("Received at", class: 'govuk-caption-m')
       end
       row.cell(header: true) do
-        tag.span("Enquiry type") +
-          tag.span("No action required", class: 'govuk-caption-m')
+        tag.span("Tag: Enquiry type") +
+          tag.span("Tag: No action required", class: 'govuk-caption-m')
       end
     end
   end

--- a/app/views/support_interface/zendesk/index.html.erb
+++ b/app/views/support_interface/zendesk/index.html.erb
@@ -7,7 +7,7 @@
     </h1>
 
     <p>
-      The tickets below have not had any activity in the past 6 months and
+      The following tickets have not had any activity in the past 6 months and
       should be deleted. Deleted tickets are kept in Zendesk for a further 30
       days. They are then permanently deleted.
     </p>

--- a/app/views/support_interface/zendesk/index.html.erb
+++ b/app/views/support_interface/zendesk/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for :page_title, 'Zendesk ticket deletion' %>
+
+<h1 class="govuk-heading-l">
+  Zendesk tickets to be deleted
+  <span class="govuk-caption-l">
+    Showing <%= @zendesk_tickets.size %> total
+  </span>
+</h1>
+
+<%= govuk_table do |table|
+  table.head do |head|
+    head.row do |row|
+      row.cell(header: true, width: 'one-quarter') do
+        tag.span("Ticket link") +
+          tag.span("Group name", class: 'govuk-caption-m')
+      end
+      row.cell(header: true, width: 'one-third') do
+        tag.span("Closed at") +
+          tag.span("Received at", class: 'govuk-caption-m')
+      end
+      row.cell(header: true) do
+        tag.span("Enquiry type") +
+          tag.span("No action required", class: 'govuk-caption-m')
+      end
+    end
+  end
+
+  table.body do |body|
+    @zendesk_tickets.each do |ticket|
+      body.row do |row|
+        row.cell do
+          tag.a("Ticket #{ticket.ticket_id}",
+            class: 'govuk-link',
+            href: "https://teachingregulationagency.zendesk.com/agent/tickets/#{ticket.ticket_id}") +
+            tag.span(ticket.group_name, class: 'govuk-caption-m')
+        end
+        row.cell do
+          tag.span(ticket.closed_at, class: 'app-!-font-tabular') +
+            tag.span(ticket.received_at, class: 'app-!-font-tabular govuk-caption-m')
+        end
+        row.cell do
+          tag.code(ticket.enquiry_type, class: 'app-!-word-break-all') +
+            tag.span(ticket.no_action_required, class: 'govuk-caption-m')
+        end
+      end
+    end
+  end
+end %>

--- a/app/views/support_interface/zendesk/index.html.erb
+++ b/app/views/support_interface/zendesk/index.html.erb
@@ -1,11 +1,35 @@
-<% content_for :page_title, 'Zendesk ticket deletion' %>
+<% content_for :page_title, 'Zendesk tickets to be deleted' %>
 
-<h1 class="govuk-heading-l">
-  Zendesk tickets to be deleted
-  <span class="govuk-caption-l">
-    Showing <%= @zendesk_tickets.size %> total
-  </span>
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Zendesk tickets to be deleted
+    </h1>
+
+    <p>
+      The tickets below have not had any activity in the past 6 months and
+      should be deleted. Deleted tickets are kept in Zendesk for a further 30
+      days. They are then permanently deleted.
+    </p>
+
+    <p>
+      Find keeps a record of every deleted Zendesk ticket’s metadata.
+    </p>
+
+    <p>You will be asked to confirm before the tickets are deleted.</p>
+
+    <%= govuk_start_button(
+      text: 'Start',
+      href: support_interface_zendesk_confirm_deletion_path) %>
+
+    <h2 class="govuk-heading-m">
+      List of tickets to be deleted
+      <span class="govuk-caption-m">
+        Showing <%= @zendesk_tickets.size %> total
+      </span>
+    </h1>
+  </div>
+</div>
 
 <%= govuk_table do |table|
   table.head do |head|

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -20,7 +20,21 @@ class ExtendedDummyClient
   end
 
   def fetch
-    [ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)]
+    [
+      ZendeskAPI::Ticket.new(
+        GDS_ZENDESK_CLIENT,
+        id: 42,
+        created_at: (6.months + 8.days).ago,
+        updated_at: (6.months + 1.day).ago,
+        custom_fields: [
+          { id: 4_419_328_659_089, value: "Foo" },
+          { id: 4_562_126_876_049, value: "Bar" }
+        ],
+        group: {
+          name: "Some group"
+        }
+      )
+    ]
   end
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,3 +78,8 @@ en:
             itt_provider_name:
               blank: Enter your university, SCITT, school or other training provider
               too_long: Enter a school that is less than 255 letters long
+        support_interface/zendesk_ticket_deletion_form:
+          attributes:
+            number_of_tickets:
+              blank: Enter the number of tickets to delete
+              equal_to: "%{attribute} must be equal to %{count}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
         :as => :validation_error
 
     get "/zendesk", to: "zendesk#index"
+    get "/zendesk/confirm-deletion", to: "zendesk#confirm_deletion"
+    post "/zendesk/confirm-deletion", to: "zendesk#destroy"
 
     resources :trn_requests, only: [] do
       resource :zendesk_sync, only: [:create], controller: "zendesk_sync"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
     get "/validation-errors/:form_object" => "validation_errors#show",
         :as => :validation_error
 
+    get "/zendesk", to: "zendesk#index"
+
     resources :trn_requests, only: [] do
       resource :zendesk_sync, only: [:create], controller: "zendesk_sync"
     end

--- a/spec/system/zendesk_ticket_deletion_spec.rb
+++ b/spec/system/zendesk_ticket_deletion_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "Zendesk ticket deletion", type: :system do
+  before { given_the_service_is_open }
+  after { deactivate_feature_flags }
+
+  it "allows deleting outstanding Zendesk tickets", vcr: true do
+    given_i_am_authorized_as_a_support_user
+    when_i_visit_the_zendesk_support_page
+    then_i_should_see_a_ticket
+
+    when_i_click_start
+    then_i_should_see_the_confirmation_page
+
+    when_i_submit
+    then_i_should_see_a_validation_error
+
+    when_i_enter_the_number_of_tickets
+    and_i_submit
+    then_i_should_see_a_success_banner
+    and_a_job_to_delete_tickets_is_queued
+  end
+
+  private
+
+  def deactivate_feature_flags
+    FeatureFlag.deactivate(:service_open)
+  end
+
+  def given_the_service_is_open
+    FeatureFlag.activate(:service_open)
+  end
+
+  def given_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize(
+      ENV["SUPPORT_USERNAME"],
+      ENV["SUPPORT_PASSWORD"]
+    )
+  end
+
+  def when_i_visit_the_zendesk_support_page
+    visit support_interface_zendesk_path
+  end
+
+  def when_i_click_start
+    click_on "Start"
+  end
+
+  def when_i_submit
+    click_on "Delete 1 tickets"
+  end
+  alias_method :and_i_submit, :when_i_submit
+
+  def when_i_enter_the_number_of_tickets
+    fill_in "Number of tickets to delete", with: 1
+  end
+
+  def then_i_should_see_a_ticket
+    expect(page).to have_content "Ticket 42"
+  end
+
+  def then_i_should_see_the_confirmation_page
+    expect(page).to have_content "Delete 1 Zendesk tickets"
+  end
+
+  def then_i_should_see_a_validation_error
+    expect(page).to have_content "Error"
+  end
+
+  def then_i_should_see_a_success_banner
+    expect(page).to have_content "Success"
+  end
+
+  def and_a_job_to_delete_tickets_is_queued
+    expect(DeleteOldZendeskTicketsJob).to have_been_enqueued
+  end
+end


### PR DESCRIPTION
### Context

We need a way to call the `DeleteOldZendeskTicketsJob`.

### Changes proposed in this pull request

Add an interface in the Support app from which to call the job.

### Guidance to review

Review commit by commit, first few are not relevant to this work.

### Index

![image](https://user-images.githubusercontent.com/1650875/185952503-b46c3584-8fb9-47dc-9119-f77aae54b4da.png)

### Confirmation page

![image](https://user-images.githubusercontent.com/1650875/185952689-1d9411e6-963c-4575-b5cb-6402b6217e3d.png)

### After confirmation

![image](https://user-images.githubusercontent.com/1650875/185952744-499b9115-5d10-4378-8de2-e01687c35bb5.png)

### Checklist

- [x] Attach to Trello card https://trello.com/c/fOknaOcV/401-zendesk-technical-analysis-of-ticket-deletion-6-months
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally 
