### PR TITLE
Override Rails convention for credentials path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,5 +47,14 @@ module FindALostTrn
       auditor_class: "Staff",
       base_controller_class: "SupportInterface::SupportInterfaceController"
     }
+
+    config.credentials.content_path =
+      (
+        if ENV.fetch("HOSTING_ENVIRONMENT_NAME", "development") == "production"
+          "config/credentials/production.yml.enc"
+        else
+          "config/credentials.yml.enc"
+        end
+      )
   end
 end


### PR DESCRIPTION
The Rails convention for the location of the credentials file relies on
the RAILS_ENV matching a file in `config/credentials`.

We can't use that convention because all our hosted applications run
with `RAILS_ENV=production`.

As a short-term alternative, we can use `HOSTING_ENVIRONMENT_NAME` to
ensure that only the actual production app uses the production
encryption key.

Every other environment will use the key we use in development.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
