### PR TITLE
Pass in just UID to the UnlockTeacherAccountJob

### DIFF
--- a/app/jobs/unlock_teacher_account_job.rb
+++ b/app/jobs/unlock_teacher_account_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class UnlockTeacherAccountJob < ApplicationJob
-  def perform(teacher_account)
-    DqtApi.unlock_teacher!(teacher_account)
+  def perform(uid:)
+    DqtApi.unlock_teacher!(uid:)
   end
 end

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -27,7 +27,7 @@ class DqtApi
 
     teacher_account = results.first
 
-    UnlockTeacherAccountJob.perform_later(teacher_account)
+    UnlockTeacherAccountJob.perform_later(uid: teacher_account.fetch("uid"))
 
     teacher_account
   end
@@ -46,14 +46,10 @@ class DqtApi
     response.body["ittProviders"]
   end
 
-  def self.unlock_teacher!(teacher_account)
+  def self.unlock_teacher!(uid:)
     if FeatureFlag.active?(:unlock_teachers_self_service_portal_account)
       begin
-        response =
-          new.client.put(
-            "/v2/unlock-teacher/#{teacher_account.fetch("uid")}",
-            {}
-          )
+        response = new.client.put("/v2/unlock-teacher/#{uid}", {})
         raise ApiError, response.reason_phrase unless response.success?
       rescue ApiError => e
         Sentry.capture_exception(e)

--- a/spec/jobs/unlock_teacher_account_job_spec.rb
+++ b/spec/jobs/unlock_teacher_account_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe UnlockTeacherAccountJob, type: :job do
   describe "#perform" do
-    subject(:perform) { described_class.new.perform(teacher_account) }
+    subject(:perform) { described_class.new.perform(uid:) }
     let(:trn_request) do
       TrnRequest.new(
         date_of_birth: "1990-01-01",
@@ -12,17 +12,7 @@ RSpec.describe UnlockTeacherAccountJob, type: :job do
         ni_number: "1000000"
       )
     end
-    let(:teacher_account) do
-      {
-        "trn" => "2921020",
-        "emailAddresses" => ["anonymous@anonymousdomain.org.net.co.uk"],
-        "firstName" => "Kevin",
-        "lastName" => "Evans",
-        "dateOfBirth" => "1990-01-01",
-        "nationalInsuranceNumber" => "AA123456A",
-        "uid" => "f7891223-7661-e411-8047-005056822391"
-      }
-    end
+    let(:uid) { "f7891223-7661-e411-8047-005056822391" }
 
     before do
       FeatureFlag.activate(:unlock_teachers_self_service_portal_account)
@@ -38,7 +28,7 @@ RSpec.describe UnlockTeacherAccountJob, type: :job do
     context "retry unlock teacher account on client timeout", vcr: true do
       it "runs the unlock teacher job asynchronously" do
         expect { DqtApi.find_trn!(trn_request) }.not_to raise_error
-        expect(described_class).to have_been_enqueued.with(teacher_account)
+        expect(described_class).to have_been_enqueued.with(uid:)
       end
     end
   end

--- a/spec/services/dqt_api_spec.rb
+++ b/spec/services/dqt_api_spec.rb
@@ -91,22 +91,8 @@ RSpec.describe DqtApi do
       FeatureFlag.deactivate(:unlock_teachers_self_service_portal_account)
     end
 
-    subject(:unlock_teacher!) do
-      described_class.unlock_teacher!(teacher_account)
-    end
+    subject(:unlock_teacher!) { described_class.unlock_teacher!(uid:) }
     let(:uid) { "f7891223-7661-e411-8047-005056822391" }
-    let(:teacher_account_base) do
-      {
-        "trn" => "2921020",
-        "emailAddresses" => ["anonymous@anonymousdomain.org.net.co.uk"],
-        "firstName" => "Kevin",
-        "lastName" => "Evans",
-        "dateOfBirth" => "1990-01-01",
-        "nationalInsuranceNumber" => "AA123456A",
-        "uid" => uid
-      }
-    end
-    let(:teacher_account) { teacher_account_base }
 
     context "when teacher ID is found", vcr: true do
       it { is_expected.to be_nil }


### PR DESCRIPTION
We don't actually use the rest of the teacher_account information, and by passing it in as arguments, we risk leaking it to Sentry if the job fails to run.