### PR TITLE
Flip conditional for credentials.yml.enc

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,10 +50,10 @@ module FindALostTrn
 
     config.credentials.content_path =
       (
-        if ENV.fetch("HOSTING_ENVIRONMENT_NAME", "development") == "production"
-          "config/credentials/production.yml.enc"
-        else
+        if HostingEnvironment.test_environment?
           "config/credentials.yml.enc"
+        else
+          "config/credentials/production.yml.enc"
         end
       )
   end


### PR DESCRIPTION
The `dev` environment uses an encryption key that matches `config/credentials.yml.enc`.

The `test`, `preprod`, and `production` env all use an encryption key that matches `config/credentials/production.yml.enc`.

Because `dev` is the odd one out, we need to update the conditional.