### PR TITLE
Assign to config.console1984 instead of replacing the hash

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module HostingEnvironment
-  TEST_ENVIRONMENTS = %w[local test development].freeze
+  TEST_ENVIRONMENTS = %w[local test development review].freeze
   PRODUCTION_URL = "https://find-a-lost-trn.education.gov.uk/"
 
   def self.host

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,10 +43,9 @@ module FindALostTrn
 
     config.exceptions_app = routes
     config.console1984.ask_for_username_if_empty = true
-    config.audits1984 = {
-      auditor_class: "Staff",
-      base_controller_class: "SupportInterface::SupportInterfaceController"
-    }
+    config.audits1984.auditor_class = "Staff"
+    config.audits1984.base_controller_class =
+      "SupportInterface::SupportInterfaceController"
 
     config.credentials.content_path =
       (

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module FindALostTrn
     config.active_job.queue_adapter = :sidekiq
 
     config.exceptions_app = routes
-    config.console1984 = { ask_for_username_if_empty: true }
+    config.console1984.ask_for_username_if_empty = true
     config.audits1984 = {
       auditor_class: "Staff",
       base_controller_class: "SupportInterface::SupportInterfaceController"


### PR DESCRIPTION
Assigning to an existing hash doesn't replace existing default keys.
