### PR TITLE
Use ZendeskAPI destroy_many endpoint correctly

### DIFF
--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -25,7 +25,7 @@ class ZendeskService
   end
 
   def self.destroy_tickets!(ids)
-    GDS_ZENDESK_CLIENT.zendesk_client.tickets.destroy_many(ids:).fetch
+    ZendeskAPI::Ticket.destroy_many!(GDS_ZENDESK_CLIENT.zendesk_client, ids)
   end
 
   def self.ticket_template(trn_request)

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 RSpec.describe ZendeskService do
   let(:ticket_client) { GDS_ZENDESK_CLIENT.ticket }
   let(:zendesk_client) { GDS_ZENDESK_CLIENT.zendesk_client }
+  let(:zendesk_api_ticket) { ZendeskAPI::Ticket }
 
   describe ".ticket_template" do
     it "correctly formats a TRN request with no NI number" do
@@ -125,9 +126,7 @@ RSpec.describe ZendeskService do
     let(:ticket_id_2) { 13 }
 
     before do
-      allow(zendesk_client).to receive(:tickets).and_return(zendesk_client)
-      allow(zendesk_client).to receive(:destroy_many).and_return(zendesk_client)
-      allow(zendesk_client).to receive(:fetch).and_return([])
+      allow(zendesk_api_ticket).to receive(:destroy_many!).and_return([])
     end
 
     it { is_expected.to be_a(Array) }


### PR DESCRIPTION
The previous approach would send a GET request. This uses the `destroy_many!` endpoint correctly.

### Checklist

- [x] Attach to Trello card https://trello.com/c/fOknaOcV/401-zendesk-technical-analysis-of-ticket-deletion-6-months
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
