### PR TITLE
Remove smoke test in review environment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -59,11 +59,6 @@ jobs:
         with:
           message: |
             Review app deployed to ${{ steps.deploy.outputs.environment_url }}
-      - uses: ./.github/workflows/actions/smoke-test
-        id: smoke-test
-        with:
-          environment: review
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
   deploy_nonprod:
     name: Deploy to ${{ matrix.environment }} environment


### PR DESCRIPTION
### Context

Smoke test is not needed in the review environment. This PR removes the task in deploy_review workflow job.
