### PR TITLE
Implement custom layout with header displaying the `client_title` from Get an identity

### DIFF
--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -28,6 +28,7 @@ class IdentityController < ApplicationController
     session[:trn_request_id] = @trn_request.id
     session[:identity_journey_id] = allowed_create_params["journey_id"]
     session[:identity_redirect_uri] = allowed_create_params["redirect_uri"]
+    session[:client_title] = allowed_create_params["client_title"]
 
     redirect_to next_question_path
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,48 @@ module ApplicationHelper
   def shy_email(email)
     sanitize(email).scan(/\W?\w+/).join("&shy;").html_safe
   end
+
+  def custom_title(page_title)
+    return sanitize(session[:client_title]) if session[:client_title]
+
+    [page_title, t("service.name")].compact.join(" - ")
+  end
+
+  def custom_header
+    govuk_header(service_name: t("service.name")) do |header|
+      case try(:current_namespace)
+      when "support_interface"
+        header.navigation_item(
+          active: current_page?(support_interface_trn_requests_path),
+          href: support_interface_trn_requests_path,
+          text: "TRNs"
+        )
+        header.navigation_item(
+          active: current_page?(support_interface_features_path),
+          href: support_interface_features_path,
+          text: "Features"
+        )
+        header.navigation_item(
+          active: request.path.start_with?("/support/staff"),
+          href: support_interface_staff_index_path,
+          text: "Staff"
+        )
+        header.navigation_item(
+          active: false,
+          href: support_interface_sidekiq_web_path,
+          text: "Sidekiq"
+        )
+        header.navigation_item(
+          active: current_page?(support_interface_validation_errors_path),
+          href: support_interface_validation_errors_path,
+          text: "Validations"
+        )
+        header.navigation_item(
+          active: request.path.start_with?("/support/zendesk"),
+          href: support_interface_zendesk_path,
+          text: "Zendesk"
+        )
+      end
+    end
+  end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
+    <title><%= custom_title(yield(:page_title).presence) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -29,41 +29,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(service_name: t('service.name')) do |header| %>
-      <% case try(:current_namespace) %>
-      <% when 'support_interface' %>
-        <% header.navigation_item(
-          active: current_page?(support_interface_trn_requests_path),
-          href: support_interface_trn_requests_path,
-          text: "TRNs",
-        ) %>
-        <% header.navigation_item(
-          active: current_page?(support_interface_features_path),
-          href: support_interface_features_path,
-          text: "Features",
-        ) %>
-        <% header.navigation_item(
-          active: request.path.start_with?("/support/staff"),
-          href: support_interface_staff_index_path,
-          text: "Staff",
-        ) %>
-        <% header.navigation_item(
-          active: false,
-          href: support_interface_sidekiq_web_path,
-          text: "Sidekiq",
-        ) %>
-        <% header.navigation_item(
-          active: current_page?(support_interface_validation_errors_path),
-          href: support_interface_validation_errors_path,
-          text: 'Validations',
-        ) %>
-        <% header.navigation_item(
-          active: request.path.start_with?("/support/zendesk"),
-          href: support_interface_zendesk_path,
-          text: 'Zendesk',
-        ) %>
-      <% end %>
-    <% end %>
+    <%= custom_header %>
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -15,4 +15,25 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(result).to eq('alert&shy;"evil')
     end
   end
+
+  describe "#custom_title" do
+    it "Uses client_title if it is set" do
+      session[:client_title] = "Custom Client Title"
+      result = custom_title("Page Title")
+      expect(result).to eq("Custom Client Title")
+    end
+
+    it "Defaults to page_title if client_title is not set" do
+      result = custom_title("Page Title")
+      expect(result).to eq(
+        "Page Title - Find a lost teacher reference number (TRN)"
+      )
+    end
+
+    it "escapes evil input" do
+      session[:client_title] = '<script>alert("evil")</script>'
+      result = custom_title("Page Title")
+      expect(result).to eq("alert(\"evil\")")
+    end
+  end
 end

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -175,6 +175,14 @@ RSpec.describe "Identity", type: :system do
         )
       end
     end
+
+    context "custom client_title from get an identity" do
+      it "displays the client_title from get an identity journey" do
+        when_i_access_the_identity_endpoint_with_parameters
+        then_i_see_the_ask_for_trn_page
+        then_i_should_see_the_client_title_from_get_an_identity
+      end
+    end
   end
 
   private
@@ -321,6 +329,12 @@ RSpec.describe "Identity", type: :system do
     page = response.parsed_body
     expect(page).to have_content("Teacher reference number (TRN)")
     expect(page).to have_content(value)
+  end
+
+  def then_i_should_see_the_client_title_from_get_an_identity
+    follow_redirect!
+    page = response.parsed_body
+    expect(page).to have_content("The Client Title")
   end
 
   def and_i_am_redirected_to_the_error_page


### PR DESCRIPTION
[Trello Card](https://trello.com/c/svzIPqc8)

### Context

> Get an Identity is a single sign-on service that will hand over users to Find in order to enrich their profiles with additional information, such as their Names or TRN.

When users reach Find a lost TRN from Get an identity, Get an identity will give us a `client_title` param.

We should change the header title in Find to this.

### Changes proposed in this pull request

- Add `client_title` from Identity journey to session
- Create `custom_title` helper
- Replace title header ERB with `custom_title` method

### Guidance to review

- Users on the Get an identity journey see a customised title
- Make sure this doesn't introduce XSS or security vulnerabilities
  - There should be some tests testing evil input

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
