### PR TITLE
Unlock account tweaks

### DIFF
--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -74,4 +74,10 @@ class TrnRequest < ApplicationRecord
 
     !has_ni_number.nil? && !has_ni_number_was.nil?
   end
+
+  # Detect if the same email has successfully requested a different TRN
+  def previous_trn_success_for_email?
+    return false if trn.blank?
+    TrnRequest.where(email:).where.not(trn:).exists?
+  end
 end

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -27,7 +27,9 @@ class DqtApi
 
     teacher_account = results.first
 
-    UnlockTeacherAccountJob.perform_later(uid: teacher_account.fetch("uid"))
+    unless trn_request.previous_trn_success_for_email?
+      UnlockTeacherAccountJob.perform_later(uid: teacher_account.fetch("uid"))
+    end
 
     teacher_account
   end

--- a/spec/cassettes/DqtApi/_find_trn_/unlocking_a_teacher_account/enqueues_a_job_to_unlock_the_teacher_account.yml
+++ b/spec/cassettes/DqtApi/_find_trn_/unlocking_a_teacher_account/enqueues_a_job_to_unlock_the_teacher_account.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=kevin&nationalInsuranceNumber=AA123456A
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Tue, 30 Aug 2022 12:09:08 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-30T12:10:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 9585176b-19b2-4339-670b-95ce7062c1b1
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 b5a534d08b2c383ce078e25aff3f2348.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR3-C1
+        X-Amz-Cf-Id:
+          - GYtGHOa1MnxlWphnX2_EIgA0dOu63TngPZrMtaVBrY2wL91DfAE2gg==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Tue, 30 Aug 2022 12:09:08 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/DqtApi/_find_trn_/unlocking_a_teacher_account/when_there_is_a_previous_successful_trn_request_for_the_email_address/does_not_enqueue_a_job_to_unlock_the_teacher_account.yml
+++ b/spec/cassettes/DqtApi/_find_trn_/unlocking_a_teacher_account/when_there_is_a_previous_successful_trn_request_for_the_email_address/does_not_enqueue_a_job_to_unlock_the_teacher_account.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=kevin&nationalInsuranceNumber=AA123456A
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Tue, 30 Aug 2022 12:09:08 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "298"
+        X-Rate-Limit-Reset:
+          - "2022-08-30T12:10:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 065f26f6-4764-4b38-5216-3d97e4bfbfe2
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 368e5f2a7f5777c7bce3dc98a848df8a.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR3-C1
+        X-Amz-Cf-Id:
+          - KJPaWtY7oKm6ZM18cAkEONMrk7xUX5c6jYWZA3FaJckOt6xAkSlNOQ==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Tue, 30 Aug 2022 12:09:08 GMT
+recorded_with: VCR 6.1.0

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -112,4 +112,78 @@ RSpec.describe TrnRequest, type: :model do
       it { is_expected.to eq("John Smith") }
     end
   end
+
+  describe "#previous_trn_success_for_email?" do
+    subject(:trn_request) do
+      described_class.create(
+        first_name: "John",
+        last_name: "Doe",
+        previous_last_name: "Smith",
+        trn: "2921020",
+        email: "john.doe@example.com"
+      )
+    end
+
+    context "with no previous successful trn search for email address" do
+      it { expect(subject.previous_trn_success_for_email?).to be_falsey }
+    end
+
+    context "when there is no trn" do
+      it do
+        subject.trn = nil
+        expect(subject.previous_trn_success_for_email?).to be_falsey
+      end
+    end
+
+    context "when there is a previous successful trn search for the email address" do
+      context "with the same trn" do
+        let!(:previous_successful_trn_request) do
+          described_class.create(
+            first_name: "John",
+            last_name: "Doe",
+            previous_last_name: "Smith",
+            trn: "2921020",
+            email: "john.doe@example.com"
+          )
+        end
+
+        it { expect(trn_request.previous_trn_success_for_email?).to be_falsey }
+      end
+
+      context "with a different trn" do
+        let!(:previous_successful_trn_request) do
+          described_class.create(
+            first_name: "John",
+            last_name: "Doe",
+            previous_last_name: "Smith",
+            trn: "2921019",
+            email: "john.doe@example.com"
+          )
+        end
+
+        it { expect(trn_request.previous_trn_success_for_email?).to be_truthy }
+
+        context "and the current TrnRequest has no trn" do
+          it do
+            subject.trn = nil
+            expect(subject.previous_trn_success_for_email?).to be_falsey
+          end
+        end
+      end
+    end
+
+    context "when there is a previous no match trn search for the email address" do
+      let!(:previous_successful_trn_request) do
+        described_class.create(
+          first_name: "John",
+          last_name: "Doe",
+          previous_last_name: "Smith",
+          trn: nil,
+          email: "john.doe@example.com"
+        )
+      end
+
+      it { expect(trn_request.previous_trn_success_for_email?).to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
### Context

In addition to the existing criteria for unlocking someone's TSSP account (i.e. the TRN request has to be successful and the account doesn't have active sanctions) only unlock the account if the TRN requester email hasn't been used to find another TRN successfully.

### Changes proposed in this pull request

Adds an additional condition to only unlock an account if the email address has not been used previously to successfully find a trn.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
