### PR TITLE
Url encode email address parameter when checking Identity signature

### DIFF
--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -39,7 +39,7 @@ class IdentityController < ApplicationController
   end
 
   # Compare the signature provided by Identity with the signature calcuated
-  # using the recieved params. If they match then data has not been tampered with.
+  # using the received params. If they match then data has not been tampered with.
   def valid_identity_params?
     return false if expected_signature.blank? || new_signature.blank?
 
@@ -56,11 +56,10 @@ class IdentityController < ApplicationController
 
   # Encode each of the hash values and return a url paramter string, url_encode ensures
   # spaces are encoded as '%20' rather than '+' to match the encoding used by Identity.
-  # Skip the email attribute to avoid encoding the '@' character.
   def encoded_identity_params
     encoded_params =
       sorted_identity_params.flat_map do |k, v|
-        encoded_value = k == "email" ? v : ERB::Util.url_encode(v)
+        encoded_value = ERB::Util.url_encode(v)
         "#{k}=#{encoded_value}"
       end
 

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe "Identity", type: :system do
       client_title: "The Client Title",
       email: "kevin.e@example.com",
       journey_id: "9ddccb62-ec13-4ea7-a163-c058a19b8222",
-      sig: "F33FFCFCAD9511941D200954DA6B8A381C9BC4307BEABF4B8764EA0F88E95271"
+      sig: "2940250690ABB0055E0EF197E7C296BF5FF62587ECD7B39A2F88D08F3AC8A30E"
     }
 
     post identity_path, params:
@@ -197,7 +197,7 @@ RSpec.describe "Identity", type: :system do
       client_title: "New Title",
       email: "john.smith@example.com",
       journey_id: "9ddccb62-ec13-4ea7-a163-c058a19b8222",
-      sig: "F33FFCFCAD9511941D200954DA6B8A381C9BC4307BEABF4B8764EA0F88E95271"
+      sig: "2940250690ABB0055E0EF197E7C296BF5FF62587ECD7B39A2F88D08F3AC8A30E"
     }
 
     expect { post identity_path, params: }.to raise_error(


### PR DESCRIPTION
### Context

Parameters received by the Identity endpoint must be url encoded to build a parameter string that can then be signed using a shared key and compared to the accompanying signature. The email address is currently not being encoded and needs to be included as an encode parameter.

### Changes proposed in this pull request

Removes the code preventing the email address being encoded when creating the parameter string used to check the Identity signature.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
