### PR TITLE
Enable querying by email

### DIFF
--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -28,7 +28,13 @@
 #
 class TrnRequest < ApplicationRecord
   encrypts :email,
-           :first_name,
+           deterministic: {
+             fixed: false
+           },
+           previous: {
+             deterministic: false
+           }
+  encrypts :first_name,
            :last_name,
            :ni_number,
            :previous_first_name,

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,9 @@ module FindALostTrn
 
     config.active_job.queue_adapter = :sidekiq
 
+    config.active_record.encryption.extend_queries = true
+    config.active_record.encryption.store_key_references = true
+
     config.exceptions_app = routes
     config.console1984.ask_for_username_if_empty = true
     config.audits1984.auditor_class = "Staff"

--- a/db/data/20220830104609_re_encrypt_data.rb
+++ b/db/data/20220830104609_re_encrypt_data.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ReEncryptData < ActiveRecord::Migration[7.0]
+  def up
+    TrnRequest.find_each(&:encrypt)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20_220_809_085_018)
+DataMigrate::Data.define(version: 20_220_830_104_609)


### PR DESCRIPTION
The email field on a TrnRequest is encrypted using a non-deterministic
key, which makes querying it impossible.

Changing this is a 2-step process.

Firstly, we need to define the attribute as requiring a deterministic
key.

On its own, this would prevent us being able to access the email data
because Rails wouldn't be able to decrypt the field anymore as it is
expecting a derterministic key.

We can solve that by using the `previous` configuration option. This
allows us to specific the previous encryption scheme used on that field.

There is another configuration option that must be set as well, which is
`fixed: false`. This ensures that the encryption scheme can handle the
non-deterministic original values.

We then can re-encrypt all the existing data using a data migration.

The second part of this change will happen in a follow-up PR. We need to
remove the extra configuration options once the data migration has run
successfully. This will ensure that the email field is encrypted with a
deterministic key correctly for all future records.

Ideally, we'd deploy both sets of changes sequentially, at a time when
we don't expect there to be any new records created. To be certain that
this can't happen, I recommend that we disable the service during these
deployments.

Also, for local development, the same process needs to be followed if
you wish to preserve data that was encrypted with the previous scheme.

Alternatively, it is safe to reset the DB and start with fresh data.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
