### PR TITLE
Decrypt all data

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,8 @@ module FindALostTrn
 
     config.active_job.queue_adapter = :sidekiq
 
+    config.active_record.encryption.support_unencrypted_data = true
+
     config.exceptions_app = routes
     config.console1984.ask_for_username_if_empty = true
     config.audits1984.auditor_class = "Staff"

--- a/db/data/20220831084845_decrypt_all.rb
+++ b/db/data/20220831084845_decrypt_all.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DecryptAll < ActiveRecord::Migration[7.0]
+  def up
+    TrnRequest.find_each(&:decrypt)
+  end
+
+  def down
+    TrnRequest.find_each(&:encrypt)
+  end
+end


### PR DESCRIPTION
We want to encrypt the email field using a deterministic encryption
scheme. To get there, we need to re-encrypt it.

I propose doing this in 3 steps (structured in 3 separate PRs).

First, we decrypt all the TrnRequest data and re-introduce support for
unencrypted data to ensure the app continues to run as normal.

The second step is to configure the email field to use deterministic
encryption and then encrypt all the fields again.

Finally, the third step is to remove support for unencrypted data, so we
don't accidentally leave any data exposed in plaintext.

This process allows us to make changes to the encrypted fields without
introducing any downtime to the service.

The cost of this is that for the duration of time between deploying
steps 1 and 3, the data in the service will be unencrypted and viewable
as plaintext.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
