### PR TITLE
Query by TRN in Identity journey

### DIFF
--- a/app/controllers/ask_trn_controller.rb
+++ b/app/controllers/ask_trn_controller.rb
@@ -11,6 +11,15 @@ class AskTrnController < ApplicationController
   def create
     @ask_trn_form = AskTrnForm.new(trn_request:)
     if @ask_trn_form.update(trn_params)
+      begin
+        find_trn_using_api unless @trn_request.trn
+      rescue DqtApi::ApiError,
+             Faraday::ConnectionFailed,
+             Faraday::TimeoutError => e
+        Sentry.capture_exception(e)
+      rescue DqtApi::TooManyResults, DqtApi::NoResults
+        # Do nothing.
+      end
       next_question
     else
       render :new
@@ -21,5 +30,13 @@ class AskTrnController < ApplicationController
 
   def trn_params
     params.require(:ask_trn_form).permit(:do_you_know_your_trn, :trn_from_user)
+  end
+
+  def find_trn_using_api
+    response = DqtApi.find_trn!(@trn_request)
+    @trn_request.update!(
+      trn: response["trn"],
+      has_active_sanctions: response["hasActiveSanctions"]
+    )
   end
 end

--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -68,7 +68,8 @@ class DqtApi
       lastName: trn_request.last_name,
       previousFirstName: trn_request.previous_first_name,
       previousLastName: trn_request.previous_last_name,
-      nationalInsuranceNumber: trn_request.ni_number
+      nationalInsuranceNumber: trn_request.ni_number,
+      trn: trn_request.trn_from_user
     }.compact
   end
 

--- a/spec/cassettes/Identity/ask_for_TRN_page/asks_for_QTS_if_they_do_not_match_on_any_criteria.yml
+++ b/spec/cassettes/Identity/ask_for_TRN_page/asks_for_QTS_if_they_do_not_match_on_any_criteria.yml
@@ -1,0 +1,115 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1999-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 31 Aug 2022 16:12:22 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "296"
+        X-Rate-Limit-Reset:
+          - "2022-08-31T16:13:00.0000000Z"
+        X-Vcap-Request-Id:
+          - ecf3f435-c089-41b3-6647-1972dd86a476
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 50ef760066390594318a8cc54c245fd2.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - 9RqLeVo7aA-F7k4JiYdHM9mZL1JHAB2Rco6PDzCjm5ROFWRim_C3VQ==
+      body:
+        encoding: UTF-8
+        string: '{"results":[]}'
+    recorded_at: Wed, 31 Aug 2022 16:12:22 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1999-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E&trn=1234567
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 31 Aug 2022 16:12:22 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "295"
+        X-Rate-Limit-Reset:
+          - "2022-08-31T16:13:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 86a6ea44-d653-45fc-4f17-2c63553a27f7
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 1c6be95f21b3cc0cf77147b4aa61e7c2.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - RDcjZWBr7lQ2v089G2kh-PtjBvHbk-4ywSLCE6f7ky34rx-htzrnyA==
+      body:
+        encoding: UTF-8
+        string: '{"results":[]}'
+    recorded_at: Wed, 31 Aug 2022 16:12:22 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity/ask_for_TRN_page/asks_if_they_don_t_match_on_other_criteria.yml
+++ b/spec/cassettes/Identity/ask_for_TRN_page/asks_if_they_don_t_match_on_other_criteria.yml
@@ -1,0 +1,115 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1999-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 31 Aug 2022 16:12:22 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-31T16:13:00.0000000Z"
+        X-Vcap-Request-Id:
+          - bfe58d7f-1949-4de7-7e6d-ef0f639038db
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 5f684ddc3ff7bc889dac29fa9e51915a.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - 4M8hx0pre_OJ-LuBr71ervzMKrocCeTmc8rd2_M4TculmwAVS3KrPA==
+      body:
+        encoding: UTF-8
+        string: '{"results":[]}'
+    recorded_at: Wed, 31 Aug 2022 16:12:22 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1999-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E&trn=2921020
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 31 Aug 2022 16:12:22 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "298"
+        X-Rate-Limit-Reset:
+          - "2022-08-31T16:13:00.0000000Z"
+        X-Vcap-Request-Id:
+          - adac29d7-fcc9-4bd8-7296-b78a113c9f0a
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 dc934eeca08c60e0878cc8271c2e7428.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - Uq0ObyxXLsKyzptGEdnpEAf2-0NMRiBBXa6ayKqiqyKQygDShZoCKA==
+      body:
+        encoding: UTF-8
+        string: '{"results":[]}'
+    recorded_at: Wed, 31 Aug 2022 16:12:22 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity/ask_for_TRN_page/does_not_ask_if_they_match_on_other_criteria.yml
+++ b/spec/cassettes/Identity/ask_for_TRN_page/does_not_ask_if_they_match_on_other_criteria.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 31 Aug 2022 16:12:22 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "297"
+        X-Rate-Limit-Reset:
+          - "2022-08-31T16:13:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 4df72007-4eab-49c6-6f41-1f68502f66f3
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 5778022b3a2272b3eca05304cf962166.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - "-pMV2L4WOgq6JoYT27_P6DrzWcXhakfaShFLIVM0_G6UeUEmZxnlfQ=="
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Wed, 31 Aug 2022 16:12:22 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity/ask_for_TRN_page/matches_if_they_don_t_match_on_other_criteria.yml
+++ b/spec/cassettes/Identity/ask_for_TRN_page/matches_if_they_don_t_match_on_other_criteria.yml
@@ -1,0 +1,115 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1999-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 31 Aug 2022 16:36:46 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-31T16:37:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 79e7620b-39ee-4277-54fe-476243f8fc8c
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 eee2eabf1d5db87be015bf39b123f234.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - OcH9Om81FTQ9jJlecnP34IW4oMvWXpIfp64cmQbxJ91Y0tRdYt9T7A==
+      body:
+        encoding: UTF-8
+        string: '{"results":[]}'
+    recorded_at: Wed, 31 Aug 2022 16:36:46 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1999-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E&trn=2921020
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 31 Aug 2022 16:36:46 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "298"
+        X-Rate-Limit-Reset:
+          - "2022-08-31T16:37:00.0000000Z"
+        X-Vcap-Request-Id:
+          - e355584a-7fd8-440d-6217-fc4fb59517f0
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 5778022b3a2272b3eca05304cf962166.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - dFeWlmwckCPQ7ckZpDUpi35_iPYJHAg8CA5KM2Pvg64O1yOo_9mYGQ==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Wed, 31 Aug 2022 16:36:46 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
### Context

We want to query the `qualified-teachers-api` with a user submitted TRN during the identity journey to improve the chances of a match.

### Changes proposed in this pull request

Query for a TRN using the user submitted TRN after the ask for TRN page.

### Guidance to review

Review without whitespace.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
