### PR TITLE
Customise govuk_header with title from Identity

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,13 +31,11 @@ module ApplicationHelper
   end
 
   def custom_title(page_title)
-    return sanitize(session[:client_title]) if session[:client_title]
-
-    [page_title, t("service.name")].compact.join(" - ")
+    [page_title, service_name].compact.join(" - ")
   end
 
   def custom_header
-    govuk_header(service_name: t("service.name")) do |header|
+    govuk_header(service_name:) do |header|
       case try(:current_namespace)
       when "support_interface"
         header.navigation_item(
@@ -71,6 +69,14 @@ module ApplicationHelper
           text: "Zendesk"
         )
       end
+    end
+  end
+
+  def service_name
+    if session[:client_title]
+      sanitize(session[:client_title])
+    else
+      t("service.name")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "Uses client_title if it is set" do
       session[:client_title] = "Custom Client Title"
       result = custom_title("Page Title")
-      expect(result).to eq("Custom Client Title")
+      expect(result).to eq("Page Title - Custom Client Title")
     end
 
     it "Defaults to page_title if client_title is not set" do
@@ -33,7 +33,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "escapes evil input" do
       session[:client_title] = '<script>alert("evil")</script>'
       result = custom_title("Page Title")
-      expect(result).to eq("alert(\"evil\")")
+      expect(result).to eq("Page Title - alert(\"evil\")")
     end
   end
 end


### PR DESCRIPTION
The `govuk_header` service name should be bespoke during the Identity journey, so that users feel like they are going through a single connected service.

Also ensure the `page_title` comes up prefixed in the actual `<title>`.

I couldn't test this end to end locally and coming up with a solution for that was taking too much time, so I opted to skip on those improvements for now.