### PR TITLE
Fix back link on Name page in Identity journey

### DIFF
--- a/app/views/name/edit.html.erb
+++ b/app/views/name/edit.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title, "#{'Error: ' if @name_form.errors.any?}Your name" %>
-<% content_for :back_link_url, back_link_url(email_path) %>
+<% content_for :back_link_url, back_link_url(
+  @trn_request.from_get_an_identity ? url_for(:back) : email_path
+) %>
 
 <%= form_with model: @name_form, url: name_path do |f| %>
   <%= f.govuk_error_summary %>


### PR DESCRIPTION
The back link is meant to lead to the email page, but that's not accessible during the Identity journey.

Instead, we can specify `:back` to use the browser's HTTP Referer where available, so they can go back to the previous Identity page. I am not 100% sure if that will work in practice, but we can figure that out.
