### PR TITLE
Update validation message for date_of_birth blank

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
         date_of_birth_form:
           attributes:
             date_of_birth:
-              blank: Enter your date of birth, formatted as a number
+              blank: Enter your date of birth
               born_after_1900: Enter a year of birth later than 1900
               inclusion: You must be 16 or over to use this service
               missing_day: Enter a day for your date of birth, formatted as a number

--- a/spec/forms/date_of_birth_form_spec.rb
+++ b/spec/forms/date_of_birth_form_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe DateOfBirthForm, type: :model do
       it "adds an error" do
         update!
         expect(date_of_birth_form.errors[:date_of_birth]).to eq(
-          ["Enter your date of birth, formatted as a number"]
+          ["Enter your date of birth"]
         )
       end
 


### PR DESCRIPTION
"Formatted as a number" shouldn't be part of the content.
