### PR TITLE
Remove email message when from Identity

### DIFF
--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -2,7 +2,9 @@
 <%= content_for :back_link_url, back_link_url %>
 
 <h1 class="govuk-heading-xl">Check your answers</h1>
-<p class="govuk-body">We will send your TRN to <%= @trn_request.email %> if we find one matching your details.</p>
+<% unless @trn_request.from_get_an_identity? %>
+  <p class="govuk-body">We will send your TRN to <%= @trn_request.email %> if we find one matching your details.</p>
+<% end %>
 
 <%= render(TrnDetailsComponent.new(trn_request: @trn_request, actions: true)) %>
 

--- a/spec/cassettes/TRN_requests/when_user_is_not_coming_from_an_identity_journey/shows_a_message_about_sending_an_email_on_the_check_answers_page.yml
+++ b/spec/cassettes/TRN_requests/when_user_is_not_coming_from_an_identity_journey/shows_a_message_about_sending_an_email_on_the_check_answers_page.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin@kevin.com&firstName=Kevin&lastName=E
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 401
+        message: Unauthorized
+      headers:
+        Content-Length:
+          - "0"
+        Connection:
+          - keep-alive
+        Date:
+          - Thu, 01 Sep 2022 13:39:47 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-01T13:40:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 3cba5bf0-f8da-481d-630b-de0f4506a56f
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Error from cloudfront
+        Via:
+          - 1.1 ce084a1179392e1921b98c60a4590284.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR62-C5
+        X-Amz-Cf-Id:
+          - 7Bbo-nHTKhLO39bCFbxrvE9Yw4FXBHV9xuwgvq1jV4qzJN_D-QHPLg==
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Thu, 01 Sep 2022 13:39:47 GMT
+recorded_with: VCR 6.1.0

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -501,6 +501,15 @@ RSpec.describe "TRN requests", type: :system do
     end
   end
 
+  context "when user is not coming from an identity journey" do
+    it "shows a message about sending an email on the check answers page",
+       vcr: true do
+      given_i_have_completed_a_trn_request
+      then_i_see_the_check_answers_page
+      and_i_see_a_message_about_sending_an_email
+    end
+  end
+
   private
 
   def and_a_job_gets_queued_to_retry_the_zendesk_ticket_creation
@@ -679,6 +688,12 @@ RSpec.describe "TRN requests", type: :system do
     )
     expect(page).to have_content("Check your answers")
     and_i_see_my_not_matching_details
+  end
+
+  def and_i_see_a_message_about_sending_an_email
+    expect(page).to have_content(
+      "We will send your TRN to kevin@kevin.com if we find one matching your details."
+    )
   end
 
   def then_i_see_my_not_matching_details


### PR DESCRIPTION
### Context

The message shown on the check answers page to inform the user that an email will be sent on a successful TRN match is not needed for the Identity journey.

### Changes proposed in this pull request

Adds a conditional to not show the email message when the journey is from Identity.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
