### PR TITLE
Add support page to simulate an Identity session

### DIFF
--- a/app/controllers/support_interface/identity_controller.rb
+++ b/app/controllers/support_interface/identity_controller.rb
@@ -1,0 +1,46 @@
+module SupportInterface
+  class IdentityController < SupportInterfaceController
+    def new
+      @identity_params = IdentityParamsForm.new
+      @identity_params.client_title =
+        "Register for a National Professional Qualification"
+      @identity_params.email = "kevin.e@example.com"
+      @identity_params.journey_id = journey_id
+      @identity_params.redirect_uri = redirect_uri
+    end
+
+    def confirm
+      @identity_params = {
+        client_title: create_params[:client_title],
+        email: create_params[:email],
+        journey_id:,
+        redirect_uri:
+      }
+      sig = Identity.signature_from(@identity_params)
+      @identity_params[:sig] = sig
+    end
+
+    def callback
+      flash[:success] = "You have completed a simulated Identity journey"
+
+      redirect_to support_interface_identity_path
+    end
+
+    private
+
+    def create_params
+      params.require(:support_interface_identity_params_form).permit(
+        :client_title,
+        :email
+      )
+    end
+
+    def journey_id
+      "9ddccb62-ec13-4ea7-a163-c058a19b8222"
+    end
+
+    def redirect_uri
+      support_interface_identity_callback_path
+    end
+  end
+end

--- a/app/forms/support_interface/identity_params_form.rb
+++ b/app/forms/support_interface/identity_params_form.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class IdentityParamsForm
+    include ActiveModel::Model
+
+    attr_accessor :client_title, :email, :journey_id, :redirect_uri
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,6 +52,11 @@ module ApplicationHelper
           text: "Features"
         )
         header.navigation_item(
+          active: current_page?(support_interface_identity_path),
+          href: support_interface_identity_path,
+          text: "Identity"
+        )
+        header.navigation_item(
           active: request.path.start_with?("/support/staff"),
           href: support_interface_staff_index_path,
           text: "Staff"

--- a/app/lib/identity.rb
+++ b/app/lib/identity.rb
@@ -1,0 +1,24 @@
+class Identity
+  def self.signature_from(params)
+    OpenSSL::HMAC.hexdigest(
+      OpenSSL::Digest.new("sha256"),
+      ENV["IDENTITY_SHARED_SECRET_KEY"],
+      encode_params(params)
+    )
+  end
+
+  # Encode each of the hash values and return a url parameter string.
+  # url_encode ensures spaces are encoded as '%20' rather than '+' to match the
+  # encoding used by Identity.
+  def self.encode_params(params)
+    sorted_params = params.to_hash.sort # Keys must be in alphabetical order.
+
+    encoded_params =
+      sorted_params.flat_map do |k, v|
+        encoded_value = ERB::Util.url_encode(v)
+        "#{k}=#{encoded_value}"
+      end
+
+    encoded_params.join("&")
+  end
+end

--- a/app/views/support_interface/identity/confirm.html.erb
+++ b/app/views/support_interface/identity/confirm.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, "Simulate an Identity session" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Confirm session
+    </h1>
+
+    <p>
+      Submit this form to <code>POST /identity</code> with the following
+      params.
+    </p>
+
+    <%= form_with url: identity_path do |f| %>
+      <%
+        rows = @identity_params.map do |k, v|
+          {
+            key: { text: k },
+            value: { text: v }
+          }
+        end
+      %>
+      <%= govuk_summary_list(rows: rows) %>
+
+      <% @identity_params.each do |k, value| %>
+        <%= f.hidden_field k.to_sym, value: %>
+      <% end %>
+
+      <%= f.govuk_submit "Submit", prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/identity/new.html.erb
+++ b/app/views/support_interface/identity/new.html.erb
@@ -1,0 +1,39 @@
+<% content_for :page_title, "Simulate an Identity journey" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Simulate an Identity journey
+    </h1>
+
+    <p>
+      Use this form to simulate a Get an Identity journey for testing purposes.
+    </p>
+
+    <%= form_with model: @identity_params, url: support_interface_identity_confirm_path do |f| %>
+      <%= f.govuk_text_field(:client_title,
+        label: { size: 's', text: 'Client title' },
+        hint: { text: 'Will be displayed in the page <title> and the header' }
+      ) %>
+      <%= f.govuk_text_field(:email,
+        label: { size: 's', text: 'Email' },
+        hint: { text: 'Used by matching' }
+      ) %>
+      <%= f.govuk_text_field(:journey_id,
+        disabled: true,
+        label: { size: 's', text: 'Journey ID' },
+        hint: { text: "Used by Get an Identity to match up the user’s \
+                session. Editing is disabled for simulated journeys  \
+                because we don’t use it." }
+      ) %>
+      <%= f.govuk_text_field(:redirect_uri,
+        disabled: true,
+        label: { size: 's', text: 'Redirect URI' },
+        hint: { text: "Callback URL to the Identity server. Editing is \
+                disabled for simulated journeys because simulated journeys \
+                should always return to Find." }
+      ) %>
+      <%= f.govuk_submit "Continue", prevent_double_click: false %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,10 @@ Rails.application.routes.draw do
     get "/zendesk/confirm-deletion", to: "zendesk#confirm_deletion"
     post "/zendesk/confirm-deletion", to: "zendesk#destroy"
 
+    get "/identity", to: "identity#new"
+    post "/identity/confirm", to: "identity#confirm"
+    get "/identity/callback", to: "identity#callback"
+
     resources :trn_requests, only: [] do
       resource :zendesk_sync, only: [:create], controller: "zendesk_sync"
     end

--- a/spec/lib/identity_spec.rb
+++ b/spec/lib/identity_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Identity do
+  describe "#signature_from" do
+    it "computes a SHA256 HMAC signature from a set of params" do
+      sig = described_class.signature_from({ foo: "bar" })
+      expect(sig).to eq(
+        "e037a467e455d7847d50df4a6fa3b1c2ebfa4234b19cb7b2a220f1ffbfe9fdb8"
+      )
+    end
+  end
+
+  describe "#encode_params" do
+    it "encodes params" do
+      encoded_params = described_class.encode_params({ foo: "bar" })
+      expect(encoded_params).to eq("foo=bar")
+    end
+  end
+end

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -4,44 +4,50 @@ require "rails_helper"
 RSpec.describe "Identity", type: :system do
   before do
     given_the_service_is_open
+    given_i_am_authorized_as_a_support_user
     given_the_identity_endpoint_is_open
   end
 
   after { deactivate_feature_flags }
 
-  it "verifies the parameters" do
-    when_i_access_the_identity_endpoint_with_parameters
+  it "redirects to name page when parameters are verified correctly" do
+    when_i_access_the_identity_endpoint
     then_i_see_the_name_page
   end
 
   it "does not verify with modified parameters" do
+    given_the_service_is_open
     when_i_access_the_identity_endpoint_with_modified_parameters_it_raises_an_error
   end
 
   it "does not allow user to change their email" do
-    when_i_access_the_identity_endpoint_with_parameters
+    when_i_access_the_identity_endpoint
     then_i_see_the_name_page
+
     when_i_try_to_go_to_the_email_page
     then_i_see_the_name_page
   end
 
   it "does not ask for an email address", vcr: true do
-    when_i_access_the_identity_endpoint_with_parameters
+    when_i_access_the_identity_endpoint
     then_i_see_the_name_page
+
     when_i_complete_and_submit_the_name_form
     then_i_see_the_date_of_birth_page
+
     when_i_complete_and_submit_my_date_of_birth
     then_i_see_the_check_answers_page
   end
 
   context "when sending the trn to the Identity API" do
     it "redirects back to Get An Identity", vcr: true do
-      when_i_access_the_identity_endpoint_with_parameters
+      when_i_access_the_identity_endpoint
       and_i_complete_and_submit_the_name_form
       and_i_complete_and_submit_my_date_of_birth
       then_i_see_the_check_answers_page
+
       when_i_press_the_continue_button
-      then_i_am_redirected_back_to_get_an_identity
+      then_i_am_redirected_to_the_callback
     end
 
     context "when there is no trn match", vcr: true do
@@ -49,25 +55,23 @@ RSpec.describe "Identity", type: :system do
         allow(DqtApi).to receive(:find_trn!).and_raise(DqtApi::NoResults)
       end
 
-      it "does not ask for an email address" do
-        when_i_access_the_identity_endpoint_with_parameters
-        then_i_see_the_name_page
-        when_i_complete_and_submit_the_name_form
-        then_i_see_the_date_of_birth_page
-        when_i_complete_and_submit_my_date_of_birth
-        then_i_see_the_have_ni_number_page
-        when_i_have_a_ni_number
-        then_i_see_the_ni_number_page
-        when_i_complete_and_submit_my_ni_number
+      it "asks for the TRN" do
+        when_i_access_the_identity_endpoint
+        and_i_complete_and_submit_the_name_form
+        and_i_complete_and_submit_my_date_of_birth
+        and_i_have_a_ni_number
+        and_i_complete_and_submit_my_ni_number
         then_i_see_the_ask_trn_page
+
         when_i_do_not_know_the_trn
         then_i_see_the_have_awarded_qts_page
+
         when_i_have_not_been_awarded_qts
         then_i_see_the_check_answers_page
       end
 
       it "sends a blank trn to Get an Identity and redirects back Get An Identity" do
-        when_i_access_the_identity_endpoint_with_parameters
+        when_i_access_the_identity_endpoint
         and_i_complete_and_submit_the_name_form
         and_i_complete_and_submit_my_date_of_birth
         and_i_have_a_ni_number
@@ -75,14 +79,16 @@ RSpec.describe "Identity", type: :system do
         and_i_do_not_know_the_trn
         and_i_have_not_been_awarded_qts
         then_i_see_the_check_answers_page
+
         when_i_press_the_continue_button
         then_i_see_the_no_match_page
+
         when_i_submit_anyway
-        then_i_am_redirected_back_to_get_an_identity
+        then_i_am_redirected_to_the_callback
       end
 
       it "has the correct no match page copy for Get an Identity journey" do
-        when_i_access_the_identity_endpoint_with_parameters
+        when_i_access_the_identity_endpoint
         and_i_complete_and_submit_the_name_form
         and_i_complete_and_submit_my_date_of_birth
         and_i_have_a_ni_number
@@ -90,9 +96,10 @@ RSpec.describe "Identity", type: :system do
         and_i_do_not_know_the_trn
         and_i_have_not_been_awarded_qts
         then_i_see_the_check_answers_page
+
         when_i_press_the_continue_button
         then_i_see_the_no_match_page
-        and_i_see_the_correct_no_match_copy
+        and_i_see_the_correct_no_match_content
       end
     end
 
@@ -105,14 +112,11 @@ RSpec.describe "Identity", type: :system do
       after { FeatureFlag.deactivate(:identity_api_always_timeout) }
 
       it "redirects to the error page", vcr: true do
-        when_i_access_the_identity_endpoint_with_parameters
+        when_i_access_the_identity_endpoint
         and_i_complete_and_submit_the_name_form
         and_i_complete_and_submit_my_date_of_birth
-        and_i_have_a_ni_number
-        and_i_complete_and_submit_my_ni_number
-        and_i_have_not_been_awarded_qts
         then_i_see_the_check_answers_page
-        and_i_see_a_continue_button
+
         when_i_press_the_continue_button
         then_sentry_receives_a_warning_about_the_failure
         and_i_am_redirected_to_the_error_page
@@ -122,7 +126,7 @@ RSpec.describe "Identity", type: :system do
 
   context "ask for TRN page" do
     it "matches if they don't match on other criteria", vcr: true do
-      when_i_access_the_identity_endpoint_with_parameters
+      when_i_access_the_identity_endpoint
       then_i_see_the_name_page
 
       when_i_complete_and_submit_the_name_form
@@ -139,7 +143,7 @@ RSpec.describe "Identity", type: :system do
     end
 
     it "does not ask if they match on other criteria", vcr: true do
-      when_i_access_the_identity_endpoint_with_parameters
+      when_i_access_the_identity_endpoint
       then_i_see_the_name_page
 
       when_i_complete_and_submit_the_name_form
@@ -150,7 +154,7 @@ RSpec.describe "Identity", type: :system do
     end
 
     it "asks for QTS if they do not match on any criteria", vcr: true do
-      when_i_access_the_identity_endpoint_with_parameters
+      when_i_access_the_identity_endpoint
       then_i_see_the_name_page
 
       when_i_complete_and_submit_the_name_form
@@ -169,31 +173,18 @@ RSpec.describe "Identity", type: :system do
 
   context "custom client_title from get an identity" do
     it "displays the client_title from get an identity journey" do
-      when_i_access_the_identity_endpoint_with_parameters
+      when_i_access_the_identity_endpoint
       then_i_see_the_name_page
       then_i_should_see_the_client_title_from_get_an_identity
     end
   end
 
-  it "renders a link to the calling service" do
-    when_i_access_the_identity_endpoint_with_parameters
-    then_i_see_the_name_page
-    and_it_links_to_the_calling_service
-  end
-
   private
 
-  def when_i_access_the_identity_endpoint_with_parameters
-    params = {
-      client_title: "The Client Title",
-      client_url: "https://clienturi/",
-      email: "kevin.e@example.com",
-      journey_id: "9ddccb62-ec13-4ea7-a163-c058a19b8222",
-      redirect_uri: "https://authserveruri/",
-      sig: "2b92f4e7c5d22e3627f477ade69fd0a8f2c0f948c33572d53ebaece8534f858b"
-    }
-
-    post identity_path, params:
+  def when_i_access_the_identity_endpoint
+    visit support_interface_identity_path
+    click_on "Continue"
+    click_on "Submit"
   end
 
   def when_i_access_the_identity_endpoint_with_modified_parameters_it_raises_an_error
@@ -211,122 +202,87 @@ RSpec.describe "Identity", type: :system do
   end
 
   def when_i_complete_and_submit_the_name_form
-    post "/name",
-         params: {
-           name_form: {
-             first_name: "Kevin",
-             last_name: "E",
-             name_changed: false
-           }
-         }
+    fill_in "First name", with: "Kevin"
+    fill_in "Last name", with: "E"
+    choose "No, I’ve not changed my name", visible: false
+    click_on "Continue"
   end
   alias_method :and_i_complete_and_submit_the_name_form,
                :when_i_complete_and_submit_the_name_form
 
   def when_i_complete_and_submit_my_date_of_birth
-    post "/date-of-birth",
-         params: {
-           date_of_birth_form: {
-             "date_of_birth(3i)" => "1",
-             "date_of_birth(2i)" => "1",
-             "date_of_birth(1i)" => "1990"
-           }
-         }
+    fill_in "Day", with: "01"
+    fill_in "Month", with: "01"
+    fill_in "Year", with: "1990"
+    click_on "Continue"
   end
   alias_method :and_i_complete_and_submit_my_date_of_birth,
                :when_i_complete_and_submit_my_date_of_birth
 
   def when_i_complete_and_submit_my_wrong_date_of_birth
-    post "/date-of-birth",
-         params: {
-           date_of_birth_form: {
-             "date_of_birth(3i)" => "1",
-             "date_of_birth(2i)" => "1",
-             "date_of_birth(1i)" => "1999"
-           }
-         }
+    fill_in "Day", with: "01"
+    fill_in "Month", with: "01"
+    fill_in "Year", with: "1999"
+    click_on "Continue"
   end
 
   def when_i_have_a_ni_number
-    post "/have-ni-number",
-         params: {
-           has_ni_number_form: {
-             has_ni_number: true
-           }
-         }
+    choose "Yes", visible: false
+    click_on "Continue"
   end
   alias_method :and_i_have_a_ni_number, :when_i_have_a_ni_number
 
   def when_i_dont_have_a_ni_number
-    post "/have-ni-number",
-         params: {
-           has_ni_number_form: {
-             has_ni_number: false
-           }
-         }
+    choose "No", visible: false
+    click_on "Continue"
   end
 
   def when_i_complete_and_submit_my_ni_number
-    post "/ni-number",
-         params: {
-           ni_number_form: {
-             ni_number: "AA123456A"
-           },
-           submit: "submit"
-         }
+    fill_in "What is your National Insurance number?", with: "AA123456A"
+    click_on "Continue"
   end
   alias_method :and_i_complete_and_submit_my_ni_number,
                :when_i_complete_and_submit_my_ni_number
 
   def when_i_do_not_know_the_trn
-    post "/ask-trn", params: { ask_trn_form: { do_you_know_your_trn: false } }
+    choose "No, I need to continue without my TRN", visible: false
+    click_on "Continue"
   end
   alias_method :and_i_do_not_know_the_trn, :when_i_do_not_know_the_trn
 
   def when_i_submit_my_trn
-    post "/ask-trn",
-         params: {
-           ask_trn_form: {
-             do_you_know_your_trn: true,
-             trn_from_user: "2921020"
-           }
-         }
+    choose "Yes, I know my TRN", visible: false
+    fill_in "What is your TRN?", with: "2921020"
+    click_on "Continue"
   end
 
   def when_i_submit_my_wrong_trn
-    post "/ask-trn",
-         params: {
-           ask_trn_form: {
-             do_you_know_your_trn: true,
-             trn_from_user: "1234567"
-           }
-         }
+    choose "Yes, I know my TRN", visible: false
+    fill_in "What is your TRN?", with: "1234567"
+    click_on "Continue"
   end
 
   def when_i_have_not_been_awarded_qts
-    post "/awarded-qts", params: { awarded_qts_form: { awarded_qts: false } }
+    choose "No", visible: false
+    click_on "Continue"
   end
   alias_method :and_i_have_not_been_awarded_qts,
                :when_i_have_not_been_awarded_qts
 
   def then_i_see_the_check_answers_page
-    expect(response).to redirect_to("/check-answers")
-  end
-
-  def then_i_see_the_ask_for_trn_page
-    expect(response).to redirect_to("/ask-trn")
+    expect(page).to have_content("Check your answers")
   end
 
   def then_i_see_the_name_page
-    expect(response).to redirect_to("/name")
+    expect(page).to have_content("Your name")
   end
 
   def then_i_see_the_date_of_birth_page
-    expect(response).to redirect_to("/date-of-birth")
+    expect(page).to have_content("Your date of birth")
   end
 
   def then_i_see_the_have_ni_number_page
-    expect(response).to redirect_to("/have-ni-number")
+    expect(page).to have_content("Do you have a National Insurance number")
   end
 
   def then_i_see_the_ni_number_page
@@ -334,32 +290,31 @@ RSpec.describe "Identity", type: :system do
   end
 
   def then_i_see_the_ask_trn_page
-    expect(response).to redirect_to("/ask-trn")
+    expect(page).to have_content("Do you know your teacher reference number")
   end
 
   def then_i_see_the_have_awarded_qts_page
-    expect(response).to redirect_to("/awarded-qts")
-  end
-
-  def then_i_see_the_have_itt_provider_page
-    expect(response).to redirect_to("/itt-provider")
+    expect(page).to have_content(
+      "Have you been awarded qualified teacher status"
+    )
   end
 
   def when_i_try_to_go_to_the_email_page
-    get email_path
+    visit email_path
   end
 
   def when_i_press_the_continue_button
-    put "/trn-request", params: { trn_request: { answers_checked: true } }
+    click_on "Continue"
   end
-  alias_method :when_i_submit_anyway, :when_i_press_the_continue_button
 
   def then_i_see_the_no_match_page
-    expect(response).to redirect_to("/no-match")
+    expect(page).to have_content("We could not match")
   end
 
-  def then_i_am_redirected_back_to_get_an_identity
-    expect(response).to redirect_to("https://authserveruri/")
+  def then_i_am_redirected_to_the_callback
+    expect(page).to have_content(
+      "You have completed a simulated Identity journey"
+    )
   end
 
   def then_sentry_receives_a_warning_about_the_failure
@@ -367,14 +322,10 @@ RSpec.describe "Identity", type: :system do
   end
 
   def then_i_should_see_the_client_title_from_get_an_identity
-    follow_redirect!
-    page = response.parsed_body
-    expect(page).to have_content("The Client Title")
+    expect(page).to have_content("")
   end
 
-  def and_i_see_the_correct_no_match_copy
-    follow_redirect!
-    page = response.parsed_body
+  def and_i_see_the_correct_no_match_content
     expect(page).to have_content(
       "We could not match your answers with our records"
     )
@@ -384,34 +335,27 @@ RSpec.describe "Identity", type: :system do
   end
 
   def and_i_am_redirected_to_the_error_page
-    expect(response.status).to be(500)
+    expect(page).to have_content("Sorry")
   end
 
   def when_i_submit_anyway
-    post "/no-match", params: { no_match_form: { try_again: false } }
-  end
-
-  def deactivate_feature_flags
-    FeatureFlag.deactivate(:service_open)
-    FeatureFlag.deactivate(:identity_open)
+    choose "No, submit these details, they are correct", visible: false
+    click_on "Continue"
   end
 
   def given_the_service_is_open
     FeatureFlag.activate(:service_open)
   end
 
+  def deactivate_feature_flags
+    FeatureFlag.deactivate(:identity_open)
+  end
+
+  def given_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize("test", "test")
+  end
+
   def given_the_identity_endpoint_is_open
     FeatureFlag.activate(:identity_open)
-  end
-
-  def and_i_see_a_continue_button
-    follow_redirect!
-    expect(response.parsed_body).to have_button("Continue", visible: false)
-  end
-
-  def and_it_links_to_the_calling_service
-    follow_redirect!
-    page = response.parsed_body
-    expect(page).to have_link(href: "https://clienturi/")
   end
 end


### PR DESCRIPTION
### Context

Testing the Identity journey is currently a bit difficult as it requires POSTing to Find with a difficult to craft payload.

### Changes proposed in this pull request

Add a `/support/identity` page that allows us to more easily simulate a journey from Identity.

TODO:

- [x] Update `spec/system/identity_spec.rb`, switch away from using request/response and to usual Capybara system spec style
- [x] Add tests for `app/lib/identity.rb`
- [x] Add `/support/identity/callback` route
- [x] Add link to support header
- [x] Fix any broken tests

### Guidance to review

Review commit by commit.

#### #new

![image](https://user-images.githubusercontent.com/1650875/187974352-cfd79bef-0f62-49d9-bdbf-11d0c009c023.png)

#### #confirm

![image](https://user-images.githubusercontent.com/1650875/187974565-5ed2cc22-7490-4d3a-9db2-5ed57006c8c1.png)

#### Successful POST (updated title)

![image](https://user-images.githubusercontent.com/1650875/187974656-6ded2615-8713-4cff-a1c7-0a25b2591b68.png)

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
