### PR TITLE
Make DeleteOldZendeskTicketsJob work with >100 tickets

### DIFF
--- a/app/jobs/delete_old_zendesk_tickets_job.rb
+++ b/app/jobs/delete_old_zendesk_tickets_job.rb
@@ -3,9 +3,7 @@ class DeleteOldZendeskTicketsJob < ApplicationJob
     tickets = ZendeskService.find_closed_tickets_from_6_months_ago
     return if tickets.size.zero?
     if tickets.size >= 100
-      raise "More than 100 tickets to delete were found in Zendesk. " \
-              "The DeleteOldZendeskTicketsJob doesn't handle pagination. " \
-              "If you're seeing this, we need to build pagination."
+      DeleteOldZendeskTicketsJob.set(wait: 5.minutes).perform_later
     end
 
     tickets.each do |ticket|

--- a/spec/jobs/delete_old_zendesk_tickets_job_spec.rb
+++ b/spec/jobs/delete_old_zendesk_tickets_job_spec.rb
@@ -60,8 +60,12 @@ RSpec.describe DeleteOldZendeskTicketsJob, type: :job do
 
     context "with 100 or more tickets" do
       let(:returned_tickets) { tickets * 50 }
-      it "raises an error" do
-        expect { perform }.to raise_error RuntimeError
+      it "does not raise an error" do
+        expect { perform }.not_to raise_error
+      end
+      it "recursively performs the job" do
+        perform
+        expect(described_class).to have_been_enqueued
       end
     end
   end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/BtrKZvqP)

### Context

We built this job but purposefully added in a guard clause / raise to break if it's run with more than 100 tickets.

The `ZendeskService.find_closed_tickets_from_6_months_ago` can return a maximum of 100 tickets and is a paginated request. destroy_tickets! can only operate with a maximum of 100 tickets.

### Changes proposed in this pull request

Run the job recursively with more than 100 tickets

### Guidance to review

- No exception is raised for more than 100 tickets
- Recursively run the job until we get less than 100 tickets

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
