### PR TITLE
Run the Zendesk delete job weekly

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -7,5 +7,5 @@ zendesk_health_alert:
   class: "ZendeskHealthJob"
 
 zendesk_delete:
-  cron: "0 9 * * WED"
+  cron: "0 11 * * WED"
   class: "DeleteOldZendeskTicketsJob"


### PR DESCRIPTION
We want to delete the old tickets in Zendesk on a regular basis.

Weekly is an arbitrary choice and could be changed if a more suitable
schedule is required in the future.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
