### PR TITLE
Include groups when getting closed Zendesk tickets

### DIFF
--- a/app/controllers/support_interface/zendesk_controller.rb
+++ b/app/controllers/support_interface/zendesk_controller.rb
@@ -2,13 +2,9 @@ module SupportInterface
   class ZendeskController < SupportInterfaceController
     def index
       @zendesk_tickets =
-        Rails
-          .cache
-          .fetch("zendesk_tickets", expires_in: 1.hour) do
-            ZendeskService.find_closed_tickets_from_6_months_ago.map do |t|
-              ZendeskDeleteRequest.new.from(t)
-            end
-          end
+        ZendeskService.find_closed_tickets_from_6_months_ago.map do |t|
+          ZendeskDeleteRequest.new.from(t)
+        end
       @zendesk_delete_requests = ZendeskDeleteRequest.all
     end
 

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -24,7 +24,10 @@ class ZendeskService
     date = 6.months.ago.strftime("%Y-%m-%d")
     GDS_ZENDESK_CLIENT
       .zendesk_client
-      .search(query: "updated<#{date} type:ticket status:closed")
+      .search(
+        query: "updated<#{date} type:ticket status:closed",
+        include: "tickets(groups)"
+      )
       .fetch
   end
 


### PR DESCRIPTION
### Context

This solves an N+1 performance issue when displaying `/support/zendesk` and when running the deletion job.

### Changes proposed in this pull request

Add a side-loading parameter as per the docs: https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/side_loading/#searches

Remove the `Rails.cache` call in the controller now that this isn't slow anymore.

### Guidance to review

This doesn't have much "real" test coverage because everything is stubbed out for our tests, so they never had the N+1 issue to begin with. To test this would require a separate system spec that runs in a special way and probably bottling up some real Zendesk API queries using VCR. However, that feels heavy handed, for a change that effectively amounts to adding `?include=tickets(groups)` to a URL and checking that it's there...

It has been manually tested and confirmed to work locally.

### Checklist

- [x] Attach to Trello card https://trello.com/c/LcCzSy0e/659-fix-n1-query-performance-for-support-zendesk
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
