### PR TITLE
Add a Slack alert for Zendesk deletions

### DIFF
--- a/app/jobs/delete_zendesk_tickets_alert_job.rb
+++ b/app/jobs/delete_zendesk_tickets_alert_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class DeleteZendeskTicketsAlertJob < ApplicationJob
+  include ActionView::Helpers::TextHelper
+  include Rails.application.routes.url_helpers
+
+  def perform
+    return unless FeatureFlag.active?(:slack_alerts)
+
+    count = ZendeskService.find_closed_tickets_from_6_months_ago.count
+    url = support_interface_zendesk_url(host: ENV.fetch("HOSTING_DOMAIN"))
+    message =
+      "There are #{pluralize(count, "Zendesk ticket")} scheduled for deletion tomorrow. #{url}"
+    SlackClient.create_message(message)
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -9,3 +9,7 @@ zendesk_health_alert:
 zendesk_delete:
   cron: "0 11 * * WED"
   class: "DeleteOldZendeskTicketsJob"
+
+zendesk_delete_alert:
+  cron: "0 11 * * TUE"
+  class: "DeleteZendeskTicketsAlertJob"

--- a/spec/jobs/delete_zendesk_tickets_alert_job_spec.rb
+++ b/spec/jobs/delete_zendesk_tickets_alert_job_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe DeleteZendeskTicketsAlertJob, type: :job do
+  describe "#perform" do
+    subject(:perform) { described_class.new.perform }
+
+    before { allow(SlackClient).to receive(:create_message) }
+
+    context "when the feature flag is active" do
+      before { FeatureFlag.activate(:slack_alerts) }
+      after { FeatureFlag.deactivate(:slack_alerts) }
+
+      context "when there Zendesk tickets ready for deletion" do
+        before do
+          allow(ZendeskService).to receive(
+            :find_closed_tickets_from_6_months_ago
+          ).and_return([1, 2])
+        end
+
+        it "sends the count as a Slack message" do
+          perform
+          expect(SlackClient).to have_received(:create_message).with(
+            "There are 2 Zendesk tickets scheduled for deletion tomorrow. http://localhost:3000/support/zendesk"
+          )
+        end
+      end
+
+      context "when there are no Zendesk tickets for deletion" do
+        before do
+          allow(ZendeskService).to receive(
+            :find_closed_tickets_from_6_months_ago
+          ).and_return([])
+        end
+
+        it "sends the latest count as a Slack message" do
+          perform
+          expect(SlackClient).to have_received(:create_message).with(
+            "There are 0 Zendesk tickets scheduled for deletion tomorrow. http://localhost:3000/support/zendesk"
+          )
+        end
+      end
+
+      context "when the feature flags is inactive" do
+        before { FeatureFlag.deactivate(:slack_alerts) }
+
+        it "no-ops" do
+          perform
+          expect(SlackClient).not_to have_received(:create_message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In a previous change, we scheduled the automatic deletion of old Zendesk
tickets to happen weekly.

We want to have some visibility of this process during the first few
weeks of it running to give us confidence that it is working as
expected.

A proposal is that a Slack alert 24 hours before the scheduled deletion
runs will give us sufficient notice to address any irregularities in the
expected count of tickets scheduled to be deleted.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
