### PR TITLE
Revert "Use /health/all endpoint for healthchecks"

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -64,7 +64,7 @@ resource "cloudfoundry_app" "app" {
   strategy                   = "blue-green"
   environment                = local.app_environment_variables
   health_check_type          = "http"
-  health_check_http_endpoint = "/health/all"
+  health_check_http_endpoint = "/health"
   dynamic "routes" {
     for_each = local.flt_routes
     content {


### PR DESCRIPTION
This reverts commit 7a0ce4b4a5445147ea1175358b81dc5fa778bbec.

This endpoint is used by the PaaS for more than just checking the health of the container during a deployment; it's also pinged during regular operation. What this means is that if one of Find's dependencies goes down, like Zendesk or Notify, PaaS will think the container is unhealthy, and potentially kill it.