### PR TITLE
Build CSV export for Zendesk tickets

### DIFF
--- a/app/controllers/support_interface/zendesk_controller.rb
+++ b/app/controllers/support_interface/zendesk_controller.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 module SupportInterface
   class ZendeskController < SupportInterfaceController
     include Pagy::Backend
@@ -33,6 +35,13 @@ module SupportInterface
         redirect_to support_interface_zendesk_path
       else
         render :confirm_deletion
+      end
+    end
+
+    def export
+      filename = "#{Time.zone.today}_deleted_zendesk_tickets.csv"
+      respond_to do |format|
+        format.csv { send_data ZendeskDeleteRequest.to_csv, filename: }
       end
     end
 

--- a/app/models/zendesk_delete_request.rb
+++ b/app/models/zendesk_delete_request.rb
@@ -33,4 +33,21 @@ class ZendeskDeleteRequest < ApplicationRecord
     self.group_name = ticket.group.name
     self
   end
+
+  def self.to_csv
+    attributes = %w[
+      ticket_id
+      group_name
+      received_at
+      closed_at
+      enquiry_type
+      no_action_required
+    ]
+    CSV.generate(headers: true) do |csv|
+      csv << attributes.map(&:titleize)
+      all.find_each do |request|
+        csv << attributes.map { |attr| request.send(attr) }
+      end
+    end
+  end
 end

--- a/app/views/support_interface/zendesk/index.html.erb
+++ b/app/views/support_interface/zendesk/index.html.erb
@@ -83,6 +83,8 @@
     </span>
   </h2>
 
+  <p><%= govuk_link_to "Export to CSV", support_interface_zendesk_export_path(format: :csv) %></p>
+
   <%= govuk_pagination(pagy: @pagy) %>
 
   <%= govuk_table do |table|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
         :as => :validation_error
 
     get "/zendesk", to: "zendesk#index"
+    get "/zendesk/export", to: "zendesk#export"
     get "/zendesk/confirm-deletion", to: "zendesk#confirm_deletion"
     post "/zendesk/confirm-deletion", to: "zendesk#destroy"
 

--- a/spec/support/download_helpers.rb
+++ b/spec/support/download_helpers.rb
@@ -1,0 +1,45 @@
+module System
+  module DownloadHelpers
+    TIMEOUT = 10
+    PATH = Rails.root.join("tmp/capybara")
+
+    def downloads
+      Dir[PATH.join("*")].reject { |f| File.directory?(f) }
+    end
+
+    def download
+      downloads.first
+    end
+
+    def download_content
+      wait_for_download
+      File.read(download)
+    end
+
+    def wait_for_download
+      Timeout.timeout(TIMEOUT, Timeout::Error) { sleep 0.1 until downloaded? }
+    end
+
+    def downloaded?
+      !downloading? && downloads.any?
+    end
+
+    def downloading?
+      downloads.grep(/\.crdownload$/).any?
+    end
+
+    def clear_downloads
+      FileUtils.rm_f(downloads)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include System::DownloadHelpers, type: :system
+
+  config.around(:each, type: :system) do |example|
+    clear_downloads
+    example.run
+    clear_downloads
+  end
+end

--- a/spec/system/zendesk_ticket_deletion_spec.rb
+++ b/spec/system/zendesk_ticket_deletion_spec.rb
@@ -134,15 +134,7 @@ RSpec.describe "Zendesk ticket deletion", type: :system do
   end
 
   def and_i_should_be_able_to_export_tickets_to_csv
-    expect(page).to have_link("Export to CSV")
     click_on("Export to CSV")
-    filename = "#{Time.zone.today}_deleted_zendesk_tickets.csv"
-    expect(page.driver.response_headers["Content-Disposition"]).to eq(
-      "attachment; filename=\"#{filename}\"; filename*=UTF-8''#{filename}"
-    )
-    sleep(2) # Need a way to verify the download is complete
-    expect(File.read("#{Rails.root.join("tmp/capybara")}/#{filename}")).to eq(
-      ZendeskDeleteRequest.to_csv
-    )
+    expect(download_content).to eq(ZendeskDeleteRequest.to_csv)
   end
 end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/PdVXjj1N)

<img width="1205" alt="Screenshot_2022-09-07_at_16 05 57" src="https://user-images.githubusercontent.com/547202/188913743-0b2dc352-820d-4f11-ae97-e5b780c8b06a.png">

### Context

We need a way to export the deleted Zendesk tickets for reporting purposes.

### Changes proposed in this pull request

- Export a CSV of deleted Zendesk tickets from `/support/zendesk`
- The CSV contains all the `ZendeskDeleteRequest`s
- The CSV contains 6 fields: ticket ID, group name, received at, closed at, enquiry type, no action required

### Guidance to review

Execute locally and attempt to export CSV

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
