### PR TITLE
Use the count method provided by ZendeskAPI

### DIFF
--- a/app/jobs/delete_old_zendesk_tickets_job.rb
+++ b/app/jobs/delete_old_zendesk_tickets_job.rb
@@ -1,8 +1,8 @@
 class DeleteOldZendeskTicketsJob < ApplicationJob
   def perform
     tickets = ZendeskService.find_closed_tickets_from_6_months_ago
-    return if tickets.size.zero?
-    if tickets.size >= 100
+    return if tickets.count.zero?
+    if tickets.count >= 100
       DeleteOldZendeskTicketsJob.set(wait: 5.minutes).perform_later
     end
 

--- a/app/services/zendesk_service.rb
+++ b/app/services/zendesk_service.rb
@@ -22,13 +22,10 @@ class ZendeskService
 
   def self.find_closed_tickets_from_6_months_ago
     date = 6.months.ago.strftime("%Y-%m-%d")
-    GDS_ZENDESK_CLIENT
-      .zendesk_client
-      .search(
-        query: "updated<#{date} type:ticket status:closed",
-        include: "tickets(groups)"
-      )
-      .fetch
+    GDS_ZENDESK_CLIENT.zendesk_client.search(
+      query: "updated<#{date} type:ticket status:closed",
+      include: "tickets(groups)"
+    )
   end
 
   def self.destroy_tickets!(ids)

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -7,34 +7,50 @@ class ExtendedDummyClient
     @logger = logger
   end
 
+  def connection
+    Struct.new(:get).new
+  end
+
   def tickets
     self
   end
 
   def search(_params)
-    self
+    fetch
   end
 
   def destroy_many(_params)
     self
   end
 
-  def fetch
-    [
-      ZendeskAPI::Ticket.new(
-        GDS_ZENDESK_CLIENT,
-        id: 42,
-        created_at: (6.months + 8.days).ago,
-        updated_at: (6.months + 1.day).ago,
-        custom_fields: [
-          { id: 4_419_328_659_089, value: "Foo" },
-          { id: 4_562_126_876_049, value: "Bar" }
-        ],
-        group: {
-          name: "Some group"
-        }
-      )
-    ]
+  def fetch(*args)
+    fetch!(*args)
+  end
+
+  def fetch!(*_args)
+    ZendeskAPI::Collection
+      .new(self, ZendeskAPI::Ticket)
+      .tap do |collection|
+        collection.instance_variable_set(
+          :@resources,
+          [
+            ZendeskAPI::Ticket.new(
+              GDS_ZENDESK_CLIENT,
+              id: 42,
+              created_at: (6.months + 8.days).ago,
+              updated_at: (6.months + 1.day).ago,
+              custom_fields: [
+                { id: 4_419_328_659_089, value: "Foo" },
+                { id: 4_562_126_876_049, value: "Bar" }
+              ],
+              group: {
+                name: "Some group"
+              }
+            )
+          ]
+        )
+        collection.instance_variable_set(:@count, 1)
+      end
   end
 end
 

--- a/spec/services/zendesk_service_spec.rb
+++ b/spec/services/zendesk_service_spec.rb
@@ -123,14 +123,9 @@ RSpec.describe ZendeskService do
       described_class.find_closed_tickets_from_6_months_ago
     end
 
-    before do
-      allow(zendesk_client).to receive(:search).and_return(zendesk_client)
-      allow(zendesk_client).to receive(:fetch).and_return(
-        [ZendeskAPI::Ticket.new(GDS_ZENDESK_CLIENT, id: 42)]
-      )
-    end
+    let(:search_results) { double("ZendeskAPI::Colleciton", count: 1) }
 
-    it { is_expected.to be_a(Array) }
+    it { is_expected.to be_a(ZendeskAPI::Collection) }
   end
 
   describe ".destroy_tickets!" do


### PR DESCRIPTION
The ZendeskAPI library includes a method, `count` on the
`ZendeskAPI::Collection` object.

We are not using this object but instead using `fetch` and working with
the JSON response from the API.

Rather than read the count value from the API response, it seems simpler
to lean on the interface provided by the library.

The change for this is small. In fact, most of the changes are in our
test code.

See [this comment](https://github.com/DFE-Digital/find-a-lost-trn/pull/457#discussion_r963545597) for the origin of this change.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
