### PR TITLE
Healthcheck endpoint changed in statuscake

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -9,9 +9,19 @@
   "postgres_database_service_plan": "small-ha-13",
   "hostnames": ["find-a-lost-trn"],
   "statuscake_alerts": {
-    "tra-flt-prod": {
+    "tra-flt-prod-1": {
       "website_name": "find-a-lost-trn-production",
-      "website_url": "https://find-a-lost-trn-production.london.cloudapps.digital/health",
+      "website_url": "https://find-a-lost-trn-production.london.cloudapps.digital/health/all",
+      "test_type": "HTTP",
+      "contact_group": [249142],
+      "check_rate": 30,
+      "trigger_rate": 0,
+      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
+      "confirmations": 2
+    },
+    "tra-flt-prod-2": {
+      "website_name": "find-a-lost-trn-production",
+      "website_url": "https://find-a-lost-trn.education.gov.uk/health/all",
       "test_type": "HTTP",
       "contact_group": [249142],
       "check_rate": 30,


### PR DESCRIPTION
Statuscake now checks health of the app by pinging below urls.

https://find-a-lost-trn-production.london.cloudapps.digital/health/all
https://find-a-lost-trn.education.gov.uk/health/all


- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
