### PR TITLE
Reset Identity-related session variables when user leaves the service

### DIFF
--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -28,8 +28,8 @@ class IdentityController < ApplicationController
     session[:trn_request_id] = @trn_request.id
     session[:identity_journey_id] = allowed_create_params["journey_id"]
     session[:identity_redirect_uri] = allowed_create_params["redirect_uri"]
-    session[:client_title] = allowed_create_params["client_title"]
-    session[:client_url] = allowed_create_params["client_url"]
+    session[:identity_client_title] = allowed_create_params["client_title"]
+    session[:identity_client_url] = allowed_create_params["client_url"]
 
     redirect_to next_question_path
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -22,8 +22,8 @@ class PagesController < ApplicationController
   def start
     session[:form_complete] = false
 
-    if session[:client_url]
-      redirect_to session[:client_url], allow_other_host: true
+    if session[:identity_client_url]
+      redirect_to session[:identity_client_url], allow_other_host: true
       reset_session
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,5 +21,10 @@ class PagesController < ApplicationController
 
   def start
     session[:form_complete] = false
+
+    if session[:client_url]
+      redirect_to session[:client_url], allow_other_host: true
+      reset_session
+    end
   end
 end

--- a/app/controllers/support_interface/identity_controller.rb
+++ b/app/controllers/support_interface/identity_controller.rb
@@ -7,6 +7,7 @@ module SupportInterface
       @identity_params.email = "kevin.e@example.com"
       @identity_params.journey_id = journey_id
       @identity_params.redirect_uri = redirect_uri
+      @identity_params.client_url = client_url
     end
 
     def confirm
@@ -14,7 +15,8 @@ module SupportInterface
         client_title: create_params[:client_title],
         email: create_params[:email],
         journey_id:,
-        redirect_uri:
+        redirect_uri:,
+        client_url:
       }
       sig = Identity.signature_from(@identity_params)
       @identity_params[:sig] = sig
@@ -40,6 +42,10 @@ module SupportInterface
     end
 
     def redirect_uri
+      support_interface_identity_callback_path
+    end
+
+    def client_url
       support_interface_identity_callback_path
     end
   end

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -29,6 +29,7 @@ class TrnRequestsController < ApplicationController
 
           # Send the user back to Get an Identity
           redirect_to session[:identity_redirect_uri], allow_other_host: true
+          reset_session
         rescue IdentityApi::ApiError,
                Faraday::ConnectionFailed,
                Faraday::TimeoutError,

--- a/app/forms/support_interface/identity_params_form.rb
+++ b/app/forms/support_interface/identity_params_form.rb
@@ -2,6 +2,6 @@ module SupportInterface
   class IdentityParamsForm
     include ActiveModel::Model
 
-    attr_accessor :client_title, :email, :journey_id, :redirect_uri
+    attr_accessor :client_title, :email, :journey_id, :redirect_uri, :client_url
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,7 @@ module ApplicationHelper
   def custom_header
     govuk_header(
       service_name:,
-      service_url: session.fetch(:client_url, "")
+      service_url: session.fetch(:client_url, start_path)
     ) do |header|
       case try(:current_namespace)
       when "support_interface"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,8 +78,8 @@ module ApplicationHelper
   end
 
   def service_name
-    if session[:client_title]
-      sanitize(session[:client_title])
+    if session[:identity_client_title]
+      sanitize(session[:identity_client_title])
     else
       t("service.name")
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,10 +35,7 @@ module ApplicationHelper
   end
 
   def custom_header
-    govuk_header(
-      service_name:,
-      service_url: session.fetch(:client_url, start_path)
-    ) do |header|
+    govuk_header(service_name:, service_url: start_path) do |header|
       case try(:current_namespace)
       when "support_interface"
         header.navigation_item(

--- a/app/views/support_interface/identity/new.html.erb
+++ b/app/views/support_interface/identity/new.html.erb
@@ -33,6 +33,13 @@
                 disabled for simulated journeys because simulated journeys \
                 should always return to Find." }
       ) %>
+      <%= f.govuk_text_field(:client_url,
+        disabled: true,
+        label: { size: 's', text: 'Client URL' },
+        hint: { text: "Will be linked to from the header. Editing is \
+                disabled for simulated journeys because simulated journeys \
+                should always return to Find." }
+      ) %>
       <%= f.govuk_submit "Continue", prevent_double_click: false %>
     <% end %>
   </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "#custom_title" do
     it "Uses client_title if it is set" do
-      session[:client_title] = "Custom Client Title"
+      session[:identity_client_title] = "Custom Client Title"
       result = custom_title("Page Title")
       expect(result).to eq("Page Title - Custom Client Title")
     end
@@ -31,7 +31,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it "escapes evil input" do
-      session[:client_title] = '<script>alert("evil")</script>'
+      session[:identity_client_title] = '<script>alert("evil")</script>'
       result = custom_title("Page Title")
       expect(result).to eq("Page Title - alert(\"evil\")")
     end

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe "Identity", type: :system do
       client_title: "New Title",
       email: "john.smith@example.com",
       journey_id: "9ddccb62-ec13-4ea7-a163-c058a19b8222",
-      sig: "2940250690ABB0055E0EF197E7C296BF5FF62587ECD7B39A2F88D08F3AC8A30E"
+      sig: "an invalid sig"
     }
 
     expect { post identity_path, params: }.to raise_error(

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Identity", type: :system do
 
       when_i_press_the_continue_button
       then_i_am_redirected_to_the_callback
+      and_the_title_of_the_service_is_find_a_lost_trn
     end
 
     context "when there is no trn match", vcr: true do
@@ -179,6 +180,15 @@ RSpec.describe "Identity", type: :system do
     end
   end
 
+  it "renders a link to the calling service" do
+    when_i_access_the_identity_endpoint
+    then_i_see_the_name_page
+
+    when_i_click_on_the_header
+    then_i_am_redirected_to_the_callback
+    and_the_title_of_the_service_is_find_a_lost_trn
+  end
+
   private
 
   def when_i_access_the_identity_endpoint
@@ -269,6 +279,10 @@ RSpec.describe "Identity", type: :system do
   alias_method :and_i_have_not_been_awarded_qts,
                :when_i_have_not_been_awarded_qts
 
+  def when_i_click_on_the_header
+    click_on "Register for a National Professional Qualification"
+  end
+
   def then_i_see_the_check_answers_page
     expect(page).to have_content("Check your answers")
   end
@@ -357,5 +371,9 @@ RSpec.describe "Identity", type: :system do
 
   def given_the_identity_endpoint_is_open
     FeatureFlag.activate(:identity_open)
+  end
+
+  def and_the_title_of_the_service_is_find_a_lost_trn
+    expect(page).to have_content("Find a lost teacher reference number (TRN)")
   end
 end


### PR DESCRIPTION
### Context

Currently, if the user starts an Identity journey, leaves the service, then comes back to Find later, they will still find the service branded with the `client_title`.

This PR fixes that issue and refactors some adjacent code.

### Changes proposed in this pull request

See individual commits.

### Guidance to review

Review commit by commit.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
