### PR TITLE
Hide phase banner during an Identity journey

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,4 +87,8 @@ module ApplicationHelper
       t("service.name")
     end
   end
+
+  def is_identity_journey?
+    !!session[:identity_journey_id]
+  end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -32,8 +32,10 @@
     <%= custom_header %>
 
     <div class="govuk-width-container">
-      <%= govuk_phase_banner(tag: { text: "Beta" }) do %>
-        This is a new service – <a class="govuk-link" href="https://forms.gle/3LGJXe9EFaeQbFgP7">your feedback will help us to improve it</a>.
+      <% unless is_identity_journey? %>
+        <%= govuk_phase_banner(tag: { text: "Beta" }) do %>
+          This is a new service – <a class="govuk-link" href="https://forms.gle/3LGJXe9EFaeQbFgP7">your feedback will help us to improve it</a>.
+        <% end %>
       <% end %>
       <%= govuk_back_link(href: yield(:back_link_url)) unless yield(:back_link_url).blank? %>
       <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -36,4 +36,17 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(result).to eq("Page Title - alert(\"evil\")")
     end
   end
+
+  describe "#is_identity_journey?" do
+    it "returns false if it's not an identity journey" do
+      result = is_identity_journey?
+      expect(result).to be_falsey
+    end
+
+    it "returns true if it's an identity journey" do
+      session[:identity_journey_id] = "Foo"
+      result = is_identity_journey?
+      expect(result).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
### Context

We don't display it on Get an Identity, so we should be consistent and not display it in Find either.

### Changes proposed in this pull request

Hide the phase banner if an env var is set.

### Guidance to review

#### Before

![image](https://user-images.githubusercontent.com/1650875/188926142-ba45004c-d8b9-4d34-9274-d5d0019cbc64.png)

#### After 

![image](https://user-images.githubusercontent.com/1650875/188926080-3f2be0e3-a2dd-4e27-b8ea-3ac1c6a6986d.png)

### Checklist

- [x] Attach to Trello card https://trello.com/c/i6gW5Df1/674-snags
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
