### PR TITLE
Only clear downloads for specs with download: true

### DIFF
--- a/spec/support/download_helpers.rb
+++ b/spec/support/download_helpers.rb
@@ -37,7 +37,7 @@ end
 RSpec.configure do |config|
   config.include System::DownloadHelpers, type: :system
 
-  config.around(:each, type: :system) do |example|
+  config.around(:each, type: :system, download: ->(v) { v }) do |example|
     clear_downloads
     example.run
     clear_downloads

--- a/spec/system/zendesk_ticket_deletion_spec.rb
+++ b/spec/system/zendesk_ticket_deletion_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Zendesk ticket deletion", type: :system do
   before { given_the_service_is_open }
   after { deactivate_feature_flags }
 
-  it "allows deleting outstanding Zendesk tickets", vcr: true do
+  it "allows deleting outstanding Zendesk tickets", vcr: true, download: true do
     given_i_am_authorized_as_a_support_user
     when_i_visit_the_zendesk_support_page
     then_i_should_see_a_ticket


### PR DESCRIPTION
Thanks @ransom4real for pointing out that screenshots share the same folder as other downloads and would be impacted by always deleting the downloads folder.
