### PR TITLE
Fix back button on Name edit page during Identity journey

### DIFF
--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -30,7 +30,7 @@ class IdentityController < ApplicationController
     session[:identity_client_url] = recognised_params["client_url"]
     session[:identity_journey_id] = recognised_params["journey_id"]
     session[:identity_previous_url] = recognised_params["previous_url"]
-    session[:identity_redirect_uri] = recognised_params["redirect_uri"]
+    session[:identity_redirect_url] = recognised_params["redirect_url"]
 
     redirect_to next_question_path
   end
@@ -44,7 +44,7 @@ class IdentityController < ApplicationController
       :email,
       :journey_id,
       :previous_url,
-      :redirect_uri,
+      :redirect_url,
       :sig
     )
   end

--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -26,10 +26,11 @@ class IdentityController < ApplicationController
       )
 
     session[:trn_request_id] = @trn_request.id
-    session[:identity_journey_id] = recognised_params["journey_id"]
-    session[:identity_redirect_uri] = recognised_params["redirect_uri"]
     session[:identity_client_title] = recognised_params["client_title"]
     session[:identity_client_url] = recognised_params["client_url"]
+    session[:identity_journey_id] = recognised_params["journey_id"]
+    session[:identity_previous_url] = recognised_params["previous_url"]
+    session[:identity_redirect_uri] = recognised_params["redirect_uri"]
 
     redirect_to next_question_path
   end
@@ -42,6 +43,7 @@ class IdentityController < ApplicationController
       :client_url,
       :email,
       :journey_id,
+      :previous_url,
       :redirect_uri,
       :sig
     )
@@ -65,7 +67,13 @@ class IdentityController < ApplicationController
     # signature. This is necessary because new parameters can be added to Get
     # an Identity, which would cause the sig to change and break us as a
     # downstream user.
-    unsafe_params = params.to_unsafe_h.except("sig", "controller", "action")
+    unsafe_params =
+      params.to_unsafe_h.except(
+        "action",
+        "authenticity_token",
+        "controller",
+        "sig"
+      )
     Identity.signature_from(unsafe_params)
   end
 

--- a/app/controllers/no_match_controller.rb
+++ b/app/controllers/no_match_controller.rb
@@ -19,7 +19,7 @@ class NoMatchController < ApplicationController
           IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
 
           # Send the user back to Get an Identity
-          redirect_to session[:identity_redirect_uri], allow_other_host: true
+          redirect_to session[:identity_redirect_url], allow_other_host: true
         rescue IdentityApi::ApiError,
                Faraday::ConnectionFailed,
                Faraday::TimeoutError,

--- a/app/controllers/support_interface/identity_controller.rb
+++ b/app/controllers/support_interface/identity_controller.rb
@@ -4,19 +4,21 @@ module SupportInterface
       @identity_params = IdentityParamsForm.new
       @identity_params.client_title =
         "Register for a National Professional Qualification"
+      @identity_params.client_url = client_url
       @identity_params.email = "kevin.e@example.com"
       @identity_params.journey_id = journey_id
+      @identity_params.previous_url = previous_url
       @identity_params.redirect_uri = redirect_uri
-      @identity_params.client_url = client_url
     end
 
     def confirm
       @identity_params = {
         client_title: create_params[:client_title],
+        client_url:,
         email: create_params[:email],
         journey_id:,
-        redirect_uri:,
-        client_url:
+        previous_url:,
+        redirect_uri:
       }
       sig = Identity.signature_from(@identity_params)
       @identity_params[:sig] = sig
@@ -47,6 +49,10 @@ module SupportInterface
 
     def client_url
       support_interface_identity_callback_path
+    end
+
+    def previous_url
+      support_interface_identity_path
     end
   end
 end

--- a/app/controllers/support_interface/identity_controller.rb
+++ b/app/controllers/support_interface/identity_controller.rb
@@ -8,7 +8,7 @@ module SupportInterface
       @identity_params.email = "kevin.e@example.com"
       @identity_params.journey_id = journey_id
       @identity_params.previous_url = previous_url
-      @identity_params.redirect_uri = redirect_uri
+      @identity_params.redirect_url = redirect_url
     end
 
     def confirm
@@ -18,7 +18,7 @@ module SupportInterface
         email: create_params[:email],
         journey_id:,
         previous_url:,
-        redirect_uri:
+        redirect_url:
       }
       sig = Identity.signature_from(@identity_params)
       @identity_params[:sig] = sig
@@ -43,7 +43,7 @@ module SupportInterface
       "9ddccb62-ec13-4ea7-a163-c058a19b8222"
     end
 
-    def redirect_uri
+    def redirect_url
       support_interface_identity_callback_path
     end
 

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -28,7 +28,7 @@ class TrnRequestsController < ApplicationController
           IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
 
           # Send the user back to Get an Identity
-          redirect_to session[:identity_redirect_uri], allow_other_host: true
+          redirect_to session[:identity_redirect_url], allow_other_host: true
           reset_session
         rescue IdentityApi::ApiError,
                Faraday::ConnectionFailed,

--- a/app/forms/support_interface/identity_params_form.rb
+++ b/app/forms/support_interface/identity_params_form.rb
@@ -2,6 +2,11 @@ module SupportInterface
   class IdentityParamsForm
     include ActiveModel::Model
 
-    attr_accessor :client_title, :email, :journey_id, :redirect_uri, :client_url
+    attr_accessor :client_title,
+                  :email,
+                  :journey_id,
+                  :redirect_uri,
+                  :client_url,
+                  :previous_url
   end
 end

--- a/app/forms/support_interface/identity_params_form.rb
+++ b/app/forms/support_interface/identity_params_form.rb
@@ -5,7 +5,7 @@ module SupportInterface
     attr_accessor :client_title,
                   :email,
                   :journey_id,
-                  :redirect_uri,
+                  :redirect_url,
                   :client_url,
                   :previous_url
   end

--- a/app/views/name/edit.html.erb
+++ b/app/views/name/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "#{'Error: ' if @name_form.errors.any?}Your name" %>
 <% content_for :back_link_url, back_link_url(
-  @trn_request.from_get_an_identity ? url_for(:back) : email_path
+  @trn_request.from_get_an_identity ? session[:identity_previous_url] : email_path
 ) %>
 
 <%= form_with model: @name_form, url: name_path do |f| %>

--- a/app/views/support_interface/identity/new.html.erb
+++ b/app/views/support_interface/identity/new.html.erb
@@ -40,6 +40,13 @@
                 disabled for simulated journeys because simulated journeys \
                 should always return to Find." }
       ) %>
+      <%= f.govuk_text_field(:previous_url,
+        disabled: true,
+        label: { size: 's', text: 'Previous URL' },
+        hint: { text: "Linked to from the back button on the Name page. Editing \
+                is disabled for simulated journeys because simulated journeys \
+                should always return to Find." }
+      ) %>
       <%= f.govuk_submit "Continue", prevent_double_click: false %>
     <% end %>
   </div>

--- a/app/views/support_interface/identity/new.html.erb
+++ b/app/views/support_interface/identity/new.html.erb
@@ -26,9 +26,9 @@
                 session. Editing is disabled for simulated journeys  \
                 because we don’t use it." }
       ) %>
-      <%= f.govuk_text_field(:redirect_uri,
+      <%= f.govuk_text_field(:redirect_url,
         disabled: true,
-        label: { size: 's', text: 'Redirect URI' },
+        label: { size: 's', text: 'Redirect URL' },
         hint: { text: "Callback URL to the Identity server. Editing is \
                 disabled for simulated journeys because simulated journeys \
                 should always return to Find." }

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "Identity", type: :system do
 
   def when_i_access_the_identity_endpoint_with_modified_parameters_it_raises_an_error
     params = {
-      redirect_uri: "https://authserveruri/",
+      redirect_url: "https://authserveruri/",
       client_title: "New Title",
       email: "john.smith@example.com",
       journey_id: "9ddccb62-ec13-4ea7-a163-c058a19b8222",


### PR DESCRIPTION
### Context

The back button doesn't always work well, so we need to use a new parameter from the Get an Identity. `previous_url`.

### Changes proposed in this pull request

See commits.

### Guidance to review

Review commit by commit.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
