### PR TITLE
Don't run DeleteOldZendeskTicketsJobs on non-prod

### DIFF
--- a/app/jobs/delete_old_zendesk_tickets_job.rb
+++ b/app/jobs/delete_old_zendesk_tickets_job.rb
@@ -1,5 +1,7 @@
 class DeleteOldZendeskTicketsJob < ApplicationJob
   def perform
+    return unless HostingEnvironment.environment_name == "production"
+
     tickets = ZendeskService.find_closed_tickets_from_6_months_ago
     return if tickets.count.zero?
     if tickets.count >= 100


### PR DESCRIPTION
This job should only run on the production environment, because it destroys Zendesk tickets and populates the database with the delete requests. If it can run on other envs, we run the risk of having multiple envs as the source of truth for previously deleted tickets, which has unfortunately happened (preprod has 131 `ZendeskDeleteRequest`s).