### PR TITLE
Prevent Identity users returning to question pages after redirect

### DIFF
--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -5,6 +5,10 @@ module EnforceQuestionOrder
   included { before_action :redirect_to_next_question }
 
   def redirect_to_next_question
+    if request_from_identity_and_complete?
+      redirect_to session[:identity_redirect_url], allow_other_host: true
+      return
+    end
     redirect_to(start_url) and return if start_page_is_required?
     return if all_questions_answered?
     return if previous_question_answered?
@@ -20,6 +24,11 @@ module EnforceQuestionOrder
 
   def redirect_requests_from_identity
     redirect_to next_question_path if request_from_identity?
+  end
+
+  def request_from_identity_and_complete?
+    session[:identity_redirect_url] && request_from_identity? &&
+      session[:identity_trn_request_sent]
   end
 
   private

--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -31,6 +31,7 @@ class IdentityController < ApplicationController
     session[:identity_journey_id] = recognised_params["journey_id"]
     session[:identity_previous_url] = recognised_params["previous_url"]
     session[:identity_redirect_url] = recognised_params["redirect_url"]
+    session[:identity_api_request_sent] = false
 
     redirect_to next_question_path
   end

--- a/app/controllers/no_match_controller.rb
+++ b/app/controllers/no_match_controller.rb
@@ -17,9 +17,11 @@ class NoMatchController < ApplicationController
         begin
           # Send a request to Get An Identity API with no TRN found
           IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
+          session[:identity_trn_request_sent] = true
 
           # Send the user back to Get an Identity
           redirect_to session[:identity_redirect_url], allow_other_host: true
+          session[:identity_client_title] = nil
         rescue IdentityApi::ApiError,
                Faraday::ConnectionFailed,
                Faraday::TimeoutError,

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -26,10 +26,11 @@ class TrnRequestsController < ApplicationController
         begin
           # Send a request to Get An Identity API with the TRN for the journey
           IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
+          session[:identity_trn_request_sent] = true
 
           # Send the user back to Get an Identity
           redirect_to session[:identity_redirect_url], allow_other_host: true
-          reset_session
+          session[:identity_client_title] = nil
         rescue IdentityApi::ApiError,
                Faraday::ConnectionFailed,
                Faraday::TimeoutError,

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/after_being_redirected_to_the_callback/cannot_go_back_to_the_check_answers_page.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/after_being_redirected_to_the_callback/cannot_go_back_to_the_check_answers_page.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 24 Aug 2022 10:37:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-24T10:38:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 2dc630de-12c4-4c0d-7309-e4790413b478
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 22e421a47e59010b5e8eb6ae4d4bd7e4.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - Wiwy47h4WPdk7jToS7sBfkdOfFFqKv6P_ejsEHC1XFIv_mgum8coHA==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Wed, 24 Aug 2022 10:37:55 GMT
+  - request:
+      method: put
+      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Fri, 19 Aug 2022 14:51:27 GMT
+        Request-Context:
+          - appId=cid-v1:5aca65be-e52c-472b-8552-a925111002da
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-8uLzfcgnnD9mcHn8Gn07TkG9nPBfeIgB3zEAAzR/YoY='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Fri, 19 Aug 2022 14:51:28 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_no_trn_match/after_being_redirected_to_the_callback/cannot_go_back_to_the_check_answers_page.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_no_trn_match/after_being_redirected_to_the_callback/cannot_go_back_to_the_check_answers_page.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+  - request:
+      method: put
+      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'
+      headers:
+        User-Agent:
+          - Faraday v1.10.1
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Fri, 19 Aug 2022 14:51:27 GMT
+        Request-Context:
+          - appId=cid-v1:5aca65be-e52c-472b-8552-a925111002da
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-8uLzfcgnnD9mcHn8Gn07TkG9nPBfeIgB3zEAAzR/YoY='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Fri, 19 Aug 2022 14:51:28 GMT
+recorded_with: VCR 6.1.0

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -51,6 +51,21 @@ RSpec.describe "Identity", type: :system do
       and_the_title_of_the_service_is_find_a_lost_trn
     end
 
+    context "after being redirected to the callback" do
+      it "cannot go back to the check answers page", vcr: true do
+        when_i_access_the_identity_endpoint
+        and_i_complete_and_submit_the_name_form
+        and_i_complete_and_submit_my_date_of_birth
+        then_i_see_the_check_answers_page
+
+        when_i_press_the_continue_button
+        then_i_am_redirected_to_the_callback
+
+        when_i_try_to_go_to_the_check_answers_page
+        then_i_am_redirected_to_the_callback
+      end
+    end
+
     context "when there is no trn match", vcr: true do
       before do
         allow(DqtApi).to receive(:find_trn!).and_raise(DqtApi::NoResults)
@@ -101,6 +116,28 @@ RSpec.describe "Identity", type: :system do
         when_i_press_the_continue_button
         then_i_see_the_no_match_page
         and_i_see_the_correct_no_match_content
+      end
+
+      context "after being redirected to the callback" do
+        it "cannot go back to the check answers page" do
+          when_i_access_the_identity_endpoint
+          and_i_complete_and_submit_the_name_form
+          and_i_complete_and_submit_my_date_of_birth
+          and_i_have_a_ni_number
+          and_i_complete_and_submit_my_ni_number
+          and_i_do_not_know_the_trn
+          and_i_have_not_been_awarded_qts
+          then_i_see_the_check_answers_page
+
+          when_i_press_the_continue_button
+          then_i_see_the_no_match_page
+
+          when_i_submit_anyway
+          then_i_am_redirected_to_the_callback
+
+          when_i_try_to_go_to_the_check_answers_page
+          then_i_am_redirected_to_the_callback
+        end
       end
     end
 
@@ -315,6 +352,10 @@ RSpec.describe "Identity", type: :system do
 
   def when_i_try_to_go_to_the_email_page
     visit email_path
+  end
+
+  def when_i_try_to_go_to_the_check_answers_page
+    visit check_answers_path
   end
 
   def when_i_press_the_continue_button


### PR DESCRIPTION
### Context

When the Identity journey is complete the user should not be able to press back and resubmit their TRN to Identity. 

### Changes proposed in this pull request

Prevents a user going 'back' to any of the pages in Find (when used via Identity) after the API call to Identity has been made.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
