### PR TITLE
Find Snag - Back Link on Check Answers Page

### DIFF
--- a/app/views/trn_requests/show.html.erb
+++ b/app/views/trn_requests/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, 'Check your answers' %>
-<%= content_for :back_link_url, back_link_url %>
 
 <h1 class="govuk-heading-xl">Check your answers</h1>
 <% unless @trn_request.from_get_an_identity? %>

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -413,13 +413,6 @@ RSpec.describe "TRN requests", type: :system do
     when_i_fill_in_my_ni_number
     when_i_press_continue
     then_i_see_the_check_answers_page
-
-    when_i_press_back
-    then_i_see_the_ni_number_page
-
-    when_i_press_continue
-    then_i_see_the_check_answers_page
-
     when_i_press_the_submit_button
     then_i_see_a_message_to_check_my_email
     and_i_receive_an_email_with_the_trn_number


### PR DESCRIPTION
[Trello Card](https://trello.com/c/i6gW5Df1)

### Context

After conversations with @fofr the conclusion is the `Back` Link on the Check Answers page is redundant and does not need to be there. Hence this PR removes the Back link on the Check Answers page and maintains the current functionality of the Back Link on all other pages

### Changes proposed in this pull request

- Remove the `Back` link on the Check Answers page
- Update System Specs to take out checks for the back link on the Check Answers page as it is no longer relevant

### Guidance to review

- Ensure the`Back` link is not on the Check Answers Page
- Verify the `Back` functionality remains unchanged when navigating through forms

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
