### PR TITLE
Identity support user list page

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,5 +8,5 @@ SLACK_WEBHOOK_URL=test
 SUPPORT_USERNAME=test
 SUPPORT_PASSWORD=test
 IDENTITY_SHARED_SECRET_KEY=testkey
-IDENTITY_API_URL=https://s165d01-getanid-dev-auth-server-app.azurewebsites.net
+IDENTITY_API_URL=https://s165t01-getanid-preprod-auths-app.azurewebsites.net
 IDENTITY_API_KEY=testkey

--- a/app/controllers/support_interface/identity_controller.rb
+++ b/app/controllers/support_interface/identity_controller.rb
@@ -27,7 +27,7 @@ module SupportInterface
     def callback
       flash[:success] = "You have completed a simulated Identity journey"
 
-      redirect_to support_interface_identity_path
+      redirect_to support_interface_identity_simulate_path
     end
 
     private
@@ -44,15 +44,15 @@ module SupportInterface
     end
 
     def redirect_url
-      support_interface_identity_callback_path
+      support_interface_identity_simulate_callback_path
     end
 
     def client_url
-      support_interface_identity_callback_path
+      support_interface_identity_simulate_callback_path
     end
 
     def previous_url
-      support_interface_identity_path
+      support_interface_identity_simulate_path
     end
   end
 end

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -1,5 +1,14 @@
+# frozen_string_literal: true
 module SupportInterface
   class UsersController < SupportInterfaceController
+    include Pagy::Backend
+
+    def index
+      @all_users ||= IdentityApi.get_users
+      @total = @all_users.size
+      @pagy, @users = pagy_array(@all_users)
+    end
+
     def show
       @teacher = IdentityApi.get_teacher(uuid)
       @teacher_name =

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,9 +49,16 @@ module ApplicationHelper
           text: "Features",
         )
         header.navigation_item(
-          active: current_page?(support_interface_identity_path),
-          href: support_interface_identity_path,
-          text: "Identity",
+          active:
+            current_page?(support_interface_identity_users_path) ||
+              current_page?(support_interface_identity_path),
+          href: support_interface_identity_users_path,
+          text: "Users",
+        )
+        header.navigation_item(
+          active: current_page?(support_interface_identity_simulate_path),
+          href: support_interface_identity_simulate_path,
+          text: "Simulate",
         )
         header.navigation_item(
           active: request.path.start_with?("/support/staff"),

--- a/app/helpers/support_interface_helper.rb
+++ b/app/helpers/support_interface_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module SupportInterfaceHelper
+  def user_info_link(user)
+    govuk_link_to(
+      user.full_name,
+      support_interface_identity_user_path(uuid: user.uuid),
+    )
+  end
+
+  def user_verification_status(user)
+    if user.name_verified?
+      govuk_tag(colour: "green", text: "VERIFIED")
+    else
+      govuk_tag(colour: "grey", text: "UNVERIFIED")
+    end
+  end
+
+  def user_dqt_record_status(user)
+    if user.trn
+      tag.span("Yes")
+    else
+      "#{tag.span("No")} #{govuk_link_to("(Add a DQT record)", "#")}".html_safe
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,27 @@
+class User
+  attr_reader :first_name,
+              :last_name,
+              :email,
+              :date_of_birth,
+              :uuid,
+              :trn,
+              :name_verified
+
+  def initialize(attributes = {})
+    @first_name = attributes.fetch("firstName", nil)
+    @last_name = attributes.fetch("lastName", nil)
+    @email = attributes.fetch("email", nil)
+    @date_of_birth = attributes.fetch("dateOfBirth", nil)
+    @uuid = attributes.fetch("userId", nil)
+    @trn = attributes.fetch("trn", nil)
+    @name_verified = attributes.fetch("nameVerified", false)
+  end
+
+  def full_name
+    [first_name, last_name].join(" ")
+  end
+
+  def name_verified?
+    name_verified
+  end
+end

--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -32,6 +32,19 @@ class IdentityApi
     response.body
   end
 
+  def self.get_users
+    if FeatureFlag.active?(:identity_api_always_timeout)
+      raise Faraday::TimeoutError, "Time-out feature flag enabled"
+    end
+
+    response = new.client.get("/api/v1/teachers")
+
+    raise ApiError, response.reason_phrase unless response.status == 200
+
+    users = response.body.fetch("teachers", [])
+    users.map { |user| User.new(user) }
+  end
+
   def self.trn_request_params(trn_request)
     {
       firstName: trn_request.first_name,

--- a/app/views/support_interface/users/index.html.erb
+++ b/app/views/support_interface/users/index.html.erb
@@ -1,0 +1,53 @@
+<% content_for :page_title, 'Support for Get an identity' %>
+
+<h2 class="govuk-heading-m">
+  <span class="govuk-caption-m">
+    Showing <%= @users.size %> of <%= @total %> total
+  </span>
+</h2>
+
+<%= govuk_pagination(pagy: @pagy) %>
+
+<% if @users.size.zero? %>
+  <p>No users.</p>
+<% else %>
+  <%= govuk_table do |table|
+    table.head do |head|
+      head.row do |row|
+        row.cell(header: true, width: 'one-quarter') do
+          tag.span("Name")
+        end
+        row.cell(header: true, width: 'one-quarter') do
+          tag.span("Name verified?")
+        end
+        row.cell(header: true, width: 'one-quarter') do
+          tag.span("DQT record")
+        end
+        row.cell(header: true, width: 'one-quarter') do
+          tag.span("TRN")
+        end
+      end
+    end
+
+    table.body do |body|
+      @users.each do |user|
+        body.row do |row|
+          row.cell do
+            user_info_link(user)
+          end
+          row.cell do
+            user_verification_status(user)
+          end
+          row.cell do
+            user_dqt_record_status(user)
+          end
+          row.cell do
+            tag.span(user.trn)
+          end
+        end
+      end
+    end
+  end %>
+<% end %>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -35,7 +35,7 @@ Pagy::DEFAULT[:page_param] = :page # default
 
 # Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
 # See https://ddnexus.github.io/pagy/extras/array
-# require 'pagy/extras/array'
+require "pagy/extras/array"
 
 # Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
 # See https://ddnexus.github.io/pagy/extras/calendar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,9 +36,12 @@ Rails.application.routes.draw do
 
     resources :zendesk_imports, only: %i[new create]
 
-    get "/identity", to: "identity#new"
+    get "/identity", to: "users#index"
     post "/identity/confirm", to: "identity#confirm"
-    get "/identity/callback", to: "identity#callback"
+    get "/identity/simulate/callback", to: "identity#callback"
+    get "/identity/simulate", to: "identity#new"
+    get "/identity/users", to: "users#index"
+    get "/identity/users/:uuid", to: "users#show", as: :identity_user
 
     get "/users/:uuid", to: "users#show", as: :user
 

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/after_being_redirected_to_the_callback/cannot_go_back_to_the_check_answers_page.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/after_being_redirected_to_the_callback/cannot_go_back_to_the_check_answers_page.yml
@@ -58,7 +58,7 @@ http_interactions:
     recorded_at: Wed, 24 Aug 2022 10:37:55 GMT
   - request:
       method: put
-      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
       body:
         encoding: UTF-8
         string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/redirects_back_to_Get_An_Identity.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/redirects_back_to_Get_An_Identity.yml
@@ -58,7 +58,7 @@ http_interactions:
     recorded_at: Wed, 24 Aug 2022 10:37:55 GMT
   - request:
       method: put
-      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
       body:
         encoding: UTF-8
         string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_no_trn_match/after_being_redirected_to_the_callback/cannot_go_back_to_the_check_answers_page.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_no_trn_match/after_being_redirected_to_the_callback/cannot_go_back_to_the_check_answers_page.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: put
-      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
       body:
         encoding: UTF-8
         string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'

--- a/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_no_trn_match/sends_a_blank_trn_to_Get_an_Identity_and_redirects_back_Get_An_Identity.yml
+++ b/spec/cassettes/Identity/when_sending_the_trn_to_the_Identity_API/when_there_is_no_trn_match/sends_a_blank_trn_to_Get_an_Identity_and_redirects_back_Get_An_Identity.yml
@@ -58,7 +58,7 @@ http_interactions:
     recorded_at: Fri, 19 Aug 2022 16:40:28 GMT
   - request:
       method: put
-      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
       body:
         encoding: UTF-8
         string: '{"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01"}'

--- a/spec/cassettes/IdentityApi/_submit_trn_/with_a_TRN_request/1_1_1_1.yml
+++ b/spec/cassettes/IdentityApi/_submit_trn_/with_a_TRN_request/1_1_1_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: put
-      uri: https://s165d01-getanid-dev-auth-server-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
       body:
         encoding: UTF-8
         string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'

--- a/spec/cassettes/Identity_Users_Support/displays_a_list_of_users.yml
+++ b/spec/cassettes/Identity_Users_Support/displays_a_list_of_users.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 15 Sep 2022 16:51:36 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-+bnYwS++CIUAr+PO3AjljCKj0q5VbYkdbL6DTV4EWdI='
+      body:
+        encoding: UTF-8
+        string: '{"teachers":[{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null},{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"jake.benilov@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"},{"userId":"f3ef3547-071e-4fbd-8a85-4faeaf788a51","email":"naomi@lockyy.com","firstName":"Naomi","lastName":"Lockhart","dateOfBirth":"1992-02-17","trn":null}]}'
+    recorded_at: Thu, 15 Sep 2022 16:51:36 GMT
+recorded_with: VCR 6.1.0

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe "Identity", type: :system do
   private
 
   def when_i_access_the_identity_endpoint
-    visit support_interface_identity_path
+    visit support_interface_identity_simulate_path
     click_on "Continue"
     click_on "Submit"
   end

--- a/spec/system/support_interface/users_spec.rb
+++ b/spec/system/support_interface/users_spec.rb
@@ -1,0 +1,137 @@
+require "rails_helper"
+
+RSpec.describe "Identity Users Support", type: :system do
+  user = {
+    "userId" => "37ee5357-fb84-478e-b750-bf552e5c8eed",
+    "email" => "kevin.e@example.com",
+    "firstName" => "Kevin",
+    "lastName" => "E",
+    "dateOfBirth" => "1990-01-01",
+    "trn" => nil,
+  }
+
+  it "displays a list of users", vcr: true, download: true do
+    given_i_am_authorized_as_a_support_user
+    when_i_visit_the_identity_users_support_page
+    then_i_should_see_a_user
+  end
+
+  context "when there are more than 100 users" do
+    before do
+      users = 150.times.map { User.new(user) }
+      allow(IdentityApi).to receive(:get_users).and_return(users)
+    end
+
+    it "shows the Identity users paginated" do
+      given_i_am_authorized_as_a_support_user
+      when_i_visit_the_identity_users_support_page
+      and_i_should_see_page_1_navigation_links
+      when_i_click_on_next
+      then_i_should_see_page_2_navigation_links
+    end
+  end
+
+  context "when there is an unverified user" do
+    before do
+      user["nameVerified"] = false
+      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+    end
+
+    it "shows an unverified user" do
+      given_i_am_authorized_as_a_support_user
+      when_i_visit_the_identity_users_support_page
+      then_i_should_see_an_unverified_user
+    end
+  end
+
+  context "when there is an verified user" do
+    before do
+      user["nameVerified"] = true
+      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+    end
+
+    it "shows an unverified user" do
+      given_i_am_authorized_as_a_support_user
+      when_i_visit_the_identity_users_support_page
+      then_i_should_see_a_verified_user
+    end
+  end
+
+  context "when the user does not have a DQT record" do
+    before do
+      user["trn"] = nil
+      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+    end
+
+    it "shows a link to add a DQT record" do
+      given_i_am_authorized_as_a_support_user
+      when_i_visit_the_identity_users_support_page
+      then_i_should_see_a_link_to_add_a_dqt_record
+    end
+  end
+
+  context "when the user has a DQT record" do
+    before do
+      user["trn"] = "12345"
+      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+    end
+
+    it "shows a link to add a DQT record" do
+      given_i_am_authorized_as_a_support_user
+      when_i_visit_the_identity_users_support_page
+      then_i_should_not_see_a_link_to_add_a_dqt_record
+    end
+  end
+
+  private
+
+  def given_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize(
+      ENV["SUPPORT_USERNAME"],
+      ENV["SUPPORT_PASSWORD"],
+    )
+  end
+
+  def when_i_visit_the_identity_users_support_page
+    visit support_interface_identity_users_path
+  end
+
+  def then_i_should_see_a_user
+    expect(page).to have_content "Jane Doess"
+  end
+
+  def then_i_should_see_an_unverified_user
+    expect(page).to have_content "UNVERIFIED"
+  end
+
+  def then_i_should_see_a_verified_user
+    expect(page).to have_content "VERIFIED"
+  end
+
+  def then_i_should_see_a_link_to_add_a_dqt_record
+    expect(page).to have_link "Add a DQT record"
+  end
+
+  def then_i_should_not_see_a_link_to_add_a_dqt_record
+    expect(page).to_not have_link "Add a DQT record"
+  end
+
+  def when_i_click_on_next
+    # There are top and bottom page navigation menus
+    first("a", text: "Next").click
+  end
+
+  def and_i_should_see_page_1_navigation_links
+    expect(page).to have_link("1")
+    expect(page).to have_link("2")
+    expect(page).to have_link("Next")
+    expect(page).to_not have_link("Prev")
+  end
+
+  def then_i_should_see_page_2_navigation_links
+    expect(page).to have_link("1")
+    expect(page).to have_link("2")
+    expect(page).to have_link("Prev")
+    expect(page).to_not have_link("Next")
+  end
+end


### PR DESCRIPTION
### Context

A page for the Support section to list users stored within Get an Identity.

### Changes proposed in this pull request

Adds a new page in the support section to list users stored within Get An Identity. Pagination is enabled for lists of over 100 users.

The Identity simulator has been moved to the `/support/identity/simulate` path.

<img width="691" alt="Screenshot 2022-09-16 at 10 56 52" src="https://user-images.githubusercontent.com/109349640/190613139-af54152c-2091-4fbd-aabb-bf4782c0378d.png">

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
