### PR TITLE
Fix markdown link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Setup the project (re-run after `Gemfile` or `package.json` updates, automatical
 bin/setup
 ```
 
-Follow the instructions in (docs/encryption.md)[docs/encryption.md]
+Follow the instructions in [docs/encryption.md](docs/encryption.md)
 to correctly set up database encryption.
 
 Run the application on `http://localhost:3000`:


### PR DESCRIPTION
### Context

The link to the encryption README in the root README is broken, as the link syntax isn't quite right.

### Changes proposed in this pull request

Fix the link syntax.

