### PR TITLE
Update support user page to fetch data from Identity API

### DIFF
--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -12,7 +12,7 @@ module SupportInterface
     def show
       @teacher = IdentityApi.get_teacher(uuid)
       @teacher_name =
-        "#{@teacher.fetch(:firstName)} #{@teacher.fetch(:lastName)}"
+        "#{@teacher.fetch("firstName")} #{@teacher.fetch("lastName")}"
     end
 
     private

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -10,9 +10,7 @@ module SupportInterface
     end
 
     def show
-      @teacher = IdentityApi.get_teacher(uuid)
-      @teacher_name =
-        "#{@teacher.fetch("firstName")} #{@teacher.fetch("lastName")}"
+      @user = IdentityApi.get_teacher(uuid)
     end
 
     private

--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -5,15 +5,16 @@ class IdentityApi
 
   FIVE_SECONDS = 5
 
-  def self.get_teacher(_uuid)
-    # Stub this method for now while the required API endpoint is being built
-    {
-      userId: "29e9e624-073e-41f5-b1b3-8164ce3a5233",
-      email: "kevin.e@digital.education.gov.uk",
-      firstName: "Kevin",
-      lastName: "E",
-      dateOfBirth: "1990-01-01",
-    }
+  def self.get_teacher(uuid)
+    if FeatureFlag.active?(:identity_api_always_timeout)
+      raise Faraday::TimeoutError, "Time-out feature flag enabled"
+    end
+
+    response = new.client.get("/api/v1/teachers/#{uuid}")
+
+    raise ApiError, response.reason_phrase unless response.status == 200
+
+    response.body
   end
 
   def self.submit_trn!(trn_request, journey_id)

--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -14,7 +14,7 @@ class IdentityApi
 
     raise ApiError, response.reason_phrase unless response.status == 200
 
-    response.body
+    User.new(response.body)
   end
 
   def self.submit_trn!(trn_request, journey_id)

--- a/app/views/support_interface/users/show.html.erb
+++ b/app/views/support_interface/users/show.html.erb
@@ -33,7 +33,7 @@
 
       <% list.row do |row| %>
         <% row.key { "Email address" } %>
-        <% row.value { @teacher.fetch(:email) } %>
+        <% row.value { @teacher.fetch("email") } %>
         <%= row.action(text: "Change", href: "#", visually_hidden_text: "email address") %>
       <% end %>
 

--- a/app/views/support_interface/users/show.html.erb
+++ b/app/views/support_interface/users/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for :page_title, 'Teachers' %>
 
-<%= govuk_breadcrumbs(breadcrumbs: { "Support" => support_interface_validation_errors_path, @teacher_name => nil }) %>
+<%= govuk_breadcrumbs(breadcrumbs: { "Support" => support_interface_validation_errors_path, @user.full_name => nil }) %>
 <h1 class="govuk-heading-xl">
-  <%= @teacher_name %>
+  <%= @user.full_name %>
 </h1>
 
 <section class="x-govuk-summary-card govuk-!-margin-bottom-9">
@@ -18,7 +18,7 @@
         <% row.key { "Official name" } %>
         <% row.value do %>
           <p>
-            <%= @teacher_name %>
+            <%= @user.full_name %>
             <%= govuk_tag(text: "Unverified", colour: "grey") %>
           </p>
 
@@ -33,7 +33,7 @@
 
       <% list.row do |row| %>
         <% row.key { "Email address" } %>
-        <% row.value { @teacher.fetch("email") } %>
+        <% row.value { @user.email } %>
         <%= row.action(text: "Change", href: "#", visually_hidden_text: "email address") %>
       <% end %>
 

--- a/spec/cassettes/User_page_in_support/Staff_user_views_user_details.yml
+++ b/spec/cassettes/User_page_in_support/Staff_user_views_user_details.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Tue, 20 Sep 2022 14:10:10 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-CBFrTy0U2WyBTdBODmxD/VA7qXxyIRT9Bt23MqVZNwU='
+      body:
+        encoding: UTF-8
+        string: '{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"kevin.e@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"}'
+    recorded_at: Tue, 20 Sep 2022 14:10:11 GMT
+recorded_with: VCR 6.1.0

--- a/spec/system/support_interface/view_a_user_spec.rb
+++ b/spec/system/support_interface/view_a_user_spec.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe "View a user in support", type: :system do
-  scenario "Staff user views user details" do
+RSpec.feature "User page in support", type: :system do
+  background { @user_email = "kevin.e@digital.education.gov.uk" }
+
+  scenario(
+    "Staff user views user details",
+    vcr: {
+      erb: {
+        user_email: @user_email,
+      },
+    },
+  ) do
     given_i_am_authorized_as_staff
     and_a_user_exists_on_the_identity_api
     when_i_navigate_to_the_user_show_page_in_support
@@ -16,9 +25,8 @@ RSpec.describe "View a user in support", type: :system do
   end
 
   def and_a_user_exists_on_the_identity_api
-    # Use an arbitrary uuid value for now. Once the required API endpoint is implemented,
-    # this should match the value used in a recorded VCR cassette.
-    @uuid = "any-uuid"
+    # Matches uuid value used in VCR cassette
+    @uuid = "29e9e624-073e-41f5-b1b3-8164ce3a5233"
   end
 
   def when_i_navigate_to_the_user_show_page_in_support
@@ -32,7 +40,7 @@ RSpec.describe "View a user in support", type: :system do
         expect(page).to have_content "Get an identity details"
       end
       expect(page).to have_content "Kevin E"
-      expect(page).to have_content "kevin.e@digital.education.gov.uk"
+      expect(page).to have_content @user_email
     end
   end
 end


### PR DESCRIPTION
### Context

The Identity API now has an endpoint for returning user details. We can make use of it on the user show page in support.

### Changes proposed in this pull request

- Implement API interaction in the IdentityApi service class.
- Amend the system spec, adding a VCR recording of the interaction.

![Screenshot_20220921_094502](https://user-images.githubusercontent.com/519250/191458768-8996ce5a-4654-495f-8e92-c1a1475894ed.png)


### Guidance to review

n/a

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
