### PR TITLE
Identity Support: Is this the right record page

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,5 +4,5 @@ HOSTING_ENVIRONMENT_NAME=local
 SUPPORT_PASSWORD=test
 SUPPORT_USERNAME=test
 IDENTITY_SHARED_SECRET_KEY=testkey
-IDENTITY_API_URL=https://s165d01-getanid-dev-auth-server-app.azurewebsites.net
+IDENTITY_API_URL=https://s165t01-getanid-preprod-auths-app.azurewebsites.net
 IDENTITY_API_KEY=testkey

--- a/app/components/confirm_dqt_component.html.erb
+++ b/app/components/confirm_dqt_component.html.erb
@@ -1,0 +1,22 @@
+<%
+  teacher_rows = []
+
+  teacher_name_row = {
+    key: { text: 'Official name' },
+    value: { text: teacher_full_name },
+  }
+
+  teacher_email_row = {
+    key: { text: 'Email address' },
+    value: { text: teacher_email },
+  }
+
+  teacher_rows.push(teacher_name_row)
+  teacher_rows.push(teacher_email_row)
+%>
+
+<%= render(SummaryCardComponent.new(rows: teacher_rows)) do %>
+  <%= render SummaryCardHeaderComponent.new(title: 'Get an identity') %>
+<% end %>
+
+<%= render(DqtRecordComponent.new(dqt_record: @dqt_record)) %>

--- a/app/components/confirm_dqt_component.rb
+++ b/app/components/confirm_dqt_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class ConfirmDqtComponent < ViewComponent::Base
+  def initialize(user:, dqt_record:)
+    super
+    @user = user
+    @dqt_record = dqt_record
+  end
+
+  def teacher_full_name
+    "#{@user.first_name} #{@user.last_name}"
+  end
+
+  def teacher_email
+    helpers.shy_email(@user.email)
+  end
+end

--- a/app/controllers/support_interface/dqt_records_controller.rb
+++ b/app/controllers/support_interface/dqt_records_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module SupportInterface
+  class DqtRecordsController < ApplicationController
+    def edit
+      uuid = params[:id]
+      @confirm_dqt_record_form = ConfirmDqtRecordForm.new
+      @user = IdentityApi.get_user(uuid)
+      @dqt_record = DqtApi.find_teacher!(date_of_birth:, trn:)
+    end
+
+    def update
+      uuid = params[:id]
+      @confirm_dqt_record_form =
+        ConfirmDqtRecordForm.new(confirm_dqt_record_params)
+      if @confirm_dqt_record_form.valid?
+        if @confirm_dqt_record_form.confirmed?
+          IdentityApi.update_user_trn(uuid, trn)
+
+          flash[:success] = "DQT Record added"
+        else
+          flash[:notice] = "DQT Record not added"
+        end
+
+        redirect_to support_interface_identity_user_path(uuid)
+      else
+        @dqt_record = DqtApi.find_teacher!(date_of_birth:, trn:)
+        @user = IdentityApi.get_user(uuid)
+        render :edit
+      end
+    end
+
+    private
+
+    def date_of_birth
+      "1990-01-01"
+    end
+
+    def trn
+      "2921020"
+    end
+
+    def confirm_dqt_record_params
+      params.fetch(:support_interface_confirm_dqt_record_form, {}).permit(
+        :add_dqt_record,
+      )
+    end
+  end
+end

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -11,21 +11,21 @@ module SupportInterface
 
     def show
       @user = IdentityApi.get_user(uuid)
-      @dqt_record =
-        DqtApi.find_teacher!(
-          date_of_birth: @user.date_of_birth,
-          trn: @user.trn,
-        ) if @user.trn
+      @dqt_record = DqtApi.find_teacher!(date_of_birth:, trn:) if @user.trn
     end
 
     private
 
-    def uuid
-      params.require(:uuid)
+    def date_of_birth
+      "1990-01-01"
     end
 
     def trn
-      params.require(:trn)
+      "2921020"
+    end
+
+    def uuid
+      params.require(:uuid)
     end
   end
 end

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -18,13 +18,6 @@ module SupportInterface
         ) if @user.trn
     end
 
-    def update
-      IdentityApi.update_user_trn(uuid, trn)
-
-      flash[:success] = "DQT record added"
-      redirect_to support_interface_identity_user_path(uuid:)
-    end
-
     private
 
     def uuid

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -10,7 +10,7 @@ module SupportInterface
     end
 
     def show
-      @user = IdentityApi.get_teacher(uuid)
+      @user = IdentityApi.get_user(uuid)
       @dqt_record =
         DqtApi.find_teacher!(
           date_of_birth: @user.date_of_birth,

--- a/app/forms/support_interface/confirm_dqt_record_form.rb
+++ b/app/forms/support_interface/confirm_dqt_record_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module SupportInterface
+  class ConfirmDqtRecordForm
+    include ActiveModel::Model
+    include LogErrors
+
+    attr_accessor :add_dqt_record
+
+    validates :add_dqt_record, inclusion: { in: %w[Yes No] }
+
+    def confirmed?
+      add_dqt_record.downcase == "yes"
+    end
+  end
+end

--- a/app/helpers/support_interface_helper.rb
+++ b/app/helpers/support_interface_helper.rb
@@ -20,7 +20,12 @@ module SupportInterfaceHelper
     if user.trn
       tag.span("Yes")
     else
-      "#{tag.span("No")} #{govuk_link_to("(Add a DQT record)", "#")}".html_safe
+      link =
+        govuk_link_to(
+          "(Add a DQT record)",
+          edit_support_interface_dqt_record_path(user.uuid),
+        )
+      "#{tag.span("No")} #{link}".html_safe
     end
   end
 end

--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -5,12 +5,12 @@ class IdentityApi
 
   FIVE_SECONDS = 5
 
-  def self.get_teacher(uuid)
+  def self.get_user(uuid)
     if FeatureFlag.active?(:identity_api_always_timeout)
       raise Faraday::TimeoutError, "Time-out feature flag enabled"
     end
 
-    response = new.client.get("/api/v1/teachers/#{uuid}")
+    response = new.client.get("/api/v1/users/#{uuid}")
 
     raise ApiError, response.reason_phrase unless response.status == 200
 

--- a/app/views/support_interface/dqt_records/edit.html.erb
+++ b/app/views/support_interface/dqt_records/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "W#{'Error: ' if @confirm_dqt_record_form.errors.any?}e found a DQT record, is it the right one?" %>
+<% content_for :back_link_url, back_link_url %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @confirm_dqt_record_form, url: support_interface_dqt_record_path(@user.uuid), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        We found a DQT record, is it the right one?
+      </h1>
+
+      <%= render(ConfirmDqtComponent.new(user: @user, dqt_record: @dqt_record)) %>
+
+      <%= f.govuk_radio_buttons_fieldset :add_dqt_record, legend: { size: 'm', text: 'Do you want to add this DQT record?' } do %>
+        <%= f.govuk_radio_button :add_dqt_record, 'Yes', label: { text: "Yes, add this record" }, link_errors: true %>
+        <%= f.govuk_radio_button :add_dqt_record, 'No', label: { text: "No, this is the wrong record" } %>
+      <% end %>
+
+      <%= f.govuk_submit text: "Finish", prevent_double_click: false %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/users/show.html.erb
+++ b/app/views/support_interface/users/show.html.erb
@@ -43,7 +43,7 @@
       if @user.trn
         ary << { text: "Change record", href: "#" }
       else
-        ary << { text: "Add record", href: support_interface_identity_user_update_path(uuid: @user.uuid, trn: "2921020") }
+        ary << { text: "Add record", href: edit_support_interface_dqt_record_path(@user.uuid) }
       end
     end
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,3 +91,7 @@ en:
               blank: Enter your TRN number
               too_long: Enter a TRN number that is 7 digits long
               wrong_length: Your TRN number should contain 7 digits
+        support_interface/confirm_dqt_record_form:
+          attributes:
+            add_dqt_record:
+              inclusion: Tell us if this is the right DQT record

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
     get "/identity/users", to: "users#index"
     get "/identity/users/:uuid", to: "users#show", as: :identity_user
 
+    resources :dqt_records, only: %i[edit update]
+
     get "/users/:uuid", to: "users#show", as: :user
 
     resources :trn_requests, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,9 +42,6 @@ Rails.application.routes.draw do
     get "/identity/simulate", to: "identity#new"
     get "/identity/users", to: "users#index"
     get "/identity/users/:uuid", to: "users#show", as: :identity_user
-    get "/identity/users/update/:uuid",
-        to: "users#update",
-        as: :identity_user_update
 
     get "/users/:uuid", to: "users#show", as: :user
 

--- a/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/Asks_user_to_select_an_option_if_they_have_non_selected.yml
+++ b/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/Asks_user_to_select_an_option_if_they_have_non_selected.yml
@@ -1,0 +1,233 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 28 Sep 2022 11:06:45 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-pR2Mpgh2fhtmOfqmibwz/8egKfjZVlnoeN21g5xtdaI='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:07:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null}'
+    recorded_at: Wed, 28 Sep 2022 11:06:46 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Sep 2022 11:06:46 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:07:00.0000000Z"
+        X-Vcap-Request-Id:
+          - d9d45c55-861c-4ff6-53ad-26f755c2bce0
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 b1c64361268fcbad3c03abbe37eb5cfa.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - FRA60-P4
+        X-Amz-Cf-Id:
+          - ubDgMz8sbnesxK7AUjIKyPG7zwGQzoDepnITVdCcFMvm9n_tOuWT0A==
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Wed, 28 Sep 2022 11:06:46 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Sep 2022 11:06:47 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "298"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:07:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 87a5d0b6-ae5c-4483-67c7-5e87f1d5c060
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 ba67e20db38657ee5cb05d05b3da9d70.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - FRA60-P4
+        X-Amz-Cf-Id:
+          - hWtc6v9Oji-Bu0RK5TmIBSqFY13GgTeig_5rY7ZOJksjMQNwgA4fQA==
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Wed, 28 Sep 2022 11:06:47 GMT
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 28 Sep 2022 11:06:47 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-Wgb/rF3wwPfXtIjv+7UOird3eANoeYxOdTaiRtUpNnM='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "298"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:07:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null}'
+    recorded_at: Wed, 28 Sep 2022 11:06:48 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/Does_not_link_DQT_record_when_user_rejects_confirmation.yml
+++ b/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/Does_not_link_DQT_record_when_user_rejects_confirmation.yml
@@ -1,0 +1,171 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 28 Sep 2022 11:06:48 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-PCaZnUlBgwycQ8J+2S1iVcO2sbe5YXI0/md+F8GNn48='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "297"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:07:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null}'
+    recorded_at: Wed, 28 Sep 2022 11:06:48 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Sep 2022 11:06:49 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "297"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:07:00.0000000Z"
+        X-Vcap-Request-Id:
+          - d743a3eb-c156-46f8-7440-b2985e189721
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 dd4531988f4862a3b186f9d3356a6a74.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - FRA60-P4
+        X-Amz-Cf-Id:
+          - "-PKDUzLPfa74B5Lk-zQc2zxRzk9tg42P_zYriLqDoKWGsQuWudoBAw=="
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Wed, 28 Sep 2022 11:06:49 GMT
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 28 Sep 2022 11:06:49 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-GimZAzk0fmkiVgmAeTWHpS9SIDVsHd+KOqnBL6ahpuo='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "296"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:07:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null}'
+    recorded_at: Wed, 28 Sep 2022 11:06:50 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/Navigates_us_to_the_previous_page.yml
+++ b/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/Navigates_us_to_the_previous_page.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 28 Sep 2022 11:07:18 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-U6NueZYQm+ajfwiP0O15qjcfkRH2qsOZEq6/5qSjrVo='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "295"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:08:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null}'
+    recorded_at: Wed, 28 Sep 2022 11:07:19 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Sep 2022 11:07:19 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "296"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:08:00.0000000Z"
+        X-Vcap-Request-Id:
+          - b1646906-4baf-4845-796a-1991a5ac0e7b
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 cfa647edefc0769e715b9781478b0626.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - FRA60-P4
+        X-Amz-Cf-Id:
+          - vPe_TY6tGNXyvLJNMusKMgLHYeyh79pe5gbNHHt4FjLT54AQkQ46lw==
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Wed, 28 Sep 2022 11:07:19 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/links_DQT_record_when_user_accepts_confirmation.yml
+++ b/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/links_DQT_record_when_user_accepts_confirmation.yml
@@ -1,0 +1,272 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 28 Sep 2022 11:07:19 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-8Y1yLybvRgEwW5xK3Q50NAk5D6rGh5lSdkkWt8U+sS8='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "294"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:08:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null}'
+    recorded_at: Wed, 28 Sep 2022 11:07:20 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Sep 2022 11:07:20 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "295"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:08:00.0000000Z"
+        X-Vcap-Request-Id:
+          - cfceadbd-ee3f-4f92-6d33-41f04ef0860e
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 816b7f4e336674d9d7828ef4700482e8.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - FRA60-P4
+        X-Amz-Cf-Id:
+          - z1PXonq1bSiYh6OdfL9BPJG-Ha3NSE4Klkd4VddQVHAh3m4xTxD18g==
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Wed, 28 Sep 2022 11:07:20 GMT
+  - request:
+      method: put
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed/trn
+      body:
+        encoding: UTF-8
+        string: '{"trn":"2921020"}'
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Tue, 27 Sep 2022 09:49:10 GMT
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-asHF58N2tfVs09Qp6CCdpo8wjBe7yTKknLFuN/6luKE='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Tue, 27 Sep 2022 09:49:10 GMT
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Tue, 27 Sep 2022 09:49:11 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-PKZKUDo3fRLRxCkipnItYBeBBbyg2l6xuIyVmNjwElM='
+      body:
+        encoding: UTF-8
+        string: '{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":"2921020"}'
+    recorded_at: Tue, 27 Sep 2022 09:49:11 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 28 Sep 2022 11:20:06 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-28T11:21:00.0000000Z"
+        X-Vcap-Request-Id:
+          - d18f7535-03ef-4772-5f7a-b5a9703e3c8a
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 72e8bbddfffeeec486003f867d631024.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - FRA56-C1
+        X-Amz-Cf-Id:
+          - tx67tKkNqske8e-F6vsWwy11tZ9g033nixVAofKvkV0-_oUT_Gtiag==
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Wed, 28 Sep 2022 11:20:06 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/User_page_in_support/displays_the_user.yml
+++ b/spec/cassettes/User_page_in_support/displays_the_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/29e9e624-073e-41f5-b1b3-8164ce3a5233
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/cassettes/User_page_in_support/when_the_user_has_no_DQT_record/does_not_show_a_DQT_section.yml
+++ b/spec/cassettes/User_page_in_support/when_the_user_has_no_DQT_record/does_not_show_a_DQT_section.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/29e9e624-073e-41f5-b1b3-8164ce3a5233
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/cassettes/User_page_in_support/when_the_user_has_no_DQT_record/when_i_click_on_add_record.yml
+++ b/spec/cassettes/User_page_in_support/when_the_user_has_no_DQT_record/when_i_click_on_add_record.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/29e9e624-073e-41f5-b1b3-8164ce3a5233
       body:
         encoding: US-ASCII
         string: ""
@@ -156,7 +156,7 @@ http_interactions:
     recorded_at: Thu, 22 Sep 2022 18:38:38 GMT
   - request:
       method: get
-      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/29e9e624-073e-41f5-b1b3-8164ce3a5233
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/system/support_interface/view_a_user_spec.rb
+++ b/spec/system/support_interface/view_a_user_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe "User page in support", vcr: true, type: :system do
 
     it "when_i_click_on_add_record" do
       and_i_click_on_add_record
-      then_i_see_an_add_dqt_success_message
-      and_i_can_see_the_users_dqt_details
+      then_i_see_the_confirm_dqt_page
     end
   end
 
@@ -89,7 +88,7 @@ RSpec.describe "User page in support", vcr: true, type: :system do
     click_on "Add record"
   end
 
-  def then_i_see_an_add_dqt_success_message
-    expect(page).to have_content("DQT record added")
+  def then_i_see_the_confirm_dqt_page
+    expect(page).to have_content("Do you want to add this DQT record?")
   end
 end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/qCxyKAGw/696-identity-support-is-this-the-right-record-page)

<img width="487" alt="Screenshot 2022-09-21 at 13 08 58" src="https://user-images.githubusercontent.com/547202/191489813-296080f3-b4e8-4408-9444-8465420235b1.png">

### Context

When users attempt to match an Identity record to a DQT record, we want them to review the details before they confirm the match.

### Changes proposed in this pull request

- When users click Add record on the user page, we immediately look up Kevin E's TRN, but ask them to confirm before we associate it with the record
- The page looks like the design and is populated with data both from the Identity API as well as the qualified-teachers-api
- The page lives at something like /support/identity/users/1/confirm
- The radio buttons work correctly
- "No" simply aborts the process and takes the user back to the user page
- Submitting with "Yes" associates the record and takes the staff user back to the user page

### Guidance to review

- Design matches requirement
- Links Work Correctly
- URL routes look ok
- Does not break previous functionality

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
