### PR TITLE
Move recursion to the tail end of the job

### DIFF
--- a/app/jobs/delete_old_zendesk_tickets_job.rb
+++ b/app/jobs/delete_old_zendesk_tickets_job.rb
@@ -4,9 +4,6 @@ class DeleteOldZendeskTicketsJob < ApplicationJob
 
     tickets = ZendeskService.find_closed_tickets_from_6_months_ago
     return if tickets.count.zero?
-    if tickets.count >= 100
-      DeleteOldZendeskTicketsJob.set(wait: 5.minutes).perform_later
-    end
 
     tickets.each do |ticket|
       ZendeskDeleteRequest
@@ -17,5 +14,9 @@ class DeleteOldZendeskTicketsJob < ApplicationJob
 
     ids = tickets.map(&:id)
     ZendeskService.destroy_tickets!(ids)
+
+    if tickets.count >= 100
+      DeleteOldZendeskTicketsJob.set(wait: 5.minutes).perform_later
+    end
   end
 end


### PR DESCRIPTION
DeleteOldZendeskTicketsJob checks if there are more than 100 tickets to delete. If there are, it queues another job, then tries to delete them.

The problem is that if the delete call fails, it also queues another job. So you can queue 2 jobs from 1 job. Then those 2 jobs can queue up to 4 jobs. And so on.

This is a temporary fix to move the recursion to the end of the call. A better fix is to rewrite the job to use pagination/fetch the full list of Zendesk tickets instead of relying on recursion.