### PR TITLE
Increase the timeout on DQT API unlock request to 10 seconds

### DIFF
--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -54,7 +54,7 @@ class DqtApi
   def self.unlock_teacher!(uid:)
     if FeatureFlag.active?(:unlock_teachers_self_service_portal_account)
       begin
-        response = new.client.put("/v2/unlock-teacher/#{uid}", {})
+        response = new.client.put("/v2/unlock-teacher/#{uid}", { timeout: 10 })
         raise ApiError, response.reason_phrase unless response.success?
         response.body["hasBeenUnlocked"]
       rescue ApiError => e


### PR DESCRIPTION
### Context

This endpoint can be slow, and since it's called in the background the longer timeout doesn't impact users.

### Changes proposed in this pull request

Increase the timeout on DQT API unlock request to 10 seconds

