### PR TITLE
Match an Identity record to Kevin E

### DIFF
--- a/app/components/dqt_record_component.html.erb
+++ b/app/components/dqt_record_component.html.erb
@@ -1,0 +1,39 @@
+<%
+  dqt_rows = []
+
+  name_row = {
+    key: { text: 'Official name' },
+    value: { text: full_name },
+  }
+
+  date_of_birth_row = {
+    key: { text: 'Date of birth' },
+    value: { text: date_of_birth },
+  }
+
+  nino_row = {
+    key: { text: 'National insurance number' },
+    value: { text: nino },
+  }
+
+  trn_row = {
+    key: { text: 'TRN' },
+    value: { text: trn },
+  }
+
+  dqt_rows.push(name_row)
+  dqt_rows.push(date_of_birth_row)
+  dqt_rows.push(nino_row)
+  dqt_rows.push(trn_row)
+%>
+
+<section class="x-govuk-summary-card govuk-!-margin-bottom-6">
+ <header class="x-govuk-summary-card__header">
+  <h2 class="x-govuk-summary-card__title">
+    DQT record
+  </h2>
+ </header>
+ <div class="x-govuk-summary-card__body">
+  <%= govuk_summary_list(rows: dqt_rows) %>
+ </div>
+</section>

--- a/app/components/dqt_record_component.rb
+++ b/app/components/dqt_record_component.rb
@@ -1,0 +1,22 @@
+class DqtRecordComponent < ViewComponent::Base
+  def initialize(dqt_record:)
+    super
+    @dqt_record = dqt_record
+  end
+
+  def full_name
+    @dqt_record.fetch("name", nil)
+  end
+
+  def date_of_birth
+    @dqt_record.fetch("dob", nil)&.to_date&.to_fs(:long_ordinal_uk)
+  end
+
+  def nino
+    @dqt_record.fetch("ni_number", nil) ? "Given" : "Not Given"
+  end
+
+  def trn
+    @dqt_record["trn"]
+  end
+end

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -11,12 +11,28 @@ module SupportInterface
 
     def show
       @user = IdentityApi.get_teacher(uuid)
+      @dqt_record =
+        DqtApi.find_teacher!(
+          date_of_birth: @user.date_of_birth,
+          trn: @user.trn,
+        ) if @user.trn
+    end
+
+    def update
+      IdentityApi.update_user_trn(uuid, trn)
+
+      flash[:success] = "DQT record added"
+      redirect_to support_interface_identity_user_path(uuid:)
     end
 
     private
 
     def uuid
       params.require(:uuid)
+    end
+
+    def trn
+      params.require(:trn)
     end
   end
 end

--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -33,6 +33,18 @@ class IdentityApi
     response.body
   end
 
+  def self.update_user_trn(uuid, trn)
+    if FeatureFlag.active?(:identity_api_always_timeout)
+      raise Faraday::TimeoutError, "Time-out feature flag enabled"
+    end
+
+    response = new.client.put("/api/v1/users/#{uuid}/trn", { trn: })
+
+    raise ApiError, response.reason_phrase unless response.status == 204
+
+    response.body
+  end
+
   def self.get_users
     if FeatureFlag.active?(:identity_api_always_timeout)
       raise Faraday::TimeoutError, "Time-out feature flag enabled"
@@ -42,7 +54,7 @@ class IdentityApi
 
     raise ApiError, response.reason_phrase unless response.status == 200
 
-    users = response.body.fetch("teachers", [])
+    users = response.body.fetch("users", [])
     users.map { |user| User.new(user) }
   end
 

--- a/app/views/support_interface/users/show.html.erb
+++ b/app/views/support_interface/users/show.html.erb
@@ -40,8 +40,14 @@
       <% list.row do |row| %>
         <% row.key { "DQT record" } %>
         <% row.value { "No record linked" } %>
-        <% row.action(text: "Add record", href: "#") %>
+        <% if @user.trn %>
+        <% row.action(text: "Change record", href: '#') %>
+        <% else %>
+        <% row.action(text: "Add record", href: support_interface_identity_user_update_path(uuid: @user.uuid, trn: "2921020")) %>
+        <% end %>
       <% end %>
     <% end %>
   </div>
 </section>
+
+<%= render(DqtRecordComponent.new(dqt_record: @dqt_record)) if @dqt_record %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ Rails.application.routes.draw do
     get "/identity/simulate", to: "identity#new"
     get "/identity/users", to: "users#index"
     get "/identity/users/:uuid", to: "users#show", as: :identity_user
+    get "/identity/users/update/:uuid",
+        to: "users#update",
+        as: :identity_user_update
 
     get "/users/:uuid", to: "users#show", as: :user
 

--- a/spec/cassettes/Identity_Users_Support/displays_a_list_of_users.yml
+++ b/spec/cassettes/Identity_Users_Support/displays_a_list_of_users.yml
@@ -45,6 +45,6 @@ http_interactions:
             'nonce-+bnYwS++CIUAr+PO3AjljCKj0q5VbYkdbL6DTV4EWdI='
       body:
         encoding: UTF-8
-        string: '{"teachers":[{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null},{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"jake.benilov@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"},{"userId":"f3ef3547-071e-4fbd-8a85-4faeaf788a51","email":"naomi@lockyy.com","firstName":"Naomi","lastName":"Lockhart","dateOfBirth":"1992-02-17","trn":null}]}'
+        string: '{"users":[{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null},{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"jake.benilov@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"},{"userId":"f3ef3547-071e-4fbd-8a85-4faeaf788a51","email":"naomi@lockyy.com","firstName":"Naomi","lastName":"Lockhart","dateOfBirth":"1992-02-17","trn":null}]}'
     recorded_at: Thu, 15 Sep 2022 16:51:36 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/User_page_in_support/adding_a_DQT_record/when_i_click_on_add_record.yml
+++ b/spec/cassettes/User_page_in_support/adding_a_DQT_record/when_i_click_on_add_record.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 22 Sep 2022 16:15:52 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-GmFRN2y8/sq+UZSD+pr4oaFOMbclgdd6xAwwKIPShro='
+      body:
+        encoding: UTF-8
+        string: '{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"kevin.e@digital.education.gov.uk,"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"}'
+    recorded_at: Thu, 22 Sep 2022 16:15:53 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Thu, 22 Sep 2022 16:15:53 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-22T16:16:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 109c8ace-fd97-4a82-7382-1ab9433b4734
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 323b4a7971a31c96655a9c4fcac2b9ce.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-C2
+        X-Amz-Cf-Id:
+          - jcH-4eKyR3KByLGAhc-bxVVItlOl8iB45J7O-xRSbct5HM9IZclT0g==
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Thu, 22 Sep 2022 16:15:53 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/User_page_in_support/displays_the_user.yml
+++ b/spec/cassettes/User_page_in_support/displays_the_user.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 22 Sep 2022 18:04:30 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-s6kgvaapFwPTdgN+cKpfzK7R42gVHA3+h5hcqqRTDFg='
+      body:
+        encoding: UTF-8
+        string: '{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"kevin.e@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"}'
+    recorded_at: Thu, 22 Sep 2022 18:04:30 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Thu, 22 Sep 2022 18:04:34 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-22T18:05:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 136b5a6d-4f27-4e45-573b-0b7e1773fcac
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 8ba281782b2b20f7db8f5372bc06a3a2.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - fk_l6wmcZhqbSs2F1O4idnxy_pfgXMe-_gUBQwVTs8yFcAYkhAX7kw==
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Thu, 22 Sep 2022 18:04:34 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/User_page_in_support/when_the_user_has_no_DQT_record/does_not_show_a_DQT_section.yml
+++ b/spec/cassettes/User_page_in_support/when_the_user_has_no_DQT_record/does_not_show_a_DQT_section.yml
@@ -23,7 +23,7 @@ http_interactions:
         Content-Type:
           - application/json; charset=utf-8
         Date:
-          - Tue, 20 Sep 2022 14:10:10 GMT
+          - Thu, 22 Sep 2022 18:26:20 GMT
         Transfer-Encoding:
           - chunked
         Request-Context:
@@ -42,9 +42,8 @@ http_interactions:
           - no-referrer
         Content-Security-Policy:
           - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
-            'nonce-CBFrTy0U2WyBTdBODmxD/VA7qXxyIRT9Bt23MqVZNwU='
+            'nonce-jDQxmKQLH+kyWosDMI/evbtiDvZIhvAeU9UB3/MRbCQ='
       body:
         encoding: UTF-8
-        string: '{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"kevin.e@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"}'
-    recorded_at: Tue, 20 Sep 2022 14:10:11 GMT
-recorded_with: VCR 6.1.0
+        string: '{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"kevin.e@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":null}'
+    recorded_at: Thu, 22 Sep 2022 18:26:20 GMT

--- a/spec/cassettes/User_page_in_support/when_the_user_has_no_DQT_record/when_i_click_on_add_record.yml
+++ b/spec/cassettes/User_page_in_support/when_the_user_has_no_DQT_record/when_i_click_on_add_record.yml
@@ -1,0 +1,204 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 22 Sep 2022 18:38:36 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-hTp4wyO0cZ4v86IOElAVOIwiMse1eCqXCeZpoP6Cw4k='
+      body:
+        encoding: UTF-8
+        string: '{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"kevin.e@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":null}'
+    recorded_at: Thu, 22 Sep 2022 18:38:36 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v1/teachers/2921020?birthdate=1990-01-01
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Thu, 22 Sep 2022 18:38:37 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-22T18:39:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 3fabdeed-00d7-4ffa-4fd7-29d02bb8ae5b
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 de0dad50586f94423362513b4f1660b2.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - I8OoJ8l4t0ri3_ras2vKbHVdOHXqMZdABGRAy0jbSpSvNcijs3cBOA==
+      body:
+        encoding: UTF-8
+        string:
+          '{"trn":"2921020","ni_number":"AA123456A","qualified_teacher_status":{"name":"Trainee
+          Teacher:DMS","state":"Active","state_name":"Active","qts_date":null},"induction":null,"initial_teacher_training":{"state":"Active","state_code":"Active","programme_start_date":"2020-04-01T00:00:00Z","programme_end_date":"2020-10-10T00:00:00Z","programme_type":"Graduate
+          Teacher Programme","result":"In Training","subject1":"computer science","subject2":null,"subject3":null,"qualification":null,"subject1_code":"100366","subject2_code":null,"subject3_code":null},"qualifications":[{"name":"Higher
+          Education","date_awarded":"2021-05-03T00:00:00Z","he_qualification_name":"First
+          Degree","he_subject1":"computer science","he_subject2":null,"he_subject3":null,"he_subject1_code":"100366","he_subject2_code":null,"he_subject3_code":null,"class":"FirstClassHonours"}],"name":"Kevin
+          E","dob":"1990-01-01T00:00:00","active_alert":false,"state":"Active","state_name":"Active"}'
+    recorded_at: Thu, 22 Sep 2022 18:38:37 GMT
+  - request:
+      method: put
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/29e9e624-073e-41f5-b1b3-8164ce3a5233/trn
+      body:
+        encoding: UTF-8
+        string: '{"trn":"2921020"}'
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Thu, 22 Sep 2022 18:38:37 GMT
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-asHF58N2tfVs09Qp6CCdpo8wjBe7yTKknLFuN/6luKE='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Thu, 22 Sep 2022 18:38:38 GMT
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 22 Sep 2022 18:38:37 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=2592000
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI='
+            'nonce-PKZKUDo3fRLRxCkipnItYBeBBbyg2l6xuIyVmNjwElM='
+      body:
+        encoding: UTF-8
+        string: '{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"kevin.e@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"}'
+    recorded_at: Thu, 22 Sep 2022 18:38:39 GMT
+recorded_with: VCR 6.1.0

--- a/spec/system/support_interface/view_a_user_spec.rb
+++ b/spec/system/support_interface/view_a_user_spec.rb
@@ -1,21 +1,32 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.feature "User page in support", type: :system do
-  background { @user_email = "kevin.e@digital.education.gov.uk" }
-
-  scenario(
-    "Staff user views user details",
-    vcr: {
-      erb: {
-        user_email: @user_email,
-      },
-    },
-  ) do
+RSpec.describe "User page in support", vcr: true, type: :system do
+  it "displays the user" do
     given_i_am_authorized_as_staff
     and_a_user_exists_on_the_identity_api
     when_i_navigate_to_the_user_show_page_in_support
     then_i_can_see_the_users_details
+    and_i_can_see_the_users_dqt_details
+    and_i_can_see_a_link_to_change_the_dqt_record
+  end
+
+  context "when the user has no DQT record", vcr: true do
+    before do
+      given_i_am_authorized_as_staff
+      and_a_user_exists_on_the_identity_api
+      when_i_navigate_to_the_user_show_page_in_support
+    end
+
+    it "does not show a DQT section" do
+      then_i_cannot_see_the_users_dqt_section
+    end
+
+    it "when_i_click_on_add_record" do
+      and_i_click_on_add_record
+      then_i_see_an_add_dqt_success_message
+      and_i_can_see_the_users_dqt_details
+    end
   end
 
   private
@@ -35,12 +46,48 @@ RSpec.feature "User page in support", type: :system do
 
   def then_i_can_see_the_users_details
     expect(current_path).to eq support_interface_user_path(@uuid)
-    within(".x-govuk-summary-card") do
+    within first(".x-govuk-summary-card") do
       within(".x-govuk-summary-card__header") do
         expect(page).to have_content "Get an identity details"
       end
       expect(page).to have_content "Kevin E"
-      expect(page).to have_content @user_email
+      expect(page).to have_content "kevin.e@digital.education.gov.uk"
     end
+  end
+
+  def and_i_can_see_the_users_dqt_details
+    within all(".x-govuk-summary-card").last do
+      within(".x-govuk-summary-card__header") do
+        expect(page).to have_content "DQT record"
+      end
+      expect(page).to have_content "Official name"
+      expect(page).to have_content "Kevin E"
+      expect(page).to have_content "Date of birth"
+      expect(page).to have_content "1 January 1990"
+      expect(page).to have_content "National insurance number"
+      expect(page).to have_content "Given"
+      expect(page).to have_content "TRN"
+      expect(page).to have_content "2921020"
+    end
+  end
+
+  def and_i_can_see_a_link_to_change_the_dqt_record
+    within first(".x-govuk-summary-card") do
+      expect(page).to have_link "Change record"
+    end
+  end
+
+  def then_i_cannot_see_the_users_dqt_section
+    within all(".x-govuk-summary-card__header").last do
+      expect(page).to_not have_content "DQT record"
+    end
+  end
+
+  def and_i_click_on_add_record
+    click_on "Add record"
+  end
+
+  def then_i_see_an_add_dqt_success_message
+    expect(page).to have_content("DQT record added")
   end
 end


### PR DESCRIPTION
### Context

We want the Support for Get an Identity interface to allow users to match an Identity record to a DQT record. Before allowing users to specify a TRN, we can allow Kevin E's TRN to be matched for the user.

### Changes proposed in this pull request

Allows a users to match to Kevin E's trn, skipping the steps to specify a trn, and sending the trn directly to the Identity API. Displays a success message and the DQT record of the user if successful.

https://user-images.githubusercontent.com/109349640/192007984-c3273f9a-7aa9-4158-beb5-ad9f15f12503.mov

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
