### PR TITLE
Improve Identity support pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,12 +53,7 @@ module ApplicationHelper
             current_page?(support_interface_identity_users_path) ||
               current_page?(support_interface_identity_path),
           href: support_interface_identity_users_path,
-          text: "Users",
-        )
-        header.navigation_item(
-          active: current_page?(support_interface_identity_simulate_path),
-          href: support_interface_identity_simulate_path,
-          text: "Simulate",
+          text: "Identity",
         )
         header.navigation_item(
           active: request.path.start_with?("/support/staff"),

--- a/app/views/support_interface/users/index.html.erb
+++ b/app/views/support_interface/users/index.html.erb
@@ -55,3 +55,10 @@
 <% end %>
 
 <%= govuk_pagination(pagy: @pagy) %>
+
+<h2 class="govuk-heading-m">Other tools</h2>
+
+<p>
+  <%= link_to "Simulate an Identity journey",
+    support_interface_identity_simulate_path %>
+</p>

--- a/app/views/support_interface/users/index.html.erb
+++ b/app/views/support_interface/users/index.html.erb
@@ -1,5 +1,9 @@
 <% content_for :page_title, 'Support for Get an identity' %>
 
+<h1 class="govuk-heading-xl">
+  Support for Get an Identity
+</h1>
+
 <h2 class="govuk-heading-m">
   <span class="govuk-caption-m">
     Showing <%= @users.size %> of <%= @total %> total


### PR DESCRIPTION
### Context

Three small fixes.

### Changes proposed in this pull request

- Add missing h1 title to Identity users page
- Rename support menu entry from Users to Identity
- Link to simulation tool from Identity page

### Guidance to review

![image](https://user-images.githubusercontent.com/1650875/192463211-f289ce43-a394-4824-9e5d-b7c7bdcb455d.png)

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
