### PR TITLE
Place breadcrumbs before main content

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -38,6 +38,9 @@
         <% end %>
       <% end %>
       <%= govuk_back_link(href: yield(:back_link_url)) unless yield(:back_link_url).blank? %>
+
+      <%= yield(:before_content) %>
+
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= render(FlashMessageComponent.new(flash: flash)) %>
         <%= content_for?(:content) ? yield(:content) : yield %>

--- a/app/views/support_interface/users/show.html.erb
+++ b/app/views/support_interface/users/show.html.erb
@@ -1,6 +1,9 @@
 <% content_for :page_title, 'Teachers' %>
 
-<%= govuk_breadcrumbs(breadcrumbs: { "Support" => support_interface_validation_errors_path, @user.full_name => nil }) %>
+<% content_for :before_content do %>
+  <%= govuk_breadcrumbs(breadcrumbs: { "Support" => support_interface_identity_users_path, @user.full_name => nil }) %>
+<% end %>
+
 <h1 class="govuk-heading-xl">
   <%= @user.full_name %>
 </h1>

--- a/app/views/support_interface/validation_errors/show.html.erb
+++ b/app/views/support_interface/validation_errors/show.html.erb
@@ -1,6 +1,9 @@
 <% content_for :page_title, "Validation errors for #{@form_object}" %>
 
-<%= govuk_breadcrumbs(breadcrumbs: { "Validation errors" => support_interface_validation_errors_path, @form_object => nil }) %>
+<% content_for :before_content do %>
+  <%= govuk_breadcrumbs(breadcrumbs: { "Validation errors" => support_interface_validation_errors_path, @form_object => nil }) %>
+<% end %>
+
 <h1 class="govuk-heading-xl">
   Validation errors for <%= @form_object %>
 </h1>


### PR DESCRIPTION

### Context

Breadcrumbs are currently rendered in the main tag — they should sit just outside.
https://trello.com/c/jd0fA1yh
### Changes proposed in this pull request

- Introduce a yield in the base layout
- Use this when rendering breadcrumbs so that they render outside the 'main' html tag.

### Guidance to review


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
