### PR TITLE
Identity support menu items and breadcrumbs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,9 +49,7 @@ module ApplicationHelper
           text: "Features",
         )
         header.navigation_item(
-          active:
-            current_page?(support_interface_identity_users_path) ||
-              current_page?(support_interface_identity_path),
+          active: current_page_for_identity_support?,
           href: support_interface_identity_users_path,
           text: "Identity",
         )
@@ -89,5 +87,12 @@ module ApplicationHelper
 
   def is_identity_journey?
     !!session[:identity_journey_id]
+  end
+
+  def current_page_for_identity_support?
+    current_page?(support_interface_identity_path) ||
+      current_page?(support_interface_identity_users_path) ||
+      current_page?(support_interface_identity_user_path) ||
+      current_page?(support_interface_identity_simulate_path)
   end
 end

--- a/app/views/support_interface/users/show.html.erb
+++ b/app/views/support_interface/users/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, 'Teachers' %>
 
-<%= govuk_breadcrumbs(breadcrumbs: { "Support" => support_interface_validation_errors_path, @user.full_name => nil }) %>
+<%= govuk_breadcrumbs(breadcrumbs: { "Support" => support_interface_identity_users_path, @user.full_name => nil }) %>
 <h1 class="govuk-heading-xl">
   <%= @user.full_name %>
 </h1>


### PR DESCRIPTION
### Context

The Identity header option is not being highlighted for all user support pages and the user support page Support breadcrumb is not linking to the correct path.

### Changes proposed in this pull request

Ensures that the Identity header options is highlighted for all Identity support pages and corrects the Support breadcrumb on the Identity user page.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
