### PR TITLE
Include NINO in Identity API PUT /find-trn/user payload

### DIFF
--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -64,6 +64,7 @@ class IdentityApi
       lastName: trn_request.last_name,
       trn: trn_request.trn,
       dateOfBirth: trn_request.date_of_birth&.to_date&.to_s,
+      nationalInsuranceNumber: trn_request.ni_number,
     }.compact
   end
 

--- a/spec/services/identity_api_spec.rb
+++ b/spec/services/identity_api_spec.rb
@@ -38,4 +38,52 @@ RSpec.describe IdentityApi do
       end
     end
   end
+
+  describe ".trn_request_params" do
+    context "when there is a NI number on the trn request" do
+      let(:trn_request) do
+        TrnRequest.new(
+          first_name: "John",
+          last_name: "Smith",
+          date_of_birth: Time.zone.local(2000, 1, 1),
+          ni_number: "QQ123456C",
+          trn: "2921020",
+        )
+      end
+
+      it "the params contain the NI number" do
+        expect(IdentityApi.trn_request_params(trn_request)).to eq(
+          {
+            firstName: "John",
+            lastName: "Smith",
+            dateOfBirth: "2000-01-01",
+            trn: "2921020",
+            nationalInsuranceNumber: "QQ123456C",
+          },
+        )
+      end
+    end
+
+    context "when there is no NI number on the trn request" do
+      let(:trn_request) do
+        TrnRequest.new(
+          first_name: "John",
+          last_name: "Smith",
+          date_of_birth: Time.zone.local(2000, 1, 1),
+          trn: "2921020",
+        )
+      end
+
+      it "the params do not contain the NI number" do
+        expect(IdentityApi.trn_request_params(trn_request)).to eq(
+          {
+            firstName: "John",
+            lastName: "Smith",
+            dateOfBirth: "2000-01-01",
+            trn: "2921020",
+          },
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

We should compare **all** the details the user entered with what's in DQT.
https://trello.com/c/CWJLZ3cL/169-populate-nationalinsurancenumber-in-the-identity-handover-api

### Changes proposed in this pull request

Include `nationalInsuranceNumber` (if present) in the payload for Identity API `PUT /find-trn/user/{journeyId}`.

### Guidance to review

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
