### PR TITLE
Corrected redirect path for when TRN does not exist

### DIFF
--- a/app/controllers/support_interface/dqt_records_controller.rb
+++ b/app/controllers/support_interface/dqt_records_controller.rb
@@ -7,7 +7,7 @@ module SupportInterface
       @dqt_record = DqtApi.find_teacher_by_trn!(trn:)
     rescue DqtApi::NoResults
       flash[:notice] = "TRN does not exist"
-      redirect_to edit_support_interface_identity_user_index_path(uuid)
+      redirect_to edit_support_interface_identity_user_path(uuid)
     end
 
     def update

--- a/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/invalid_trn/redirects_to_the_user_page_if_the_trn_does_not_exist.yml
+++ b/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/invalid_trn/redirects_to_the_user_page_if_the_trn_does_not_exist.yml
@@ -1,0 +1,114 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/37ee5357-fb84-478e-b750-bf552e5c8eed
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 29 Sep 2022 17:05:02 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='
+            'sha256-wmo5EWLjw+Yuj9jZzGNNeSsUOBQmBvE1pvSPVNQzJ34=' 'nonce-xCoiHImg1cZF7q2yLTzYuTA7/bxv4mULNl/zr9xOvyI='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-29T17:06:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null}'
+    recorded_at: Thu, 29 Sep 2022 17:05:02 GMT
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/2222234
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 404
+        message: Not Found
+      headers:
+        Content-Type:
+          - application/problem+json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Thu, 29 Sep 2022 17:05:03 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-09-29T17:06:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 60d73613-4135-4cef-4443-82350e810735
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Error from cloudfront
+        Via:
+          - 1.1 e3572bc2867545c7e2bf0953e1795990.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-C1
+        X-Amz-Cf-Id:
+          - Ecgvj8f7WKRwjgA7Cv4yEy23kMm6tr0SjHbSaC8BpupnJ-L_GL4qpA==
+      body:
+        encoding: UTF-8
+        string:
+          '{"type":"https://tools.ietf.org/html/rfc7231#section-6.5.4","title":"Not
+          Found","status":404,"traceId":"00-36f2dee0caea62c698934b2c15b99b1e-2c00167268ce107b-00"}'
+    recorded_at: Thu, 29 Sep 2022 17:05:03 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/links_DQT_record_when_user_accepts_confirmation.yml
+++ b/spec/cassettes/Identity_Users_Support/When_user_attempts_to_match_identity_record_to_a_DQT_record/links_DQT_record_when_user_accepts_confirmation.yml
@@ -129,7 +129,7 @@ http_interactions:
     response:
       status:
         code: 204
-        message: OK
+        message: No Content
       headers:
         Content-Type:
           - application/problem+json; charset=utf-8
@@ -162,7 +162,7 @@ http_interactions:
           - "2022-09-29T11:31:00.0000000Z"
       body:
         encoding: UTF-8
-        string: "{}"
+        string: ""
     recorded_at: Thu, 29 Sep 2022 11:30:19 GMT
   - request:
       method: get

--- a/spec/system/support_interface/users_spec.rb
+++ b/spec/system/support_interface/users_spec.rb
@@ -108,13 +108,23 @@ RSpec.describe "Identity Users Support", type: :system do
     end
 
     context "invalid trn" do
-      it "redirects to the confirmation page", vcr: true do
+      it "shows an error message if the trn is too long" do
+        given_i_am_authorized_as_a_support_user
+        when_i_visit_the_identity_users_support_page
+        and_i_proceed_to_add_a_dqt_record
+        and_i_add_a_trn_with_invalid_formatting
+        and_i_click_continue
+        then_i_should_see_an_error_message
+      end
+
+      it "redirects to the user page if the trn does not exist", vcr: true do
         given_i_am_authorized_as_a_support_user
         when_i_visit_the_identity_users_support_page
         and_i_proceed_to_add_a_dqt_record
         and_i_add_an_invalid_trn
         and_i_click_continue
-        then_i_should_see_an_error_message
+        then_i_should_see_the_add_trn_page
+        and_i_should_see_a_notification
       end
     end
 
@@ -224,9 +234,13 @@ RSpec.describe "Identity Users Support", type: :system do
     fill_in "What is their teacher reference number (TRN)?", with: "2921020"
   end
 
-  def and_i_add_an_invalid_trn
+  def and_i_add_a_trn_with_invalid_formatting
     fill_in "What is their teacher reference number (TRN)?",
             with: "292102012345"
+  end
+
+  def and_i_add_an_invalid_trn
+    fill_in "What is their teacher reference number (TRN)?", with: "2222234"
   end
 
   def then_i_should_see_an_error_message
@@ -236,6 +250,10 @@ RSpec.describe "Identity Users Support", type: :system do
         "is the wrong length (should be 7 characters)",
       )
     end
+  end
+
+  def and_i_should_see_a_notification
+    expect(page).to have_content("TRN does not exist")
   end
 
   def and_i_click_continue


### PR DESCRIPTION
### Context

Within the Identity support section If the user enters a valid TRN that does not exist then the page will redirect back to the user and show a notification. The redirect path is currently invalid.

### Changes proposed in this pull request

Updates the redirect path used when no trn has been found by DQT after submitting the TRN form, includes rspec tests.

<img width="844" alt="Screenshot 2022-09-30 at 09 28 22" src="https://user-images.githubusercontent.com/109349640/193227303-9a0c94d7-166d-4899-83a6-89da78224a05.png">

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
