### PR TITLE
Set iso8601 DOB format compatibile with DQT API

### DIFF
--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -73,7 +73,7 @@ class DqtApi
 
   def self.trn_request_params(trn_request)
     {
-      dateOfBirth: trn_request.date_of_birth,
+      dateOfBirth: trn_request.date_of_birth&.to_date&.iso8601,
       emailAddress: trn_request.email,
       firstName: trn_request.first_name,
       ittProviderName: trn_request.itt_provider_name_for_dqt,

--- a/spec/services/dqt_api_spec.rb
+++ b/spec/services/dqt_api_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DqtApi do
 
     let(:trn_request) do
       TrnRequest.new(
-        date_of_birth: "1990-01-01",
+        date_of_birth: Date.new(1990, 1, 1),
         email: "kevin.e@example.com",
         first_name: "kevin",
         ni_number: "AA123456A",


### PR DESCRIPTION
### Context

We rely on `TrnRequest#date_of_birth#to_s` to default to ISO8601 date format. 
[Recent Sentry errors](https://sentry.io/organizations/dfe-teacher-services/issues/3508852224) imply this might not be the case.

https://trello.com/c/1NBJMITf/190-fix-date-of-birth-400-error

### Changes proposed in this pull request

Explicitly set ISO8601 date format on DOB when present.

### Guidance to review

See https://github.com/DFE-Digital/qualified-teachers-api/blob/155174c8d5e5f2cfcd148c52bf45129371d38878/src/DqtApi/Json/DateOnlyConverter.cs#L18 and https://github.com/DFE-Digital/qualified-teachers-api/blob/11aa6b57cfee5412ba29f80342179173be6e1206/src/DqtApi/ModelBinding/Constants.cs#L5 for API expectations around formatting dates. 


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
