### PR TITLE
Make /v1/ Identity API endpoints use access token

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,7 @@ DQT_API_KEY=testkey
 DQT_API_URL=https://preprod-teacher-qualifications-api.education.gov.uk/
 HOSTING_ENVIRONMENT_NAME=local
 IDENTITY_API_KEY=testkey
+IDENTITY_USER_TOKEN=testkey
 IDENTITY_API_URL=https://s165t01-getanid-preprod-auths-app.azurewebsites.net
 IDENTITY_CLIENT_ID=test
 IDENTITY_CLIENT_SECRET=test

--- a/.env.test
+++ b/.env.test
@@ -10,3 +10,4 @@ SUPPORT_PASSWORD=test
 IDENTITY_SHARED_SECRET_KEY=testkey
 IDENTITY_API_URL=https://s165t01-getanid-preprod-auths-app.azurewebsites.net
 IDENTITY_API_KEY=testkey
+IDENTITY_USER_TOKEN=testkey

--- a/app/controllers/concerns/consumes_identity_users_api.rb
+++ b/app/controllers/concerns/consumes_identity_users_api.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module ConsumesIdentityUsersApi
+  extend ActiveSupport::Concern
+
+  def identity_users_api
+    @identity_users_api ||=
+      IdentityUsersApi.new(identity_users_api_access_token)
+  end
+
+  def identity_users_api_access_token
+    if FeatureFlag.active?("identity_auth_service")
+      session[:identity_users_api_access_token]
+    else
+      ENV.fetch("IDENTITY_USER_TOKEN", nil)
+    end
+  end
+end

--- a/app/controllers/staff/omniauth_callbacks_controller.rb
+++ b/app/controllers/staff/omniauth_callbacks_controller.rb
@@ -1,7 +1,9 @@
 class Staff::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def identity
-    @staff = Staff.from_identity(request.env["omniauth.auth"])
+    auth = request.env["omniauth.auth"]
+    @staff = Staff.from_identity(auth)
     sign_in @staff
+    session[:identity_users_api_access_token] = auth.credentials.token
     flash[:notice] = "Signed in successfully."
     redirect_to support_interface_path
   end

--- a/app/controllers/support_interface/dqt_records_controller.rb
+++ b/app/controllers/support_interface/dqt_records_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 module SupportInterface
   class DqtRecordsController < ApplicationController
+    include ConsumesIdentityUsersApi
+
     def edit
       @confirm_dqt_record_form = ConfirmDqtRecordForm.new(trn:)
-      @user = IdentityApi.get_user(uuid)
+      @user = identity_users_api.get_user(uuid)
       @dqt_record = DqtApi.find_teacher_by_trn!(trn:)
     rescue DqtApi::NoResults
       flash[:notice] = "TRN does not exist"
@@ -15,7 +17,7 @@ module SupportInterface
         ConfirmDqtRecordForm.new(confirm_dqt_record_params)
       if @confirm_dqt_record_form.valid?
         if @confirm_dqt_record_form.confirmed?
-          IdentityApi.update_user_trn(uuid, @confirm_dqt_record_form.trn)
+          identity_users_api.update_user_trn(uuid, @confirm_dqt_record_form.trn)
 
           flash[:success] = "DQT Record added"
         else
@@ -26,7 +28,7 @@ module SupportInterface
       else
         @dqt_record =
           DqtApi.find_teacher_by_trn!(trn: @confirm_dqt_record_form.trn)
-        @user = IdentityApi.get_user(uuid)
+        @user = identity_users_api.get_user(uuid)
         render :edit
       end
     end

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -2,17 +2,18 @@
 module SupportInterface
   class UsersController < SupportInterfaceController
     include Pagy::Backend
+    include ConsumesIdentityUsersApi
 
     layout "two_thirds", only: %i[edit update]
 
     def index
-      @all_users ||= IdentityApi.get_users
+      @all_users ||= identity_users_api.get_users
       @total = @all_users.size
       @pagy, @users = pagy_array(@all_users)
     end
 
     def show
-      @user = IdentityApi.get_user(uuid)
+      @user = identity_users_api.get_user(uuid)
       @dqt_record = DqtApi.find_teacher_by_trn!(trn: @user.trn) if @user.trn
     end
 

--- a/app/services/identity_users_api.rb
+++ b/app/services/identity_users_api.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+class IdentityUsersApi < IdentityApi
+  attr_reader :access_token
+
+  def initialize(access_token)
+    super()
+    @access_token = access_token
+  end
+
+  def get_user(uuid)
+    if FeatureFlag.active?(:identity_api_always_timeout)
+      raise Faraday::TimeoutError, "Time-out feature flag enabled"
+    end
+
+    response = client.get("/api/v1/users/#{uuid}")
+
+    raise ApiError, response.reason_phrase unless response.status == 200
+
+    User.new(response.body)
+  end
+
+  def update_user_trn(uuid, trn)
+    if FeatureFlag.active?(:identity_api_always_timeout)
+      raise Faraday::TimeoutError, "Time-out feature flag enabled"
+    end
+
+    response = client.put("/api/v1/users/#{uuid}/trn", { trn: })
+
+    raise ApiError, response.reason_phrase unless response.status == 204
+
+    response.body
+  end
+
+  def get_users
+    if FeatureFlag.active?(:identity_api_always_timeout)
+      raise Faraday::TimeoutError, "Time-out feature flag enabled"
+    end
+
+    response = client.get("/api/v1/teachers")
+
+    raise ApiError, response.reason_phrase unless response.status == 200
+
+    users = response.body.fetch("users", [])
+    users.map { |user| User.new(user) }
+  end
+end

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -12,6 +12,7 @@ module Omniauth
       option :pkce, true
       option :scope, "get-an-identity:support"
 
+      credentials { { token: access_token.token } }
       info { { name: raw_info["name"], email: raw_info["email"] } }
 
       extra { { "raw_info" => raw_info } }

--- a/spec/cassettes/IdentityUsersApi/_get_user_uuid_/returns_a_user_from_the_identity_api.yml
+++ b/spec/cassettes/IdentityUsersApi/_get_user_uuid_/returns_a_user_from_the_identity_api.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.6.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 05 Oct 2022 13:56:56 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='
+            'sha256-wmo5EWLjw+Yuj9jZzGNNeSsUOBQmBvE1pvSPVNQzJ34=' 'nonce-Sc7HFYNYSQ+Vx5vEDyfGe0rzRgX5F+ZW3rDfDqcEyaI='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-10-05T13:57:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"jake.benilov@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"}'
+    recorded_at: Wed, 05 Oct 2022 13:56:58 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/IdentityUsersApi/_get_users/returns_users_from_the_identity_api.yml
+++ b/spec/cassettes/IdentityUsersApi/_get_users/returns_users_from_the_identity_api.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/teachers
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.6.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 05 Oct 2022 14:11:03 GMT
+        Transfer-Encoding:
+          - chunked
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='
+            'sha256-wmo5EWLjw+Yuj9jZzGNNeSsUOBQmBvE1pvSPVNQzJ34=' 'nonce-G7iwU2XgLOE7mz0tBNmAuGleIySeIu7dsIKrqewKFHQ='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-10-05T14:12:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: '{"users":[{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null},{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"jake.benilov@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"},{"userId":"51a31384-113d-4c84-adae-0de84a686fc0","email":"tarikjohnston@gmail.com","firstName":"tarik","lastName":"johnston","dateOfBirth":"1980-01-31","trn":null},{"userId":"f3ef3547-071e-4fbd-8a85-4faeaf788a51","email":"naomi@lockyy.com","firstName":"Naomi","lastName":"Lockhart","dateOfBirth":"1992-02-17","trn":null}]}'
+    recorded_at: Wed, 05 Oct 2022 14:11:03 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/IdentityUsersApi/_update_user_trn_uuid_trn_/updates_the_user_s_trn.yml
+++ b/spec/cassettes/IdentityUsersApi/_update_user_trn_uuid_trn_/updates_the_user_s_trn.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+  - request:
+      method: put
+      uri: https://s165t01-getanid-preprod-auths-app.azurewebsites.net/api/v1/users/29e9e624-073e-41f5-b1b3-8164ce3a5233/trn
+      body:
+        encoding: UTF-8
+        string: '{"trn":"2921020"}'
+      headers:
+        User-Agent:
+          - Faraday v2.6.0
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Thu, 06 Oct 2022 12:43:04 GMT
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='
+            'sha256-wmo5EWLjw+Yuj9jZzGNNeSsUOBQmBvE1pvSPVNQzJ34=' 'nonce-15NjqkiH2uK56VTYxLh4N6bELtPmt0sXXbAw2x5CQJA='
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-10-06T12:44:00.0000000Z"
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Thu, 06 Oct 2022 12:43:05 GMT
+recorded_with: VCR 6.1.0

--- a/spec/services/identity_users_api_spec.rb
+++ b/spec/services/identity_users_api_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe IdentityUsersApi do
+  describe "#get_users", vcr: true do
+    it "returns users from the identity api" do
+      users = described_class.new(ENV["IDENTITY_USER_TOKEN"]).get_users
+
+      expect(users.map(&:uuid)).to include(
+        "29e9e624-073e-41f5-b1b3-8164ce3a5233",
+      )
+    end
+  end
+
+  describe "#get_user(uuid)", vcr: true do
+    let(:uuid) { "29e9e624-073e-41f5-b1b3-8164ce3a5233" }
+
+    it "returns a user from the identity api" do
+      user = described_class.new(ENV["IDENTITY_USER_TOKEN"]).get_user(uuid)
+
+      expect(user.uuid).to eq(uuid)
+      expect(user.first_name).to eq("Kevin")
+      expect(user.last_name).to eq("E")
+    end
+  end
+
+  describe "#update_user_trn(uuid, trn)", vcr: true do
+    let(:uuid) { "29e9e624-073e-41f5-b1b3-8164ce3a5233" }
+    let(:trn) { "2921020" }
+
+    it "updates the user's trn" do
+      response =
+        described_class.new(ENV["IDENTITY_USER_TOKEN"]).update_user_trn(
+          uuid,
+          trn,
+        )
+      expect(response).to be_empty
+    end
+  end
+end

--- a/spec/system/staff/staff_spec.rb
+++ b/spec/system/staff/staff_spec.rb
@@ -134,7 +134,17 @@ RSpec.describe "Staff support", type: :system do
     OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock(
       :identity,
-      { uid: nil, credentials: { token: "1234567890" }, extra: { raw_info: { email: "new@example.com" } } },
+      {
+        uid: nil,
+        credentials: {
+          token: "1234567890",
+        },
+        extra: {
+          raw_info: {
+            email: "new@example.com",
+          },
+        },
+      },
     )
   end
 

--- a/spec/system/staff/staff_spec.rb
+++ b/spec/system/staff/staff_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Staff support", type: :system do
     OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock(
       :identity,
-      { uid: nil, extra: { raw_info: { email: "new@example.com" } } },
+      { uid: nil, credentials: { token: "1234567890" }, extra: { raw_info: { email: "new@example.com" } } },
     )
   end
 

--- a/spec/system/support_interface/users_spec.rb
+++ b/spec/system/support_interface/users_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe "Identity Users Support", type: :system do
     "trn" => nil,
   }
 
+  let(:identity_api) { IdentityUsersApi.new(ENV["IDENTITY_USER_TOKEN"]) }
+
+  before { allow(IdentityUsersApi).to receive(:new).and_return(identity_api) }
+
   it "displays a list of users", vcr: true, download: true do
+    allow(identity_api).to receive(:get_users).and_return([User.new(user)])
     given_i_am_authorized_as_a_support_user
     when_i_visit_the_identity_users_support_page
     then_i_should_see_a_user
@@ -19,7 +24,7 @@ RSpec.describe "Identity Users Support", type: :system do
   context "when there are more than 100 users" do
     before do
       users = 150.times.map { User.new(user) }
-      allow(IdentityApi).to receive(:get_users).and_return(users)
+      allow(identity_api).to receive(:get_users).and_return(users)
     end
 
     it "shows the Identity users paginated" do
@@ -34,7 +39,7 @@ RSpec.describe "Identity Users Support", type: :system do
   context "when there is an unverified user" do
     before do
       user["nameVerified"] = false
-      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+      allow(identity_api).to receive(:get_users).and_return([User.new(user)])
     end
 
     it "shows an unverified user" do
@@ -47,7 +52,7 @@ RSpec.describe "Identity Users Support", type: :system do
   context "when there is an verified user" do
     before do
       user["nameVerified"] = true
-      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+      allow(identity_api).to receive(:get_users).and_return([User.new(user)])
     end
 
     it "shows an unverified user" do
@@ -60,7 +65,7 @@ RSpec.describe "Identity Users Support", type: :system do
   context "when the user does not have a DQT record" do
     before do
       user["trn"] = nil
-      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+      allow(identity_api).to receive(:get_users).and_return([User.new(user)])
     end
 
     it "shows a link to add a DQT record" do
@@ -73,7 +78,7 @@ RSpec.describe "Identity Users Support", type: :system do
   context "when the user has a DQT record" do
     before do
       user["trn"] = "12345"
-      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+      allow(identity_api).to receive(:get_users).and_return([User.new(user)])
     end
 
     it "shows a link to add a DQT record" do
@@ -86,7 +91,7 @@ RSpec.describe "Identity Users Support", type: :system do
   context "When user attempts to match identity record to a DQT record" do
     before do
       user["trn"] = nil
-      allow(IdentityApi).to receive(:get_users).and_return([User.new(user)])
+      allow(identity_api).to receive(:get_users).and_return([User.new(user)])
     end
 
     it "shows the add TRN page", vcr: true do
@@ -176,7 +181,7 @@ RSpec.describe "Identity Users Support", type: :system do
   end
 
   def then_i_should_see_a_user
-    expect(page).to have_content "Jane Doess"
+    expect(page).to have_content "Kevin E"
   end
 
   def then_i_should_see_an_unverified_user


### PR DESCRIPTION
### Context

Support UI calls via the `/v1` Identity API endpoints should use the access token made available via Oauth2 identity authentication.

https://trello.com/c/sptpIEil/210-update-identity-ruby-client-to-support-two-different-auth-schemes

### Changes proposed in this pull request

- Populate access token in Oauth2 hash
- Add token to session
- Split IdentityApi service into respective endpoints requiring Oauth2 token for user and token from ENV
- Call relevant service class in Support Interface controllers

### Guidance to review

Testing locally requires a bit of mocking of Oauth2.

1. Add a Staff record.
2. Activate identity auth feature flag.
3. In `config/environments/development.rb` append the following:

```ruby
OmniAuth.config.test_mode = true
OmniAuth.config.add_mock(
  :identity,
  {
    uid: nil,
    credentials: {
      token: ENV['IDENTITY_API_KEY'], # Alternatively amend your env with the correct client_id and credentials to obtain a token.
    },  
    extra: {
      raw_info: {
        email: "someone@example.com", # Change this to the email on the Staff record created in step 1.
      },  
    },  
  },  
)
```
4. Sign in with identity
![image](https://user-images.githubusercontent.com/93511/194272254-4c14af1d-d177-4793-a56e-e0c0bcd6acb3.png)


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
