### PR TITLE
Make GOV.UK in header link to gov.uk

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,7 +35,11 @@ module ApplicationHelper
   end
 
   def custom_header
-    govuk_header(service_name:, service_url: start_path) do |header|
+    govuk_header(
+      homepage_url: t("govuk.url"),
+      service_name:,
+      service_url: start_path,
+    ) do |header|
       case try(:current_namespace)
       when "support_interface"
         header.navigation_item(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  govuk:
+    url: https://www.gov.uk
   service:
     email: qts.enquiries@education.gov.uk
     name: Find a lost teacher reference number (TRN)


### PR DESCRIPTION
### Context

Currently it links to the start page of the service.
https://trello.com/c/fASpONEg
### Changes proposed in this pull request

Specify homepage_url param in govuk_header method.

### Guidance to review

Can be tested in review app.

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
