### PR TITLE
Improve sign in / sign out journey for staff users

### DIFF
--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -18,6 +18,10 @@ class Staff::SessionsController < Devise::SessionsController
   #   super
   # end
 
+  def after_sign_out_path_for(_resource_or_scope)
+    new_staff_session_path
+  end
+
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,6 +79,11 @@ module ApplicationHelper
           href: support_interface_zendesk_path,
           text: "Zendesk",
         )
+        if current_staff
+          header.navigation_item(href: staff_sign_out_path, text: "Sign out")
+        else
+          header.navigation_item(href: new_staff_session_path, text: "Sign in")
+        end
       end
     end
   end

--- a/app/views/staff/sessions/new.html.erb
+++ b/app/views/staff/sessions/new.html.erb
@@ -1,16 +1,26 @@
 <h1 class="govuk-heading-l">Log in</h1>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
-  <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
-
-  <% if devise_mapping.rememberable? %>
-    <%= f.govuk_check_boxes_fieldset :remember_me, multiple: false, legend: nil do %>
-      <%= f.govuk_check_box :remember_me, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Remember me?" } %>
+<% if FeatureFlag.active?(:identity_auth_service) %>
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <% if FeatureFlag.active?(:identity_auth_service) %>
+        <%= govuk_button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+      <% end %>
     <% end %>
   <% end %>
+<% else %>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+    <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
 
-  <%= f.govuk_submit "Log in" %>
+    <% if devise_mapping.rememberable? %>
+      <%= f.govuk_check_boxes_fieldset :remember_me, multiple: false, legend: nil do %>
+        <%= f.govuk_check_box :remember_me, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Remember me?" } %>
+      <% end %>
+    <% end %>
+
+    <%= f.govuk_submit "Log in" %>
+  <% end %>
+
+  <%= render "staff/shared/links" %>
 <% end %>
-
-<%= render "staff/shared/links" %>

--- a/app/views/staff/shared/_links.html.erb
+++ b/app/views/staff/shared/_links.html.erb
@@ -18,12 +18,4 @@
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
     <%= govuk_link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
   <% end %>
-
-  <%- if devise_mapping.omniauthable? %>
-    <%- resource_class.omniauth_providers.each do |provider| %>
-      <% if FeatureFlag.active?(:identity_auth_service) %>
-        <%= govuk_button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
-      <% end %>
-    <% end %>
-  <% end %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
                sessions: "staff/sessions",
                unlocks: "staff/unlocks",
              }
+  devise_scope :staff do
+    get "/staff/sign_out", to: "staff/sessions#destroy"
+  end
 
   namespace :support_interface, path: "/support" do
     get "/", to: redirect("/support/trn-requests")


### PR DESCRIPTION
### Context

This journey is currently a bit confusing.

https://trello.com/c/pwC7gEVw

### Changes proposed in this pull request

See commits

### Sign in page

![Screenshot_20221010_113228](https://user-images.githubusercontent.com/519250/194847131-b2f1dd0a-c0f8-4808-b844-ed380614c1a2.png)


### Header links

![Screenshot_20221010_113425](https://user-images.githubusercontent.com/519250/194847301-4b2c0fbf-e067-4f67-a236-283da7f7e3c9.png)

### Guidance to review

Can be tested by starting at `/support`. You need to be set up on Identity pre-prod and have the the following env vars set:

```
IDENTITY_CLIENT_ID=get-an-identity-support
IDENTITY_CLIENT_SECRET=dm_me_if_required
```

- navigating to `/support` should redirect you to a page containing nothing but the identity sign in button
- after successful identity sign in, you should end up in the support section
- header should contain functioning sign in / sign out links

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
