### PR TITLE
Remove error handling code in Identity controller

### DIFF
--- a/app/controllers/no_match_controller.rb
+++ b/app/controllers/no_match_controller.rb
@@ -14,24 +14,15 @@ class NoMatchController < ApplicationController
       redirect_to check_answers_path
     elsif @no_match_form.valid?
       if trn_request.from_get_an_identity?
-        begin
-          # Send a request to Get An Identity API with no TRN found
-          IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
-          session[:identity_trn_request_sent] = true
+        # Send a request to Get An Identity API with no TRN found
+        IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
+        session[:identity_trn_request_sent] = true
 
-          create_zendesk_ticket_for_identity_user
+        create_zendesk_ticket_for_identity_user
 
-          # Send the user to the redirect url specified by the client app
-          redirect_to session[:identity_redirect_url], allow_other_host: true
-          session[:identity_client_title] = nil
-        rescue IdentityApi::ApiError,
-               Faraday::ConnectionFailed,
-               Faraday::TimeoutError,
-               ActionController::ActionControllerError => e
-          Sentry.capture_exception(e)
-          # Do not redirect back to Get An Identity
-          render "errors/internal_server_error", status: :internal_server_error
-        end
+        # Send the user to the redirect url specified by the client app
+        redirect_to session[:identity_redirect_url], allow_other_host: true
+        session[:identity_client_title] = nil
       else
         create_zendesk_ticket
 

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -23,22 +23,13 @@ class TrnRequestsController < ApplicationController
       raise TrnHasAlert if trn_request.has_active_sanctions
 
       if trn_request.from_get_an_identity?
-        begin
-          # Send a request to Get An Identity API with the TRN for the journey
-          IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
-          session[:identity_trn_request_sent] = true
+        # Send a request to Get An Identity API with the TRN for the journey
+        IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])
+        session[:identity_trn_request_sent] = true
 
-          # Send the user back to Get an Identity
-          redirect_to session[:identity_redirect_url], allow_other_host: true
-          session[:identity_client_title] = nil
-        rescue IdentityApi::ApiError,
-               Faraday::ConnectionFailed,
-               Faraday::TimeoutError,
-               ActionController::ActionControllerError => e
-          Sentry.capture_exception(e)
-          # Do not redirect back to Get An Identity
-          render "errors/internal_server_error", status: :internal_server_error
-        end
+        # Send the user back to Get an Identity
+        redirect_to session[:identity_redirect_url], allow_other_host: true
+        session[:identity_client_title] = nil
       else
         TeacherMailer.found_trn(trn_request).deliver_later
         redirect_to trn_found_path

--- a/spec/system/identity_spec.rb
+++ b/spec/system/identity_spec.rb
@@ -102,26 +102,6 @@ RSpec.describe "Identity", type: :system do
         ).to eq "[Find a lost TRN - Identity auth] Support request from #{trn_request.name}"
       end
     end
-
-    context "when there is an Identity API error" do
-      before do
-        allow(Sentry).to receive(:capture_exception)
-        FeatureFlag.activate(:identity_api_always_timeout)
-      end
-
-      after { FeatureFlag.deactivate(:identity_api_always_timeout) }
-
-      it "redirects to the error page", vcr: true do
-        when_i_access_the_identity_endpoint
-        and_i_complete_and_submit_the_name_form
-        and_i_complete_and_submit_my_date_of_birth
-        then_i_see_the_check_answers_page
-
-        when_i_press_the_continue_button
-        then_sentry_receives_a_warning_about_the_failure
-        and_i_am_redirected_to_the_error_page
-      end
-    end
   end
 
   context "ask for TRN page" do
@@ -334,10 +314,6 @@ RSpec.describe "Identity", type: :system do
     )
   end
 
-  def then_sentry_receives_a_warning_about_the_failure
-    expect(Sentry).to have_received(:capture_exception)
-  end
-
   def then_i_should_see_the_client_title_from_get_an_identity
     expect(page).to have_content("")
   end
@@ -349,10 +325,6 @@ RSpec.describe "Identity", type: :system do
     expect(page).to have_content("Check your answers")
     expect(page).not_to have_content("We could not find your TRN")
     expect(page).not_to have_content("Check your details")
-  end
-
-  def and_i_am_redirected_to_the_error_page
-    expect(page).to have_content("Sorry")
   end
 
   def when_i_submit_anyway


### PR DESCRIPTION
Rescuing and then capturing a sentry error + rendering a 500 is what happens by default. This code isn't very useful, because locally it actually causes a 500 page to be shown whereas you'd expect a detailed error page with a stacktrace and the like.

Review without whitespace.
