### PR TITLE
Replace 'log in' with 'sign in'

### DIFF
--- a/app/views/staff/sessions/new.html.erb
+++ b/app/views/staff/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">Log in</h1>
+<h1 class="govuk-heading-l">Sign in</h1>
 
 <% if FeatureFlag.active?(:identity_auth_service) %>
   <%- if devise_mapping.omniauthable? %>
@@ -19,7 +19,7 @@
       <% end %>
     <% end %>
 
-    <%= f.govuk_submit "Log in" %>
+    <%= f.govuk_submit "Sign in" %>
   <% end %>
 
   <%= render "staff/shared/links" %>

--- a/app/views/staff/shared/_links.html.erb
+++ b/app/views/staff/shared/_links.html.erb
@@ -1,6 +1,6 @@
 <p class="govuk-body">
   <%- if controller_name != 'sessions' %>
-    <%= govuk_link_to "Log in", new_session_path(resource_name) %><br />
+    <%= govuk_link_to "Sign in", new_session_path(resource_name) %><br />
   <% end %>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>


### PR DESCRIPTION
Use consistent language across staff auth flow.