### PR TITLE
Check for expired access tokens on support pages

### DIFF
--- a/app/controllers/concerns/consumes_identity_users_api.rb
+++ b/app/controllers/concerns/consumes_identity_users_api.rb
@@ -9,7 +9,7 @@ module ConsumesIdentityUsersApi
 
   def identity_users_api_access_token
     if FeatureFlag.active?("identity_auth_service")
-      session[:identity_users_api_access_token]
+      session[:identity_users_api_access_token]["access_token"]
     else
       ENV.fetch("IDENTITY_USER_TOKEN", nil)
     end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -3,10 +3,23 @@ module SupportInterface
   class SupportInterfaceController < ApplicationController
     layout "support_layout"
 
-    before_action :authenticate_staff!
+    before_action :authenticate_staff!,
+                  unless: -> { FeatureFlag.active?(:identity_auth_service) }
+    before_action :check_omniauth_token!,
+                  if: -> { FeatureFlag.active?(:identity_auth_service) }
 
     def find_current_auditor
       current_staff
+    end
+
+    def check_omniauth_token!
+      redirect_to new_staff_session_path unless valid_access_token?
+    end
+
+    def valid_access_token?
+      credentials = session[:identity_users_api_access_token]
+      credentials.present? &&
+        Time.zone.at(credentials.fetch("expires_at", 0)).future?
     end
   end
 end

--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -12,7 +12,7 @@ module Omniauth
       option :pkce, true
       option :scope, "get-an-identity:support"
 
-      credentials { { token: access_token.token } }
+      credentials { { token: access_token } }
       info { { name: raw_info["name"], email: raw_info["email"] } }
 
       extra { { "raw_info" => raw_info } }

--- a/spec/requests/support_interface/identity_auth_token_expiry_spec.rb
+++ b/spec/requests/support_interface/identity_auth_token_expiry_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "GET /support with identity_auth_service feature enabled",
+               type: :request do
+  let(:staff) { FactoryBot.create(:staff) }
+  let(:expires_at) { 1.minute.from_now.to_i }
+  before do
+    FeatureFlag.activate(:service_open)
+    FeatureFlag.activate(:identity_auth_service)
+    FeatureFlag.deactivate(:staff_http_basic_auth)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:identity] = OmniAuth::AuthHash.new(
+      {
+        provider: "identity",
+        extra: {
+          raw_info: {
+            email: staff.email,
+          },
+        },
+        credentials: {
+          token: {
+            access_token: "some_token",
+            expires_at:,
+          },
+        },
+      },
+    )
+
+    get staff_identity_omniauth_callback_path
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:identity] = nil
+  end
+
+  context "with an access token which is valid" do
+    let(:identity_users_api) do
+      instance_double(IdentityUsersApi, get_users: [])
+    end
+
+    it "allows access to support pages" do
+      allow(IdentityUsersApi).to receive(:new).with("some_token").and_return(
+        identity_users_api,
+      )
+
+      get "/support/identity"
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "with an access token which is expired" do
+    let(:expires_at) { 1.minute.ago.to_i }
+
+    it "redirects to the sign in path" do
+      get "/support/identity"
+
+      expect(response).to redirect_to("/staff/sign_in")
+    end
+  end
+end

--- a/spec/system/staff/staff_spec.rb
+++ b/spec/system/staff/staff_spec.rb
@@ -137,7 +137,10 @@ RSpec.describe "Staff support", type: :system do
       {
         uid: nil,
         credentials: {
-          token: "1234567890",
+          token: {
+            access_token: "1234567890",
+            expires_at: 1.minute.from_now.to_i,
+          },
         },
         extra: {
           raw_info: {


### PR DESCRIPTION
### Context

With the identity auth service feature active we issue an access token when authenticating staff. This token has an expiry time of one hour, we should limit access to support pages based on this expiry.
https://trello.com/c/pwC7gEVw/229-staff-sign-in-flow-enhancements

### Changes proposed in this pull request

Adds the `expires_at` value to the session as well as the access token.
Checks the `expires_at` value in the session against the current time when staff access support pages.

### Guidance to review

I couldn't find a solution to this which integrated well with existing Devise strategies, hence the `before_action` addition to `SupportInterfaceController`. Perhaps there's a neater way than this?

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
