### PR TITLE
Fix totals in Zendesk support section

### DIFF
--- a/app/controllers/support_interface/zendesk_controller.rb
+++ b/app/controllers/support_interface/zendesk_controller.rb
@@ -5,12 +5,13 @@ module SupportInterface
     include Pagy::Backend
 
     def index
+      closed_tickets = ZendeskService.find_closed_tickets_from_6_months_ago
       @zendesk_tickets =
-        ZendeskService.find_closed_tickets_from_6_months_ago.map do |t|
-          ZendeskDeleteRequest.new.from(t)
-        end
+        closed_tickets.map { |t| ZendeskDeleteRequest.new.from(t) }
 
-      @total = ZendeskDeleteRequest.count
+      @zendesk_tickets_total = closed_tickets.count
+
+      @zendesk_delete_requests_total = ZendeskDeleteRequest.count
 
       @pagy, @zendesk_delete_requests =
         pagy(ZendeskDeleteRequest.order(closed_at: :desc))

--- a/app/views/support_interface/zendesk/index.html.erb
+++ b/app/views/support_interface/zendesk/index.html.erb
@@ -27,7 +27,7 @@
 <h2 class="govuk-heading-m">
   List of tickets to be deleted
   <span class="govuk-caption-m">
-    Showing <%= @zendesk_tickets.size %> total
+    Showing <%= @zendesk_tickets.size %> of <%= @zendesk_tickets_total %> total
   </span>
 </h2>
 
@@ -78,7 +78,7 @@
 <h2 class="govuk-heading-m">
   Tickets that have been requested for deletion
   <span class="govuk-caption-m">
-    Showing <%= @zendesk_delete_requests.size %> of <%= @total %> total
+    Showing <%= @zendesk_delete_requests.size %> of <%= @zendesk_delete_requests_total %> total
   </span>
 </h2>
 


### PR DESCRIPTION
The total tickets to be deleted is wrong, as it doesn't call the `.count` method on the search object, which is the true count of records.

### Before

![image](https://user-images.githubusercontent.com/1650875/195037644-4ba3c465-9c27-46a3-9d5e-10c893a6e3e7.png)

### After

![image](https://user-images.githubusercontent.com/1650875/195037679-a750e638-b990-4820-8349-4ee285205be0.png)
