### PR TITLE
Configure sidekiq critical and low priority queues

### DIFF
--- a/app/jobs/create_zendesk_ticket_job.rb
+++ b/app/jobs/create_zendesk_ticket_job.rb
@@ -1,5 +1,6 @@
 class CreateZendeskTicketJob < ApplicationJob
   discard_on ActiveRecord::RecordNotFound
+  sidekiq_options queue: "critical"
 
   def perform(trn_request_id)
     trn_request = TrnRequest.find(trn_request_id)

--- a/app/jobs/delete_old_zendesk_tickets_job.rb
+++ b/app/jobs/delete_old_zendesk_tickets_job.rb
@@ -1,4 +1,6 @@
 class DeleteOldZendeskTicketsJob < ApplicationJob
+  sidekiq_options queue: "low"
+
   def perform
     return unless HostingEnvironment.production?
 

--- a/app/jobs/unlock_teacher_account_job.rb
+++ b/app/jobs/unlock_teacher_account_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class UnlockTeacherAccountJob < ApplicationJob
+  sidekiq_options queue: "critical"
+
   def perform(uid:, trn_request_id:)
     unlocked = DqtApi.unlock_teacher!(uid:)
     AccountUnlockEvent.create!(trn_request_id:) if unlocked

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,4 +7,6 @@ production:
 :max_retries: 1
 
 :queues:
+  - critical
   - default
+  - low


### PR DESCRIPTION
Sidekiq allows us to specify multiple queue names, and they are given priority in the order they are declared in.

This sets up a Critical priority queue which is used for Zendesk ticket creation and for Account unlocking functionality, and a Low priority queue which is used for the Zendesk ticket deletion job. All other jobs by default will execute in the medium priority default queue.