### PR TITLE
Store TRN in hidden field when editing DQT records

### DIFF
--- a/app/controllers/support_interface/dqt_records_controller.rb
+++ b/app/controllers/support_interface/dqt_records_controller.rb
@@ -10,8 +10,6 @@ module SupportInterface
     rescue DqtApi::NoResults
       flash[:notice] = "TRN does not exist"
       redirect_to edit_support_interface_identity_user_path(uuid)
-    ensure
-      session.delete(:support_interface_trn_form_trn)
     end
 
     def update
@@ -42,7 +40,7 @@ module SupportInterface
     end
 
     def trn
-      session[:support_interface_trn_form_trn]
+      params.require(:trn)
     end
 
     def confirm_dqt_record_params

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -25,12 +25,20 @@ module SupportInterface
     def update
       @trn_form = TrnForm.new(import_params)
       if @trn_form.save
-        session[:support_interface_trn_form_trn] = @trn_form.trn
-        redirect_to edit_support_interface_dqt_record_path(id: uuid)
+        @confirm_dqt_record_form = ConfirmDqtRecordForm.new(trn: @trn_form.trn)
+        @user = identity_users_api.get_user(uuid)
+        @dqt_record = DqtApi.find_teacher_by_trn!(trn: @trn_form.trn)
+
+        render "support_interface/dqt_records/edit",
+               id: uuid,
+               trn: @trn_form.trn
       else
         @uuid = uuid
         render :edit
       end
+    rescue DqtApi::NoResults
+      flash[:notice] = "TRN does not exist"
+      redirect_to edit_support_interface_identity_user_path(uuid)
     end
 
     private

--- a/spec/requests/support_interface/edit_dqt_record_spec.rb
+++ b/spec/requests/support_interface/edit_dqt_record_spec.rb
@@ -3,64 +3,45 @@ require "rails_helper"
 RSpec.describe "GET edit DQT record", type: :request do
   include IdentityAuthServiceHelper
 
-  context "with a TRN stored in session" do
-    let(:uuid) { SecureRandom.uuid }
-    let(:trn) { token_for_mock_identity_authentication }
-    let(:identity_users_api) do
-      instance_double(
-        IdentityUsersApi,
-        get_user:
-          User.new("userId" => uuid, "email" => "someone@somewhere.com"),
-      )
-    end
-    let(:mock_session) do
-      instance_double(
-        ActionDispatch::Request::Session,
-        enabled?: true,
-        key?: true,
-        loaded?: true,
-      )
-    end
+  let(:uuid) { SecureRandom.uuid }
+  let(:trn) { "7654321" }
+  let(:user) { User.new("userId" => uuid, "email" => "someone@somewhere.com") }
+  let(:identity_users_api) { instance_double(IdentityUsersApi, get_user: user) }
+
+  before do
+    authenticate_staff_with_mock_identity_provider
+    allow(IdentityUsersApi).to receive(:new).and_return(identity_users_api)
+  end
+  after { reset_mock_identity_provider_authentication }
+
+  context "when a record exists" do
     before do
-      authenticate_staff_with_mock_identity_provider
-      allow(IdentityUsersApi).to receive(:new).and_return(identity_users_api)
       allow(DqtApi).to receive(:find_teacher_by_trn!).and_return(
         "firstName" => "Some",
         "lastName" => "One",
         "dateOfBirth" => "2000-01-01",
       )
-      allow_any_instance_of(ActionDispatch::Request).to receive(
-        :session,
-      ).and_return(mock_session)
-      allow(mock_session).to receive(:[])
-      allow(mock_session).to receive(:[]=)
-      allow(mock_session).to receive(:[]).with(
-        :support_interface_trn_form_trn,
-      ).and_return(trn)
-      allow(mock_session).to receive(:[]).with(
-        :identity_users_api_access_token,
-      ).and_return(
-        {
-          "access_token" => token_for_mock_identity_authentication,
-          "expires_at" => 2.minutes.from_now,
-        },
-      )
-      allow(mock_session).to receive(:delete)
     end
 
-    after { reset_mock_identity_provider_authentication }
-
-    it "calls find_teacher_by_trn! with the TRN from the current session" do
-      get edit_support_interface_dqt_record_path(id: uuid)
+    it "calls find_teacher_by_trn! with the TRN from the form" do
+      get edit_support_interface_dqt_record_path(id: uuid, trn:)
 
       expect(DqtApi).to have_received(:find_teacher_by_trn!).with(trn:)
     end
+  end
 
-    it "deletes the TRN from the session" do
-      get edit_support_interface_dqt_record_path(id: uuid)
+  context "when a record doesn't exist" do
+    before do
+      allow(DqtApi).to receive(:find_teacher_by_trn!).and_raise(
+        DqtApi::NoResults,
+      )
+    end
 
-      expect(mock_session).to have_received(:delete).with(
-        :support_interface_trn_form_trn,
+    it "renders a flash message" do
+      get edit_support_interface_dqt_record_path(id: uuid, trn:)
+
+      expect(response).to redirect_to(
+        edit_support_interface_identity_user_path(uuid),
       )
     end
   end


### PR DESCRIPTION
### Context

We used to redirect from the users (trn) update action to the DQT records edit action which exposed the TRN in the redirect URL.

We stopped exposing the TRN by storing it in the session but this would cause side-effects with multiple forms being open across tabs, as the same TRN in session would be used.

### Changes proposed in this pull request

Render the dqt_records edit form directly from the preceding action instead, this hides the TRN in a form field but requires a bit of duplication of API calls in the update action.

### Guidance to review

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
