### PR TITLE
Remove redundant two-thirds on TRN confirm page

### DIFF
--- a/app/controllers/support_interface/dqt_records_controller.rb
+++ b/app/controllers/support_interface/dqt_records_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SupportInterface
-  class DqtRecordsController < ApplicationController
+  class DqtRecordsController < SupportInterfaceController
     include ConsumesIdentityUsersApi
 
     def edit

--- a/app/views/support_interface/dqt_records/edit.html.erb
+++ b/app/views/support_interface/dqt_records/edit.html.erb
@@ -1,25 +1,21 @@
 <% content_for :page_title, "W#{'Error: ' if @confirm_dqt_record_form.errors.any?}e found a DQT record, is it the right one?" %>
 <% content_for :back_link_url, back_link_url %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @confirm_dqt_record_form, url: support_interface_dqt_record_path(@user.uuid), method: :patch do |f| %>
-      <%= f.hidden_field :trn, value: @confirm_dqt_record_form.trn %>
-      <%= f.govuk_error_summary %>
+<%= form_with model: @confirm_dqt_record_form, url: support_interface_dqt_record_path(@user.uuid), method: :patch do |f| %>
+  <%= f.hidden_field :trn, value: @confirm_dqt_record_form.trn %>
+  <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        We found a DQT record, is it the right one?
-      </h1>
+  <h1 class="govuk-heading-xl">
+    We found a DQT record, is it the right one?
+  </h1>
 
-      <%= render(ConfirmDqtComponent.new(user: @user, dqt_record: @dqt_record)) %>
+  <%= render(ConfirmDqtComponent.new(user: @user, dqt_record: @dqt_record)) %>
 
-      <%= f.govuk_radio_buttons_fieldset :add_dqt_record, legend: { size: 'm', text: 'Do you want to add this DQT record?' } do %>
-        <%= f.govuk_radio_button :add_dqt_record, 'Yes', label: { text: "Yes, add this record" }, link_errors: true %>
-        <%= f.govuk_radio_button :add_dqt_record, 'No', label: { text: "No, this is the wrong record" } %>
-      <% end %>
+  <%= f.govuk_radio_buttons_fieldset :add_dqt_record, legend: { size: 'm', text: 'Do you want to add this DQT record?' } do %>
+    <%= f.govuk_radio_button :add_dqt_record, 'Yes', label: { text: "Yes, add this record" }, link_errors: true %>
+    <%= f.govuk_radio_button :add_dqt_record, 'No', label: { text: "No, this is the wrong record" } %>
+  <% end %>
 
-      <%= f.govuk_submit text: "Finish", prevent_double_click: false %>
+  <%= f.govuk_submit text: "Finish", prevent_double_click: false %>
 
-    <% end %>
-  </div>
-</div>
+<% end %>


### PR DESCRIPTION
The two-thirds is already coming in from the support layout.

Review without whitespace.

### Before

![image](https://user-images.githubusercontent.com/1650875/195618618-0da27199-e95d-4f30-a0b7-3cc44345cc14.png)

### After

![image](https://user-images.githubusercontent.com/1650875/195618680-41a0bb05-b5f1-4003-a01c-abbb54c71ae3.png)
