### PR TITLE
Stop logging Faraday requests

### DIFF
--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -97,23 +97,7 @@ class DqtApi
         faraday.request :authorization, "Bearer", ENV.fetch("DQT_API_KEY", nil)
         faraday.request :json
         faraday.response :json
-        if faraday_log_output_enabled?
-          faraday.response(
-            :logger,
-            nil,
-            { bodies: true, headers: true },
-          ) do |logger|
-            logger.filter(
-              /((emailAddress|firstName|lastName|nationalInsuranceNumber|previousFirstName|previousLastName)=)([^&]+)/,
-              '\1[REDACTED]',
-            )
-          end
-        end
         faraday.adapter Faraday.default_adapter
       end
-  end
-
-  def faraday_log_output_enabled?
-    ActiveRecord::Type::Boolean.new.cast(ENV.fetch("FARADAY_LOG_OUTPUT", true))
   end
 end


### PR DESCRIPTION
### Context

We were logging faraday requests and responses. Requests were being filtered but the response was leaking PII into the logs.

### Changes proposed in this pull request

Remove Faraday logging. It is of limited utility and will always risk leaking if the filters aren't maintained.

### Guidance to review

We've tried configuring pre-prod using the FARADAY_LOG_OUTPUT env var and it worked. No PII was logged.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
