### PR TITLE
Update name methods in TrnRequest model

### DIFF
--- a/app/components/trn_details_component.html.erb
+++ b/app/components/trn_details_component.html.erb
@@ -7,9 +7,9 @@
     actions: @trn_request.from_get_an_identity? ? [] : [{ href: email_path, visually_hidden_text: 'email address' }]
   }
 
-  name_row = {
-    key: { text: 'Name' },
-    value: { text: name },
+  official_name_row = {
+    key: { text: 'Official name' },
+    value: { text: official_name },
     actions: [{ href: name_path, visually_hidden_text: 'name' }]
   }
 
@@ -56,7 +56,7 @@
   }
 
   rows.push(email_row)
-  rows.push(name_row)
+  rows.push(official_name_row)
   rows.push(previous_name_row) if @trn_request.previous_name?
   rows.push(preferred_name_row) if @trn_request.preferred_name?
   rows.push(date_of_birth_row)

--- a/app/components/trn_details_component.rb
+++ b/app/components/trn_details_component.rb
@@ -11,11 +11,15 @@ class TrnDetailsComponent < ViewComponent::Base
     end
   end
 
-  def name
+  def official_name
     if @anonymise
-      @trn_request.name.split.map { |name| "#{name.first}****" }.join(" ")
+      @trn_request
+        .official_name
+        .split
+        .map { |name| "#{name.first}****" }
+        .join(" ")
     else
-      @trn_request.name
+      @trn_request.official_name
     end
   end
 

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -65,11 +65,13 @@ class TrnRequest < ApplicationRecord
   end
 
   def name
-    [first_name, last_name].compact.join(" ")
+    return preferred_name if preferred_name?
+
+    official_name
   end
 
   def official_name
-    name
+    [first_name, last_name].compact.join(" ")
   end
 
   def preferred_name

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe TrnRequest, type: :model do
     end
 
     it { is_expected.to eq("John Doe") }
+
+    context "when preferred name is set" do
+      before { trn_request.preferred_first_name = "Jimmy" }
+
+      it "returns the preferred name" do
+        expect(subject).to eq "Jimmy"
+      end
+    end
   end
 
   describe "#previous_name?" do

--- a/spec/system/identity/user_matches_an_identity_spec.rb
+++ b/spec/system/identity/user_matches_an_identity_spec.rb
@@ -85,7 +85,9 @@ RSpec.feature "Get an identity", type: :system do
   def then_the_check_answers_page_contains_the_answers_i_submitted
     expect(page.current_path).to eq check_answers_path
 
-    within_summary_row("Name") { expect(page).to have_content "Steven Toast" }
+    within_summary_row("Official name") do
+      expect(page).to have_content "Steven Toast"
+    end
     within_summary_row("Preferred name") do
       expect(page).to have_content "Kevin E"
     end


### PR DESCRIPTION

### Context
We should probably use the preferred name by default if one is specified by the user.



### Changes proposed in this pull request

- Have #name return either the preferred name or official name, depending
  on whether a preferred name has been provided
- Use #official_name and #preferred_name explicitly in the
  TrnDetailsComponent


### Guidance to review

Does this make sense? 

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
