### PR TITLE
Allow changing names in Identity support

### DIFF
--- a/app/controllers/support_interface/change_name_controller.rb
+++ b/app/controllers/support_interface/change_name_controller.rb
@@ -1,0 +1,47 @@
+module SupportInterface
+  class ChangeNameController < SupportInterfaceController
+    include Pagy::Backend
+    include ConsumesIdentityUsersApi
+
+    layout "two_thirds"
+
+    def show
+      @user = identity_users_api.get_user(uuid)
+      @change_name_form = ChangeNameForm.new
+      @uuid = uuid
+    end
+
+    def update
+      @user = identity_users_api.get_user(uuid)
+      @change_name_form = ChangeNameForm.new(change_name_params)
+      @uuid = uuid
+      if @change_name_form.save
+        @user =
+          identity_users_api.update_user(
+            uuid,
+            {
+              firstName: @change_name_form.first_name,
+              lastName: @change_name_form.last_name,
+            },
+          )
+        flash[:success] = "Name changed successfully"
+        redirect_to support_interface_identity_user_path(uuid)
+      else
+        render :show, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def uuid
+      params.require(:id)
+    end
+
+    def change_name_params
+      params.require(:support_interface_change_name_form).permit(
+        :first_name,
+        :last_name,
+      )
+    end
+  end
+end

--- a/app/forms/support_interface/change_name_form.rb
+++ b/app/forms/support_interface/change_name_form.rb
@@ -1,0 +1,14 @@
+module SupportInterface
+  class ChangeNameForm
+    include ActiveModel::Model
+
+    attr_accessor :first_name, :last_name
+
+    validates :first_name, presence: true, length: { maximum: 255 }
+    validates :last_name, presence: true, length: { maximum: 255 }
+
+    def save
+      valid?
+    end
+  end
+end

--- a/app/views/support_interface/change_name/show.html.erb
+++ b/app/views/support_interface/change_name/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "#{'Error: ' if @change_name_form.errors.any?}Change their preferred name" %>
+<% content_for :back_link_url, back_link_url %>
+
+<%= form_with model: @change_name_form, url: support_interface_change_name_path(@uuid), method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl">Change their preferred name</h1>
+
+  <p>Changes to a preferred name will not update DQT.</p>
+
+  <h2 class="govuk-heading-m">Current names</h2>
+
+  <%= render(SummaryCardComponent.new(rows: [
+    { key: { text: 'Preferred name' }, value: { text: @user.full_name } }
+  ])) %>
+
+  <h2 class="govuk-heading-m">New preferred name</h2>
+
+  <%= f.govuk_text_field(:first_name, label: { size: 's', text: "First name" }) %>
+  <%= f.govuk_text_field(:last_name, label: { size: 's', text: "Last name" }) %>
+  <%= f.govuk_submit prevent_double_click: false %>
+<% end %>

--- a/app/views/support_interface/users/show.html.erb
+++ b/app/views/support_interface/users/show.html.erb
@@ -25,7 +25,7 @@
     key: { text: "Preferred name" },
     value: { text: yield(:name_row_value) },
     actions: [
-      { text: "Change", href: "#", visually_hidden_text: "name" },
+      { text: "Change", href: support_interface_change_name_path(@user.uuid), visually_hidden_text: "name" },
     ],
   },
   {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,3 +105,11 @@ en:
           attributes:
             add_dqt_record:
               inclusion: Tell us if this is the right DQT record
+        support_interface/change_name_form:
+          attributes:
+            first_name:
+              blank: Enter a first name
+              too_long: Enter a first name that is less than 255 letters long
+            last_name:
+              blank: Enter a last name
+              too_long: Enter a last name that is less than 255 letters long

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,10 @@ Rails.application.routes.draw do
 
     resources :dqt_records, only: %i[edit update]
 
+    resources :change_name,
+              path: "/identity/change-name/",
+              only: %i[show update]
+
     resources :trn_requests, only: [] do
       resource :zendesk_sync, only: [:create], controller: "zendesk_sync"
     end

--- a/spec/requests/support_interface/edit_identity_user_name_spec.rb
+++ b/spec/requests/support_interface/edit_identity_user_name_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "PUT /support/identity/change-name/:uuid" do
+  include IdentityAuthServiceHelper
+
+  before { authenticate_staff_with_mock_identity_provider }
+  after { reset_mock_identity_provider_authentication }
+  let(:uuid) { SecureRandom.uuid }
+
+  context "with an invalid first name and last name" do
+    let(:first_name) { "" }
+    let(:last_name) { "" }
+    let(:user) do
+      User.new(
+        "userId" => uuid,
+        "first_name" => "Keanu",
+        "last_name" => "Greeves",
+        "created" => "2022-10-10T15:01:22.692023Z",
+      )
+    end
+    let(:identity_users_api) do
+      instance_double(IdentityUsersApi, get_user: user, update_user: user)
+    end
+
+    before do
+      allow(IdentityUsersApi).to receive(:new).and_return(identity_users_api)
+    end
+
+    it "responds with a validation error" do
+      put support_interface_change_name_path(uuid),
+          params: {
+            id: uuid,
+            support_interface_change_name_form: {
+              first_name:,
+              last_name:,
+            },
+          }
+
+      expect(response).not_to be_successful
+      expect(response.body).to match(/Enter a first name/)
+    end
+  end
+
+  context "with a valid first name and last name" do
+    let(:first_name) { "Keanu" }
+    let(:last_name) { "Greeves" }
+    let(:user) do
+      User.new(
+        "userId" => uuid,
+        "first_name" => first_name,
+        "last_name" => last_name,
+        "created" => "2022-10-10T15:01:22.692023Z",
+      )
+    end
+    let(:identity_users_api) do
+      instance_double(IdentityUsersApi, get_user: user, update_user: user)
+    end
+
+    before do
+      allow(IdentityUsersApi).to receive(:new).and_return(identity_users_api)
+    end
+
+    it "redirects to the user page" do
+      put support_interface_change_name_path(uuid),
+          params: {
+            id: uuid,
+            support_interface_change_name_form: {
+              first_name:,
+              last_name:,
+            },
+          }
+
+      expect(response).to redirect_to(
+        support_interface_identity_user_path(uuid),
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

Implement Change name functionality in Identity support.

### Changes proposed in this pull request

Add the controller, form model, a request spec.

We can't effectively system test this because of the way the short-lived OmniAuth keys work.

### Guidance to review

Prototype: https://find-a-lost-trn.herokuapp.com/support/101

![image](https://user-images.githubusercontent.com/1650875/200373406-f60f3f17-f793-414d-9834-c6fc20bc207c.png)

![image](https://user-images.githubusercontent.com/1650875/200373480-253e9d6c-de6e-434e-ac1b-10e27ada5c8a.png)

![image](https://user-images.githubusercontent.com/1650875/200373515-f3edfb6d-1a2d-4ea7-bc51-121bf9062a76.png)


### Checklist

- [x] Attach to Trello card https://trello.com/c/ipZ4SgJt/299-implement-change-name-functionality-in-identity-support
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
