### PR TITLE
Add Identity privacy notice 

### DIFF
--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -27,6 +27,7 @@ class IdentityController < ApplicationController
 
     session[:trn_request_id] = @trn_request.id
     session[:identity_client_title] = recognised_params["client_title"]
+    session[:identity_client_id] = recognised_params["client_id"]
     session[:identity_client_url] = recognised_params["client_url"]
     session[:identity_journey_id] = recognised_params["journey_id"]
     session[:identity_previous_url] = recognised_params["previous_url"]
@@ -41,6 +42,7 @@ class IdentityController < ApplicationController
   def recognised_params
     params.permit(
       :client_title,
+      :client_id,
       :client_url,
       :email,
       :journey_id,

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,4 +2,11 @@
 
 class StaticController < ApplicationController
   layout "two_thirds"
+
+  def privacy
+    case session[:identity_client_id]
+    when "register-for-npq"
+      render "register_for_npq_privacy"
+    end
+  end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -3,6 +3,13 @@
 class StaticController < ApplicationController
   layout "two_thirds"
 
+  def accessibility
+    case session[:identity_client_id]
+    when "register-for-npq"
+      render "register_for_npq_accessibility"
+    end
+  end
+
   def privacy
     case session[:identity_client_id]
     when "register-for-npq"

--- a/app/controllers/support_interface/identity_controller.rb
+++ b/app/controllers/support_interface/identity_controller.rb
@@ -4,6 +4,7 @@ module SupportInterface
       @identity_params = IdentityParamsForm.new
       @identity_params.client_title =
         "Register for a National Professional Qualification"
+      @identity_params.client_id = "register-for-npq"
       @identity_params.client_url = client_url
       @identity_params.email = "kevin.e@example.com"
       @identity_params.journey_id = journey_id
@@ -14,6 +15,7 @@ module SupportInterface
     def confirm
       @identity_params = {
         client_title: create_params[:client_title],
+        client_id: create_params[:client_id],
         client_url:,
         email: create_params[:email],
         journey_id:,
@@ -35,6 +37,7 @@ module SupportInterface
     def create_params
       params.require(:support_interface_identity_params_form).permit(
         :client_title,
+        :client_id,
         :email,
       )
     end

--- a/app/forms/support_interface/identity_params_form.rb
+++ b/app/forms/support_interface/identity_params_form.rb
@@ -3,6 +3,7 @@ module SupportInterface
     include ActiveModel::Model
 
     attr_accessor :client_title,
+                  :client_id,
                   :email,
                   :journey_id,
                   :redirect_url,

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -52,7 +52,7 @@
       meta_items: {
         'Accessibility': '/accessibility',
         'Cookies': '/cookies',
-        'Privacy notice': '/privacy'
+        'Privacy': '/privacy'
       }) %>
   </body>
 </html>

--- a/app/views/static/register_for_npq_accessibility.html.erb
+++ b/app/views/static/register_for_npq_accessibility.html.erb
@@ -1,0 +1,46 @@
+<h1 class="govuk-heading-xl">Accessibility statement</h1>
+<p class="govuk-body">This statement applies to the Register for a national professional qualification service.</p>
+<p class="govuk-body">This service is run by the Department for Education. We want as many people as possible to be able to use it. You should be able to:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>change colours, contrast levels and fonts</li>
+  <li>zoom in up to 300% without the text spilling off the screen</li>
+  <li>navigate most of the service using just a keyboard</li>
+  <li>navigate most of the service using speech recognition software</li>
+  <li>listen to most of the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+</ul>
+<p class="govuk-body">We have also made the service text as simple as possible to understand.</p>
+<p class="govuk-body"><%= govuk_link_to 'AbilityNet', "https://mcmw.abilitynet.org.uk/" %> has advice on making your device easier to use if you have an access need.</p>
+
+<h2 class="govuk-heading-l">How accessible this service is</h2>
+<p class="govuk-body">All parts of this service are fully accessible.</p>
+
+<h2 class="govuk-heading-l">Reporting accessibility problems with this service</h2>
+<p class="govuk-body">We are always looking to improve the accessibility of this service.</p>
+<p class="govuk-body">If you find any problems not listed on this page or think we are not meeting accessibility requirements, contact us:</p>
+<p class="govuk-body">Email:<br><%= mail_to 'continuing-professional-development@digital.education.gov.uk', 'continuing-professional-development@digital.education.gov.uk', class: 'govuk-link' %></p>
+<p class="govuk-body"><%= govuk_link_to 'Read tips on contacting organisations about inaccessible websites', "http://www.w3.org/WAI/users/inaccessible" %></p>
+
+<h2 class="govuk-heading-l">Enforcement procedure</h2>
+<p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').</p>
+<p class="govuk-body">If you are not happy with how we respond to your complaint, <%= govuk_link_to 'contact the Equality Advisory and Support Service (EASS)', "https://www.equalityadvisoryservice.com/" %></p>
+
+<h2 class="govuk-heading-l">Technical information about this service’s accessibility</h2>
+<p class="govuk-body">The Department for Education is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+
+<h2 class="govuk-heading-l">Compliance status</h2>
+<p class="govuk-body">This service is fully compliant with the <%= govuk_link_to 'Web Content Accessibility Guidelines version 2.1) AA standard.', "https://www.w3.org/TR/WCAG21/" %>
+<p class="govuk-body">There may be accessibility issues we have not found yet. If you find any please contact us so we can continue to improve the services we provide.</p>
+
+<h3 class="govuk-heading-m">Disproportionate burden</h3>
+<p class="govuk-body">Not applicable</p>
+
+<h3 class="govuk-heading-m">Content not within scope of this accessibility statement</h3>
+<p class="govuk-body">Not applicable</p>
+
+<h2 class="govuk-heading-l">Preparation of this accessibility statement</h2>
+<p class="govuk-body">This statement was prepared on 21 June 2021.</p>
+<p class="govuk-body">Testing was carried out internally by the Department for Education.</p>
+<p class="govuk-body">We tested the service based on a user’s ability to complete key journeys.</p>
+<p class="govuk-body">All parts of the chosen journeys were tested.</p>
+<p class="govuk-body">Journeys were chosen based on a number of factors, including risk assessments and subject matter.</p>
+<p class="govuk-body">We will have an external accessibility audit carried out by the end of September 2021.</p>

--- a/app/views/static/register_for_npq_privacy.html.erb
+++ b/app/views/static/register_for_npq_privacy.html.erb
@@ -1,0 +1,86 @@
+<% content_for :page_title, 'Privacy notice' %>
+
+<h1 class="govuk-heading-xl">Privacy notice</h1>
+
+<h2 class="govuk-heading-m">Who we are</h2>
+
+<p class="govuk-body">Get an identity to access Teacher Services is run by the <a class="govuk-link" href=https://www.gov.uk/government/organisations/teaching-regulation-agency/about">Teaching Regulation Agency (TRA)</a>, an executive agency of the Department for Education (DfE).</p>
+
+<p>For the purpose of General Data Protection Regulation (GDPR), DfE is the data controller for the data we hold and process.</p>
+
+<h2 class="govuk-heading-m">What data we collect</h2>
+
+<p class="govuk-body">We collect:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>names</li>
+  <li>email addresses</li>
+  <li>dates of birth</li>
+  <li>National Insurance number</li>
+  <li>initial teacher training (ITT) provider - where you gained qualified teacher status(QTS) or early years teacher status (EYTS).</li>
+  <li>teacher reference number (TRN)</li>
+</ul>
+
+<h2 class="govuk-heading-m">Why we collect this data</h2>
+
+<p class="govuk-body">We collect this data to check if it is held in the database of qualified teachers (DQT) and to create an account. This will allow users to:</p>
+<ul class="govuk-list govuk-list--bullet">
+<li>access many teacher services with one login</li>
+<li>provide and update their data once across all teacher services, instead of maintaining it separately in each individual service</li>
+</ul>
+
+<h2 class="govuk-heading-m">Cookies</h2>
+
+<p class="govuk-body">You can read our <a class="govuk-link" href="/cookies">cookie policy</a> to find out about the cookies we use on Get an identity to access Teacher Services.</p>
+
+<h2 class="govuk-heading-m">What we do with personal data</h2>
+
+<p>We only collect the data we need for the purposes outlined in ‘Why we collect this data’.</p>
+
+<p class="govuk-body">We will not:</p>
+<ul class="govuk-list govuk-list--bullet">
+<li>sell or rent users’ data to third parties</li>
+<li>share data with third parties for marketing purposes</li>
+</ul>
+
+<h2 class="govuk-heading-m">Our lawful basis for processing your personal data</h2>
+
+<p>Running and improving Get an identity to access Teacher Services is in the Public Interest, as defined in data protection law (UK GDPR and Data Protection Act 2018).</p>
+
+<h2 class="govuk-heading-m">How we use third parties to process your data</h2>
+
+<p>Some of your personal information is processed by our Data Processors, listed below. They allow us to run and improve Get an identity to access Teacher Services.</p>
+
+<p>We share your data with our data processors for the purposes of provision of this service. Data Protection Agreements are in place with each of these Processors and they are required to comply with the UK GDPR and the UK Data Protection Act 2018 as Data Processors.</p>
+
+<h3 class="govuk-heading-s">Customer service management systems</h3>
+
+<p>We use Zendesk to manage and respond to your queries.</p>
+
+<p><a class="govuk-link" href="https://www.zendesk.co.uk/company/privacy-and-data-protection/#faq-general-1" rel="noreferrer noopener" target="_blank"> Visit the Zendesk website to find out how they use and look after your data (“service data”)</a>(opens in new tab)</p>
+
+<h2 class="govuk-heading-m">How long we keep your personal data</h2>
+
+<p>We keep your personal data for as long as you use the service. We will keep it for no longer than 7 years after you stop using the service.</p>
+
+<h2 class="govuk-heading-m">To Raise a concern</h2>
+
+<p class="govuk-body">You have rights under the UK GDPR and the Data Protection Act 2018. However, these rights are conditional on the lawful basis. We process your data under the lawful basis of Public Interest which grants you the following rights:</p>
+<ul class="govuk-list govuk-list--bullet">
+<li>being informed about how your data is being used</li>
+<li>accessing personal data</li>
+<li>having incorrect data corrected</li>
+<li>restricting the processing of your data (for example where the data is inaccurate or outdated)</li>
+<li>objecting to how your data is processed in certain circumstances, including automated processing and profiling</li>
+</ul>
+
+<p class="govuk-body">You can find more information about how we handle personal data in our <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" class="govuk-link">personal information charter</a>.</p>
+
+<p class="govuk-body">Contact the Get an Identity to access Teacher Services team at <a href="mailto:QTS.enquiries@digital.education.gov.uk">QTS.enquiries@digital.education.gov.uk</a>, if you have any concerns about your personal data.</p>
+
+<p class="govuk-body">You can also <a class="govuk-link" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">get in touch with the Department for Education’s data protection officer through the online contact form</a>.</p>
+
+<h2 class="govuk-heading-m">Keep up to date</h2>
+
+<p>We periodically review this policy. We’ll notify you if we change how we use your personal data.</p>
+
+<p>It was last updated on 19 October 2022.</p>

--- a/app/views/support_interface/identity/new.html.erb
+++ b/app/views/support_interface/identity/new.html.erb
@@ -15,6 +15,11 @@
         label: { size: 's', text: 'Client title' },
         hint: { text: 'Will be displayed in the page <title> and the header' }
       ) %>
+      <%= f.govuk_text_field(:client_id,
+        label: { size: 's', text: 'Client ID' },
+        hint: { text: "Is used to determine which Privacy and \
+                Accessibility pages to show" }
+      ) %>
       <%= f.govuk_text_field(:email,
         label: { size: 's', text: 'Email' },
         hint: { text: 'Used by matching' }
@@ -24,28 +29,28 @@
         label: { size: 's', text: 'Journey ID' },
         hint: { text: "Used by Get an Identity to match up the user’s \
                 session. Editing is disabled for simulated journeys  \
-                because we don’t use it." }
+                because we don’t use it" }
       ) %>
       <%= f.govuk_text_field(:redirect_url,
         disabled: true,
         label: { size: 's', text: 'Redirect URL' },
         hint: { text: "Callback URL to the Identity server. Editing is \
                 disabled for simulated journeys because simulated journeys \
-                should always return to Find." }
+                should always return to Find" }
       ) %>
       <%= f.govuk_text_field(:client_url,
         disabled: true,
         label: { size: 's', text: 'Client URL' },
         hint: { text: "Will be linked to from the header. Editing is \
                 disabled for simulated journeys because simulated journeys \
-                should always return to Find." }
+                should always return to Find" }
       ) %>
       <%= f.govuk_text_field(:previous_url,
         disabled: true,
         label: { size: 's', text: 'Previous URL' },
         hint: { text: "Linked to from the back button on the Name page. Editing \
                 is disabled for simulated journeys because simulated journeys \
-                should always return to Find." }
+                should always return to Find" }
       ) %>
       <%= f.govuk_submit "Continue", prevent_double_click: false %>
     <% end %>


### PR DESCRIPTION
### Context

This is the privacy page that we want to show while the user is in an Identity flow, specifically the Register for an NPQ one.

### Changes proposed in this pull request

See commits.

### Guidance to review

#### Usual notice

![image](https://user-images.githubusercontent.com/1650875/200896002-2fd46d97-d941-46b0-b267-3df7019860c6.png)

#### Identity flow

![image](https://user-images.githubusercontent.com/1650875/200896125-e94ae6c4-9056-46b3-85a5-47eed3a83ce2.png)


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
