### PR TITLE
Pass in preferred{First,Last}Name to Identity API

### DIFF
--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -23,8 +23,10 @@ class IdentityApi
 
   def self.trn_request_params(trn_request)
     {
-      firstName: trn_request.preferred_first_name || trn_request.first_name,
-      lastName: trn_request.preferred_last_name || trn_request.last_name,
+      firstName: trn_request.first_name,
+      lastName: trn_request.last_name,
+      preferredFirstName: trn_request.preferred_first_name,
+      preferredLastName: trn_request.preferred_last_name,
       trn: trn_request.trn,
       dateOfBirth: trn_request.date_of_birth&.to_date&.to_s,
       nationalInsuranceNumber: trn_request.ni_number,

--- a/app/services/identity_api.rb
+++ b/app/services/identity_api.rb
@@ -23,8 +23,8 @@ class IdentityApi
 
   def self.trn_request_params(trn_request)
     {
-      firstName: trn_request.first_name,
-      lastName: trn_request.last_name,
+      officialFirstName: trn_request.first_name,
+      officialLastName: trn_request.last_name,
       preferredFirstName: trn_request.preferred_first_name,
       preferredLastName: trn_request.preferred_last_name,
       trn: trn_request.trn,

--- a/spec/services/identity_api_spec.rb
+++ b/spec/services/identity_api_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe IdentityApi do
       it "the params contain the NI number" do
         expect(IdentityApi.trn_request_params(trn_request)).to eq(
           {
-            firstName: "John",
-            lastName: "Smith",
+            officialFirstName: "John",
+            officialLastName: "Smith",
             dateOfBirth: "2000-01-01",
             trn: "2921020",
             nationalInsuranceNumber: "QQ123456C",
@@ -77,8 +77,8 @@ RSpec.describe IdentityApi do
       it "the params do not contain the NI number" do
         expect(IdentityApi.trn_request_params(trn_request)).to eq(
           {
-            firstName: "John",
-            lastName: "Smith",
+            officialFirstName: "John",
+            officialLastName: "Smith",
             dateOfBirth: "2000-01-01",
             trn: "2921020",
           },
@@ -101,8 +101,8 @@ RSpec.describe IdentityApi do
       it "the params contain the preferred name" do
         expect(IdentityApi.trn_request_params(trn_request)).to eq(
           {
-            firstName: "John",
-            lastName: "Smith",
+            officialFirstName: "John",
+            officialLastName: "Smith",
             preferredFirstName: "Preferred",
             preferredLastName: "Name",
             dateOfBirth: "2000-01-01",

--- a/spec/services/identity_api_spec.rb
+++ b/spec/services/identity_api_spec.rb
@@ -101,8 +101,10 @@ RSpec.describe IdentityApi do
       it "the params contain the preferred name" do
         expect(IdentityApi.trn_request_params(trn_request)).to eq(
           {
-            firstName: "Preferred",
-            lastName: "Name",
+            firstName: "John",
+            lastName: "Smith",
+            preferredFirstName: "Preferred",
+            preferredLastName: "Name",
             dateOfBirth: "2000-01-01",
             trn: "2921020",
           },


### PR DESCRIPTION
The API expects the fields to be passed in separately, not on top of the existing firstName/lastName ones.