### PR TITLE
Amend scope for Identity support authorization

### DIFF
--- a/lib/omniauth/strategies/identity.rb
+++ b/lib/omniauth/strategies/identity.rb
@@ -10,7 +10,7 @@ module Omniauth
                token_url: "/connect/token",
              }
       option :pkce, true
-      option :scope, "get-an-identity:support"
+      option :scope, "get-an-identity:support user:write"
 
       credentials { { token: access_token } }
       info { { name: raw_info["name"], email: raw_info["email"] } }


### PR DESCRIPTION
As well as the `get-an-identity:support` scope, `user:write` is also required (https://github.com/DFE-Digital/get-an-identity/pull/298).
