### PR TITLE
Fix deprecated Identity user list endpoint

### DIFF
--- a/app/services/identity_users_api.rb
+++ b/app/services/identity_users_api.rb
@@ -30,7 +30,7 @@ class IdentityUsersApi < IdentityApi
   def get_users
     raise_if_timeout_feature_flag_active!
 
-    response = client.get("/api/v1/teachers")
+    response = client.get("/api/v1/users")
 
     raise ApiError, response.reason_phrase unless response.status == 200
 

--- a/spec/cassettes/IdentityUsersApi/_get_users/returns_users_from_the_identity_api.yml
+++ b/spec/cassettes/IdentityUsersApi/_get_users/returns_users_from_the_identity_api.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod.teaching-identity.education.gov.uk/api/v1/teachers
+      uri: https://preprod.teaching-identity.education.gov.uk/api/v1/users
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/cassettes/Identity_Users_Support/displays_a_list_of_users.yml
+++ b/spec/cassettes/Identity_Users_Support/displays_a_list_of_users.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod.teaching-identity.education.gov.uk/api/v1/teachers
+      uri: https://preprod.teaching-identity.education.gov.uk/api/v1/users
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/cassettes/User_page_in_support/adding_a_DQT_record/when_i_click_on_add_record.yml
+++ b/spec/cassettes/User_page_in_support/adding_a_DQT_record/when_i_click_on_add_record.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod.teaching-identity.education.gov.uk/api/v1/teachers/29e9e624-073e-41f5-b1b3-8164ce3a5233
+      uri: https://preprod.teaching-identity.education.gov.uk/api/v1/users/29e9e624-073e-41f5-b1b3-8164ce3a5233
       body:
         encoding: US-ASCII
         string: ""


### PR DESCRIPTION
The `/api/v1/teachers` base URL was deprecated some time ago in favour of `/api/v1/users`. This fixes up the `get_users` method to use the new URL.