### PR TITLE
Update check answers page row for preferred name

### DIFF
--- a/app/components/trn_details_component.html.erb
+++ b/app/components/trn_details_component.html.erb
@@ -58,7 +58,7 @@
   rows.push(email_row)
   rows.push(official_name_row)
   rows.push(previous_name_row) if @trn_request.previous_name?
-  rows.push(preferred_name_row) if @trn_request.preferred_name?
+  rows.push(preferred_name_row)
   rows.push(date_of_birth_row)
   rows.push(ni_row)
   rows.push(ask_trn_row) if @trn_request.from_get_an_identity? && !@trn_request.trn_from_user.nil?

--- a/app/components/trn_details_component.html.erb
+++ b/app/components/trn_details_component.html.erb
@@ -8,7 +8,7 @@
   }
 
   official_name_row = {
-    key: { text: 'Official name' },
+    key: { text: 'Name' },
     value: { text: official_name },
     actions: [{ href: name_path, visually_hidden_text: 'name' }]
   }

--- a/app/components/trn_details_component.rb
+++ b/app/components/trn_details_component.rb
@@ -24,6 +24,7 @@ class TrnDetailsComponent < ViewComponent::Base
   end
 
   def preferred_name
+    return "Same as name" if @trn_request.preferred_name.blank?
     if @anonymise
       @trn_request
         .preferred_name

--- a/app/views/name/edit.html.erb
+++ b/app/views/name/edit.html.erb
@@ -13,7 +13,7 @@
   <h2 class="govuk-heading-m">Use the name on your official documents</h2>
   <p>
     You should tell us the name that appears on your passport, driving licence or marriage certificate, if you have one.
-    We’ll try to match it against our records.
+    We’ll try to find you in our records.
   </p>
   <p>
     If the names on your documents are different, give us the most recent one.

--- a/spec/components/trn_details_component_spec.rb
+++ b/spec/components/trn_details_component_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe TrnDetailsComponent, type: :component do
   let(:awarded_qts) { true }
   let(:trn_from_user) { "1234567" }
   let(:from_get_an_identity) { false }
+  let(:preferred_first_name) { "Ray" }
+  let(:preferred_last_name) { "Purchase" }
   let(:trn_request) do
     TrnRequest.new(
       awarded_qts:,
@@ -23,8 +25,8 @@ RSpec.describe TrnDetailsComponent, type: :component do
       ni_number:,
       previous_last_name: "Smith",
       trn_from_user:,
-      preferred_first_name: "Ray",
-      preferred_last_name: "Purchase",
+      preferred_first_name:,
+      preferred_last_name:,
     )
   end
   let(:component) { render_inline(described_class.new(trn_request:)) }
@@ -161,6 +163,15 @@ RSpec.describe TrnDetailsComponent, type: :component do
           described_class.new(trn_request:, anonymise: true, actions: true),
         )
       }.to raise_error(ArgumentError)
+    end
+  end
+
+  context "when preferred name is same as name" do
+    let(:preferred_first_name) { "" }
+    let(:preferred_last_name) { "" }
+
+    it 'renders "Same as name"' do
+      expect(component.text).to include("Same as name")
     end
   end
 

--- a/spec/system/identity/user_matches_an_identity_spec.rb
+++ b/spec/system/identity/user_matches_an_identity_spec.rb
@@ -85,9 +85,7 @@ RSpec.feature "Get an identity", type: :system do
   def then_the_check_answers_page_contains_the_answers_i_submitted
     expect(page.current_path).to eq check_answers_path
 
-    within_summary_row("Official name") do
-      expect(page).to have_content "Steven Toast"
-    end
+    within_summary_row("Name") { expect(page).to have_content "Steven Toast" }
     within_summary_row("Preferred name") do
       expect(page).to have_content "Kevin E"
     end


### PR DESCRIPTION
Display "Same as name" when the user does not specify a preferred name.

Also fix some other minor content snags.

![image](https://user-images.githubusercontent.com/1650875/201933382-a966f8c5-5a78-4d96-b706-9d7612c0ee42.png)
