### PR TITLE
Get KeyVault name for sp_check from matrix data

### DIFF
--- a/.github/workflows/check_sp.yml
+++ b/.github/workflows/check_sp.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Select Tests
         id: select-tests
         run: |
-          d="{'environment':'dev', 'principal': 's165d01-faltrn-keyvault-readonly-access'}"
-          t="{'environment':'test', 'principal': 's165t01-faltrn-keyvault-readonly-access'}"
-          pp="{'environment':'preprod', 'principal': 's165t01-preprod-faltrn-keyvault-readonly-access'}"
-          p="{'environment':'production', 'principal': 's165p01-faltrn-keyvault-readonly-access'}"
+          d="{'environment':'dev', 'principal': 's165d01-faltrn-keyvault-readonly-access', 'keyvault': 's165d01-faltrn-dv-kv'}"
+          t="{'environment':'test', 'principal': 's165t01-faltrn-keyvault-readonly-access', 'keyvault': 's165t01-faltr-ts-kv'}"
+          pp="{'environment':'preprod', 'principal': 's165t01-preprod-faltrn-keyvault-readonly-access', 'keyvault': 's165t01-faltrn-pp-kv'}"
+          p="{'environment':'production', 'principal': 's165p01-faltrn-keyvault-readonly-access', 'keyvault': 's165p01-faltrn-pd-kv'}"
           tests="{ 'data':[ ${d},  ${t},  ${pp},  ${p} ]}"
           echo "tests=${tests}" >> $GITHUB_OUTPUT
   check_expires:
@@ -53,7 +53,7 @@ jobs:
         if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
         id: keyvault-yaml-secret
         with:
-          keyvault: ${{ secrets.KEY_VAULT}}
+          keyvault: ${{ matrix.data.keyvault }}
           secret: MONITORING
           key: SLACK_WEBHOOK
         env:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Slack Notification
         if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: "#ff0000"
           SLACK_TITLE: ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }} ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }}
@@ -69,4 +69,4 @@ jobs:
             The Service Principal ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }}
             key ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }} is due to expire in ${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}} days
             Please follow the process in https://dfe-technical-guidance.london.cloudapps.digital/how-to/security/managing-secrets/#access-key-expiration to renew.
-            SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

KeyVault name is stored in GitHub secret (which hasn't been set in a number of repos.  Reducing GitHub secrets reduces management overhead and makes this workflow easier to generalise.

### Changes proposed in this pull request

- Use matrix data to store KeyVault
- Pinned major version of rtCamp/action-slack-notify
- Fixed setting of SLACK_WEBHOOK env var

### Guidance to review

Review test logs [here](https://github.com/DFE-Digital/find-a-lost-trn/actions/runs/3490147846)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
