### PR TITLE
Add paging params to the Identity users endpoint

### DIFF
--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -7,9 +7,11 @@ module SupportInterface
     layout "two_thirds", only: %i[edit update email update_email]
 
     def index
-      @all_users ||= identity_users_api.get_users
-      @total = @all_users.size
-      @pagy, @users = pagy_array(@all_users)
+      page = params[:page] || 1
+      @all_users ||= identity_users_api.get_users(page:)
+      @total = @all_users[:total]
+      @pagy = Pagy.new(count: @total, page:)
+      @users = @all_users[:users]
     end
 
     def show

--- a/app/services/identity_users_api.rb
+++ b/app/services/identity_users_api.rb
@@ -27,15 +27,19 @@ class IdentityUsersApi < IdentityApi
     response.body
   end
 
-  def get_users
+  def get_users(page: 1, per_page: 100)
     raise_if_timeout_feature_flag_active!
 
-    response = client.get("/api/v1/users")
+    response =
+      client.get("/api/v1/users", { pageNumber: page, pageSize: per_page })
 
     raise ApiError, response.reason_phrase unless response.status == 200
 
     users = response.body.fetch("users", [])
-    users.map { |user| User.new(user) }
+    {
+      users: users.map { |user| User.new(user) },
+      total: response.body["total"],
+    }
   end
 
   def update_user(uuid, user_attributes)

--- a/spec/cassettes/IdentityUsersApi/_get_users/returns_users_from_the_identity_api.yml
+++ b/spec/cassettes/IdentityUsersApi/_get_users/returns_users_from_the_identity_api.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://preprod.teaching-identity.education.gov.uk/api/v1/users
+      uri: https://preprod.teaching-identity.education.gov.uk/api/v1/users?pageNumber=1&pageSize=100
       body:
         encoding: US-ASCII
         string: ""
@@ -51,6 +51,6 @@ http_interactions:
           - "2022-10-05T14:12:00.0000000Z"
       body:
         encoding: UTF-8
-        string: '{"users":[{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null},{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"jake.benilov@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"},{"userId":"51a31384-113d-4c84-adae-0de84a686fc0","email":"tarikjohnston@gmail.com","firstName":"tarik","lastName":"johnston","dateOfBirth":"1980-01-31","trn":null},{"userId":"f3ef3547-071e-4fbd-8a85-4faeaf788a51","email":"naomi@lockyy.com","firstName":"Naomi","lastName":"Lockhart","dateOfBirth":"1992-02-17","trn":null}]}'
+        string: '{"users":[{"userId":"37ee5357-fb84-478e-b750-bf552e5c8eed","email":"paul.hayes@digital.education.gov.uk","firstName":"Jane","lastName":"Doess","dateOfBirth":"1901-01-01","trn":null},{"userId":"29e9e624-073e-41f5-b1b3-8164ce3a5233","email":"jake.benilov@digital.education.gov.uk","firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","trn":"2921020"},{"userId":"51a31384-113d-4c84-adae-0de84a686fc0","email":"tarikjohnston@gmail.com","firstName":"tarik","lastName":"johnston","dateOfBirth":"1980-01-31","trn":null},{"userId":"f3ef3547-071e-4fbd-8a85-4faeaf788a51","email":"naomi@lockyy.com","firstName":"Naomi","lastName":"Lockhart","dateOfBirth":"1992-02-17","trn":null}],"total":4}'
     recorded_at: Wed, 05 Oct 2022 14:11:03 GMT
 recorded_with: VCR 6.1.0

--- a/spec/requests/support_interface/identity_auth_token_expiry_spec.rb
+++ b/spec/requests/support_interface/identity_auth_token_expiry_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "GET /support with identity_auth_service feature enabled",
 
   context "with an access token which is valid" do
     let(:identity_users_api) do
-      instance_double(IdentityUsersApi, get_users: [])
+      instance_double(IdentityUsersApi, get_users: { total: 0, users: [] })
     end
 
     it "allows access to support pages" do

--- a/spec/services/identity_users_api_spec.rb
+++ b/spec/services/identity_users_api_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe IdentityUsersApi do
   describe "#get_users", vcr: true do
     it "returns users from the identity api" do
-      users = described_class.new(ENV["IDENTITY_USER_TOKEN"]).get_users
+      users = described_class.new(ENV["IDENTITY_USER_TOKEN"]).get_users[:users]
 
       expect(users.map(&:uuid)).to include(
         "29e9e624-073e-41f5-b1b3-8164ce3a5233",

--- a/spec/system/support_interface/users_spec.rb
+++ b/spec/system/support_interface/users_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe "Identity Users Support", type: :system do
   before { allow(IdentityUsersApi).to receive(:new).and_return(identity_api) }
 
   it "displays a list of users", vcr: true, download: true do
-    allow(identity_api).to receive(:get_users).and_return([User.new(user)])
+    allow(identity_api).to receive(:get_users).and_return(
+      { total: 1, users: [User.new(user)] },
+    )
     given_i_am_authorized_as_a_support_user
     when_i_visit_the_identity_users_support_page
     then_i_should_see_a_user
@@ -25,8 +27,10 @@ RSpec.describe "Identity Users Support", type: :system do
 
   context "when there are more than 100 users" do
     before do
-      users = 150.times.map { User.new(user) }
-      allow(identity_api).to receive(:get_users).and_return(users)
+      users = 100.times.map { User.new(user) }
+      allow(identity_api).to receive(:get_users).and_return(
+        { total: 150, users: },
+      )
     end
 
     it "shows the Identity users paginated" do
@@ -41,7 +45,9 @@ RSpec.describe "Identity Users Support", type: :system do
   context "when the user does not have a DQT record" do
     before do
       user["trn"] = nil
-      allow(identity_api).to receive(:get_users).and_return([User.new(user)])
+      allow(identity_api).to receive(:get_users).and_return(
+        { total: 1, users: [User.new(user)] },
+      )
     end
 
     it "shows a link to add a DQT record" do
@@ -54,7 +60,9 @@ RSpec.describe "Identity Users Support", type: :system do
   context "when the user has a DQT record" do
     before do
       user["trn"] = "12345"
-      allow(identity_api).to receive(:get_users).and_return([User.new(user)])
+      allow(identity_api).to receive(:get_users).and_return(
+        { total: 1, users: [User.new(user)] },
+      )
     end
 
     it "shows a link to add a DQT record" do
@@ -67,7 +75,9 @@ RSpec.describe "Identity Users Support", type: :system do
   context "When user attempts to match identity record to a DQT record" do
     before do
       user["trn"] = nil
-      allow(identity_api).to receive(:get_users).and_return([User.new(user)])
+      allow(identity_api).to receive(:get_users).and_return(
+        { total: 1, users: [User.new(user)] },
+      )
     end
 
     it "shows the add TRN page", vcr: true do


### PR DESCRIPTION
The Identity API endpoint for users has recently added support for
pagination.

We can now pass query params to page the results via the API rather than
fetching all users and paging in memory.

This should result in a more performant initial load for the users view
in the support interface.

The new params are `pageNumber` and `pageSize`.

The default page size in the API is 25 but given our interface has an
expectation on paging 100 records at a time, I supplied that as our
default.

### Checklist

- [x] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
