### PR TITLE
Limit CSV exports to post-launch

### DIFF
--- a/app/models/zendesk_delete_request.rb
+++ b/app/models/zendesk_delete_request.rb
@@ -28,6 +28,7 @@ class ZendeskDeleteRequest < ApplicationRecord
             .flatten
         }
   scope :no_duplicates, -> { where.not(id: duplicate_ids) }
+  scope :since_launch, -> { where(closed_at: PerformanceStats::LAUNCH_DATE..) }
 
   def from(ticket)
     self.ticket_id = ticket.id

--- a/spec/models/zendesk_delete_request_spec.rb
+++ b/spec/models/zendesk_delete_request_spec.rb
@@ -139,4 +139,23 @@ RSpec.describe ZendeskDeleteRequest, type: :model do
       end
     end
   end
+
+  describe ".since_launch" do
+    subject { described_class.since_launch }
+
+    let(:prelaunch) { create(:zendesk_delete_request, closed_at: 1.day.ago) }
+    let(:postlaunch) do
+      create(:zendesk_delete_request, closed_at: Time.current)
+    end
+
+    before do
+      travel_to PerformanceStats::LAUNCH_DATE
+      prelaunch
+      postlaunch
+    end
+
+    after { travel_back }
+
+    it { is_expected.to eq [postlaunch] }
+  end
 end


### PR DESCRIPTION
The CSV export currently exports all delete requests. In production
we've noticed that there are some delete requests from prior to the
launch date of the service.

The team exporting the CSV don't want any delete requests from before
the launch date, so we can filter them out.

I considered making a default scope to ensure that we always filter out
delete requests anywhere we handle them but felt this might become a
subtle problem in the future. Default scopes can fly under the radar.

Instead, I opted for an explicit scope. This way we can make it obvious
about the places where we care about filtering out the requests
pre-launch.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
