### PR TITLE
Allow exporting a CSV per month

### DIFF
--- a/app/controllers/support_interface/zendesk_controller.rb
+++ b/app/controllers/support_interface/zendesk_controller.rb
@@ -15,6 +15,8 @@ module SupportInterface
 
       @pagy, @zendesk_delete_requests =
         pagy(ZendeskDeleteRequest.order(closed_at: :desc))
+
+      @export_form = SupportInterface::ZendeskExportForm.new
     end
 
     def confirm_deletion

--- a/app/controllers/support_interface/zendesk_csv_exports_controller.rb
+++ b/app/controllers/support_interface/zendesk_csv_exports_controller.rb
@@ -1,10 +1,23 @@
 module SupportInterface
   class ZendeskCsvExportsController < SupportInterfaceController
     def create
-      filename = "#{Time.zone.today}_deleted_zendesk_tickets.csv"
+      @export_form =
+        SupportInterface::ZendeskExportForm.new(zendesk_export_form_params)
+
       respond_to do |format|
-        format.csv { send_data ZendeskDeleteRequest.to_csv, filename: }
+        format.csv do
+          send_data ZendeskDeleteRequest.to_csv(@export_form.scope),
+                    filename: @export_form.filename
+        end
       end
+    end
+
+    private
+
+    def zendesk_export_form_params
+      params.require(:support_interface_zendesk_export_form).permit(
+        :time_period,
+      )
     end
   end
 end

--- a/app/forms/support_interface/zendesk_export_form.rb
+++ b/app/forms/support_interface/zendesk_export_form.rb
@@ -1,0 +1,48 @@
+module SupportInterface
+  class ZendeskExportForm
+    include ActiveModel::Model
+
+    attr_accessor :time_period
+
+    def filename
+      time_period_string = time_period.to_time&.strftime("%Y_%m_%d") || "all"
+
+      "#{time_period_string}_deleted_zendesk_tickets.csv"
+    end
+
+    def months
+      @months ||=
+        begin
+          date = PerformanceStats::LAUNCH_DATE
+          months = []
+          while date < Time.current
+            months << [
+              date.beginning_of_month.strftime("%B %Y"),
+              date.beginning_of_month,
+            ]
+            date = date.advance(months: 1)
+          end
+          months << %w[All all]
+          months.reverse
+        end
+    end
+
+    def scope
+      @scope ||=
+        begin
+          scope = ZendeskDeleteRequest.since_launch.no_duplicates
+          if time_period.present?
+            case time_period
+            when "all"
+              scope
+            else
+              start = time_period.to_time.beginning_of_month
+              closed_at = [start..start.end_of_month]
+              scope = scope.where(closed_at:)
+            end
+          end
+          scope
+        end
+    end
+  end
+end

--- a/app/models/zendesk_delete_request.rb
+++ b/app/models/zendesk_delete_request.rb
@@ -48,7 +48,7 @@ class ZendeskDeleteRequest < ApplicationRecord
     self
   end
 
-  def self.to_csv(scope = no_duplicates)
+  def self.to_csv(scope = no_duplicates.since_launch)
     CSV.generate(headers: true) do |csv|
       csv << %w[
         ticket_id

--- a/app/views/support_interface/zendesk/index.html.erb
+++ b/app/views/support_interface/zendesk/index.html.erb
@@ -91,7 +91,12 @@
 <p><%= govuk_link_to "Import from CSV", new_support_interface_zendesk_import_path %></p>
 
 <% unless @zendesk_delete_requests.size.zero? %>
-  <p><%= govuk_button_to "Export to CSV", support_interface_zendesk_exports_path(format: :csv), method: :post %></p>
+  <p>
+    <%= form_with model: @export_form, url: support_interface_zendesk_exports_path(format: :csv) do |f| %>
+      <%= f.govuk_collection_select :time_period, @export_form.months, :last, :first, include_blank: true, label: { text: "Which month do you want to export?" } %>
+      <%= f.govuk_submit "Export to CSV" %>
+    <% end %>
+  </p>
 
   <%= govuk_pagination(pagy: @pagy) %>
 

--- a/spec/forms/zendesk_export_form_spec.rb
+++ b/spec/forms/zendesk_export_form_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe SupportInterface::ZendeskExportForm, type: :model do
+  describe "#filename" do
+    subject do
+      described_class.new(
+        time_period: Time.zone.local(2022, 12, 1, 12, 0, 0),
+      ).filename
+    end
+
+    it { is_expected.to eq("2022_12_01_deleted_zendesk_tickets.csv") }
+  end
+
+  describe "#months" do
+    subject { described_class.new(time_period: nil).months }
+
+    before { travel_to Time.zone.local(2022, 6, 18, 12, 0, 0) }
+
+    after { travel_back }
+
+    it "returns all months since the launch date" do
+      is_expected.to eq(
+        [
+          %w[All all],
+          ["June 2022", Time.zone.local(2022, 6, 1, 0, 0, 0)],
+          ["May 2022", Time.zone.local(2022, 5, 1, 0, 0, 0)],
+        ],
+      )
+    end
+  end
+
+  describe "#scope" do
+    subject { described_class.new(time_period:).scope.to_a }
+
+    let!(:prelaunch_ticket) do
+      create(
+        :zendesk_delete_request,
+        closed_at: Time.zone.local(2022, 5, 3, 12, 0, 0),
+      )
+    end
+    let!(:may_ticket) do
+      create(
+        :zendesk_delete_request,
+        closed_at: Time.zone.local(2022, 5, 4, 12, 0, 0),
+      )
+    end
+    let!(:june_ticket) do
+      create(
+        :zendesk_delete_request,
+        closed_at: Time.zone.local(2022, 6, 1, 12, 0, 0),
+        ticket_id: 43,
+      )
+    end
+
+    context "when time_period is 'all'" do
+      let(:time_period) { "all" }
+
+      it { is_expected.to eq([may_ticket, june_ticket]) }
+    end
+
+    context "when time_period is a date" do
+      let(:time_period) { Time.zone.local(2022, 6, 1, 0, 0, 0) }
+
+      it { is_expected.to eq([june_ticket]) }
+    end
+  end
+end

--- a/spec/system/support_interface/zendesk_tickets_export_spec.rb
+++ b/spec/system/support_interface/zendesk_tickets_export_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.feature "Zendesk ticket exports", type: :system do
+  before do
+    travel_to Time.zone.local(2022, 12, 18, 12, 0, 0)
+    given_the_service_is_open
+  end
+
+  after do
+    travel_back
+    deactivate_feature_flags
+  end
+
+  scenario "Exporting deleted tickets", download: true do
+    given_there_is_a_deleted_zendesk_ticket
+    and_i_am_authorized_as_a_support_user
+    and_i_am_on_the_zendesk_tickets_page
+    when_i_select_the_time_period
+    and_i_click_the_export_button
+    then_the_exported_file_should_contain_the_deleted_ticket
+  end
+
+  private
+
+  def and_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize("test", "test")
+  end
+
+  def and_i_am_on_the_zendesk_tickets_page
+    visit support_interface_zendesk_path
+  end
+
+  def and_i_click_the_export_button
+    click_on "Export to CSV"
+  end
+
+  def deactivate_feature_flags
+    FeatureFlag.deactivate(:service_open)
+  end
+
+  def given_the_service_is_open
+    FeatureFlag.activate(:service_open)
+  end
+
+  def given_there_is_a_deleted_zendesk_ticket
+    create(
+      :zendesk_delete_request,
+      ticket_id: 1,
+      closed_at: Time.zone.local(2022, 12, 1, 12, 0, 0),
+    )
+    create(
+      :zendesk_delete_request,
+      ticket_id: 1,
+      closed_at: Time.zone.local(2022, 11, 1, 12, 0, 0),
+    )
+  end
+
+  def then_the_exported_file_should_contain_the_deleted_ticket
+    expect(page.response_headers["Content-Disposition"]).to eq(
+      "attachment; filename=\"2022_11_01_deleted_zendesk_tickets.csv\"; " \
+        "filename*=UTF-8''2022_11_01_deleted_zendesk_tickets.csv",
+    )
+    expect(page.response_headers["Content-Type"]).to eq("text/csv")
+    expect(download_content).to eq(
+      "Ticket,Group Name,Received At,Closed At,Enquiry Type,No Action Required\n" \
+        "1,QTS Enquiries,2022-06-05 13:00,2022-11-01 12:00,Trn,\n",
+    )
+  end
+
+  def when_i_select_the_time_period
+    select "November 2022",
+           from: "Which month do you want to export?",
+           visible: false
+  end
+end


### PR DESCRIPTION
### Context

We want to provide the option of downloading the Zendesk delete requests
for a given month.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1148" alt="Screenshot 2022-12-19 at 10 42 46 am" src="https://user-images.githubusercontent.com/3126/208408179-9f9b94b3-c529-4f63-89ce-6c3d5ea5592d.png">
<img width="1146" alt="Screenshot 2022-12-19 at 10 42 52 am" src="https://user-images.githubusercontent.com/3126/208408183-269672be-81b0-4a57-ab9e-f7cc8bbca496.png">
