### PR TITLE
Update the blank TRN error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
             do_you_know_your_trn:
               inclusion: Tell us if you know your TRN number
             trn_from_user:
-              blank: Enter your TRN number
+              blank: Enter your TRN
               too_long: Enter a TRN number that is 7 digits long
               wrong_length: Your TRN number should contain 7 digits
         support_interface/confirm_dqt_record_form:

--- a/spec/forms/ask_trn_form_spec.rb
+++ b/spec/forms/ask_trn_form_spec.rb
@@ -58,9 +58,7 @@ RSpec.describe AskTrnForm, type: :model do
       end
       it "adds an error" do
         update!
-        expect(ask_trn_form.errors[:trn_from_user]).to include(
-          "Enter your TRN number",
-        )
+        expect(ask_trn_form.errors[:trn_from_user]).to include("Enter your TRN")
       end
       it "logs a validation error" do
         expect { update! }.to change(ValidationError, :count).by(1)


### PR DESCRIPTION
We want to simplify the error message for a blank TRN.

See
https://trello.com/c/XOw8J7pi/459-copy-change-on-the-error-message-and-summary-on-trn-page
for details.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
