### PR TITLE
Remove session reset from Identity redirect

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,7 +24,6 @@ class PagesController < ApplicationController
 
     if session[:identity_client_url]
       redirect_to session[:identity_client_url], allow_other_host: true
-      reset_session
     end
   end
 end

--- a/spec/system/identity/identity_spec.rb
+++ b/spec/system/identity/identity_spec.rb
@@ -158,7 +158,6 @@ RSpec.describe "Identity", type: :system do
 
     when_i_click_on_the_header
     then_i_am_redirected_to_the_callback
-    and_the_title_of_the_service_is_find_a_lost_trn
   end
 
   private


### PR DESCRIPTION
Clearing a session on redirect to Identity may cause issues when users
use their back button.

The change in #689 ensures that we clear the session whenever we receive
a new request from GAI.

I believe the reset on redirect was intended to perform the same
function so we can safely remove it.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
