### PR TITLE
Allow users with active sanctions to continue to Identity

### DIFF
--- a/spec/cassettes/Identity/when_there_are_active_sanctions/sends_the_TRN_to_Get_an_Identity_and_redirects_to_the_client_callback_URL.yml
+++ b/spec/cassettes/Identity/when_there_are_active_sanctions/sends_the_TRN_to_Get_an_Identity_and_redirects_to_the_client_callback_URL.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://preprod-teacher-qualifications-api.education.gov.uk/v2/teachers/find?dateOfBirth=1990-01-01&emailAddress=kevin.e@example.com&firstName=Kevin&lastName=E
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v1.10.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Date:
+          - Wed, 24 Aug 2022 10:37:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - deny
+        X-Rate-Limit-Limit:
+          - 60s
+        X-Rate-Limit-Remaining:
+          - "299"
+        X-Rate-Limit-Reset:
+          - "2022-08-24T10:38:00.0000000Z"
+        X-Vcap-Request-Id:
+          - 2dc630de-12c4-4c0d-7309-e4790413b478
+        X-Xss-Protection:
+          - "0"
+        X-Cache:
+          - Miss from cloudfront
+        Via:
+          - 1.1 22e421a47e59010b5e8eb6ae4d4bd7e4.cloudfront.net (CloudFront)
+        X-Amz-Cf-Pop:
+          - LHR61-P2
+        X-Amz-Cf-Id:
+          - Wiwy47h4WPdk7jToS7sBfkdOfFFqKv6P_ejsEHC1XFIv_mgum8coHA==
+      body:
+        encoding: UTF-8
+        string: '{"results":[{"trn":"2921020","emailAddresses":["kevin.e@example.com"],"firstName":"Kevin","lastName":"E","dateOfBirth":"1990-01-01","nationalInsuranceNumber":"AA123456A","uid":"1bf8803f-3924-417c-9603-1ed6489dae0d","hasActiveSanctions":false}]}'
+    recorded_at: Wed, 24 Aug 2022 10:37:55 GMT
+  - request:
+      method: put
+      uri: https://preprod.teaching-identity.education.gov.uk/api/find-trn/user/9ddccb62-ec13-4ea7-a163-c058a19b8222
+      body:
+        encoding: UTF-8
+        string: '{"firstName":"Kevin","lastName":"E","trn":"2921020","dateOfBirth":"1990-01-01"}'
+      headers:
+        User-Agent:
+          - Faraday v2.5.2
+        Authorization:
+          - Bearer <BEARER_TOKEN_REDACTED>
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 204
+        message: No Content
+      headers:
+        Date:
+          - Tue, 04 Oct 2022 12:53:42 GMT
+        Request-Context:
+          - appId=cid-v1:0fe7bfa3-0ff2-4116-972e-452718582ac6
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        X-Frame-Options:
+          - DENY
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Content-Type-Options:
+          - nosniff
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        Referrer-Policy:
+          - no-referrer
+        Content-Security-Policy:
+          - default-src 'self';script-src 'self' 'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='
+            'sha256-wmo5EWLjw+Yuj9jZzGNNeSsUOBQmBvE1pvSPVNQzJ34=' 'nonce-xQpFOs1ivcsTvPOQ0e//FLrs/+iGQBGG9PIcPLq2Oiw='
+      body:
+        encoding: UTF-8
+        string: ""
+    recorded_at: Tue, 04 Oct 2022 12:53:43 GMT

--- a/spec/system/identity/identity_spec.rb
+++ b/spec/system/identity/identity_spec.rb
@@ -94,6 +94,22 @@ RSpec.describe "Identity", type: :system do
     end
   end
 
+  context "when there are active sanctions" do
+    it "sends the TRN to Get an Identity and redirects to the client callback URL",
+       vcr: true do
+      when_i_access_the_identity_endpoint
+      and_i_complete_and_submit_the_name_form
+      when_i_complete_and_submit_the_preferred_name_form
+      and_i_complete_and_submit_my_date_of_birth
+      then_i_see_the_check_answers_page
+
+      and_i_have_active_sanctions
+
+      when_i_press_the_continue_button
+      then_i_am_redirected_to_the_callback
+    end
+  end
+
   context "ask for TRN page" do
     it "matches if they don't match on other criteria", vcr: true do
       when_i_access_the_identity_endpoint
@@ -162,6 +178,10 @@ RSpec.describe "Identity", type: :system do
   end
 
   private
+
+  def and_i_have_active_sanctions
+    TrnRequest.last.update(has_active_sanctions: true)
+  end
 
   def when_i_access_the_identity_endpoint
     visit support_interface_identity_simulate_path


### PR DESCRIPTION
There have been cases where users in the identity flow have a TRN that
has active sanctions.

For the Get an Identity journey, having active sanctions isn't a reason
to prevent us from saving the TRN on their DQT record and sending them
to Zendesk.

The approach we settled on was to allow users on the identity journey to
continue back to GAI regardless of the presence of active sanctions.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
