### PR TITLE
Revert "Accept session_id from Get an Identity"

### DIFF
--- a/app/controllers/identity_controller.rb
+++ b/app/controllers/identity_controller.rb
@@ -30,16 +30,10 @@ class IdentityController < ApplicationController
     session[:trn_request_id] = @trn_request.id
     session[:identity_client_title] = recognised_params["client_title"]
     session[:identity_client_id] = recognised_params["client_id"]
-    session[:identity_client_url] = [
-      recognised_params["client_url"],
-      "session_id=#{recognised_params["session_id"]}",
-    ].join("?")
+    session[:identity_client_url] = recognised_params["client_url"]
     session[:identity_journey_id] = recognised_params["journey_id"]
     session[:identity_previous_url] = recognised_params["previous_url"]
-    session[:identity_redirect_url] = [
-      recognised_params["redirect_url"],
-      "session_id=#{recognised_params["session_id"]}",
-    ].join("?")
+    session[:identity_redirect_url] = recognised_params["redirect_url"]
     session[:identity_api_request_sent] = false
 
     redirect_to next_question_path
@@ -56,7 +50,6 @@ class IdentityController < ApplicationController
       :journey_id,
       :previous_url,
       :redirect_url,
-      :session_id,
       :sig,
     )
   end

--- a/app/controllers/support_interface/identity_controller.rb
+++ b/app/controllers/support_interface/identity_controller.rb
@@ -10,7 +10,6 @@ module SupportInterface
       @identity_params.journey_id = journey_id
       @identity_params.previous_url = previous_url
       @identity_params.redirect_url = redirect_url
-      @identity_params.session_id = SecureRandom.uuid
     end
 
     def confirm
@@ -22,16 +21,13 @@ module SupportInterface
         journey_id:,
         previous_url:,
         redirect_url:,
-        session_id: create_params[:session_id],
       }
       sig = Identity.signature_from(@identity_params)
       @identity_params[:sig] = sig
     end
 
     def callback
-      flash[
-        :success
-      ] = "You have completed a simulated Identity journey with session ID #{params[:session_id]}"
+      flash[:success] = "You have completed a simulated Identity journey"
 
       redirect_to support_interface_identity_simulate_path
     end
@@ -43,7 +39,6 @@ module SupportInterface
         :client_title,
         :client_id,
         :email,
-        :session_id,
       )
     end
 

--- a/app/forms/support_interface/identity_params_form.rb
+++ b/app/forms/support_interface/identity_params_form.rb
@@ -2,13 +2,12 @@ module SupportInterface
   class IdentityParamsForm
     include ActiveModel::Model
 
-    attr_accessor :client_id,
-                  :client_title,
-                  :client_url,
+    attr_accessor :client_title,
+                  :client_id,
                   :email,
                   :journey_id,
-                  :previous_url,
                   :redirect_url,
-                  :session_id
+                  :client_url,
+                  :previous_url
   end
 end

--- a/app/views/support_interface/identity/new.html.erb
+++ b/app/views/support_interface/identity/new.html.erb
@@ -52,12 +52,6 @@
                 is disabled for simulated journeys because simulated journeys \
                 should always return to Find" }
       ) %>
-      <%= f.govuk_text_field(:session_id,
-        label: { size: 's', text: 'Session ID' },
-        hint: { 
-          text: "An extra ID field using by Get an Identity. Find simply passes it back via the callback URL"
-        }
-      ) %>
       <%= f.govuk_submit "Continue", prevent_double_click: false %>
     <% end %>
   </div>

--- a/spec/system/identity/identity_spec.rb
+++ b/spec/system/identity/identity_spec.rb
@@ -165,7 +165,6 @@ RSpec.describe "Identity", type: :system do
 
   def when_i_access_the_identity_endpoint
     visit support_interface_identity_simulate_path
-    fill_in "Session ID", with: "test-123"
     click_on "Continue"
     click_on "Submit"
   end
@@ -309,7 +308,7 @@ RSpec.describe "Identity", type: :system do
 
   def then_i_am_redirected_to_the_callback
     expect(page).to have_content(
-      "You have completed a simulated Identity journey with session ID test-123",
+      "You have completed a simulated Identity journey",
     )
   end
 


### PR DESCRIPTION
Reverts DFE-Digital/find-a-lost-trn#694

This is causing issues with the DQT API and isn't needed now to support the session Id.