### PR TITLE
Enable Content Security Policy headers

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,23 +5,25 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report CSP violations to a specified URI. See:
-#   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src :self, :https, :data
+    policy.img_src :self, :https, :data
+    policy.object_src :none
+    policy.script_src :self, :https
+    policy.style_src :self, :https
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) do
+    request.session.id.to_s
+  end
+  config.content_security_policy_nonce_directives = %w[script-src]
+
+  # Report CSP violations to a specified URI. See:
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+  # config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
Rails doesn't send the CSP headers by default.

In this change, I'm enabling the headers to only allow first party
content only. This can be modified in the future if it is too
restrictive.

Assumptions:

* we don't need to load any third-party scripts, eg. Google Analytics.

https://trello.com/c/auN7FZAv/257-missing-and-misconfigured-http-security-headers

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="1166" alt="Screenshot 2023-02-03 at 9 28 37 am" src="https://user-images.githubusercontent.com/3126/216563576-561679d0-6686-48c0-9447-54b29d3401b8.png">
