### PR TITLE
Allow an inline script

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -23,9 +23,9 @@
   </head>
 
   <body class="govuk-template__body">
-    <script>
+    <%= javascript_tag nonce: true do %>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end %>
 
     <%= govuk_skip_link %>
 


### PR DESCRIPTION
The content security policy disallows inline scripts.

We have a single use case where we require one, which is to enable the
use of the design system javascript.

We can sign this inline script tag using a nonce.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
