### PR TITLE
Fix a Rubocop warning

### DIFF
--- a/app/services/dqt_api.rb
+++ b/app/services/dqt_api.rb
@@ -23,7 +23,7 @@ class DqtApi
     results = response.body["results"]
     raise TooManyResults if results.size > 1
 
-    raise NoResults if results.size.zero?
+    raise NoResults if results.empty?
 
     teacher_account = results.first
 


### PR DESCRIPTION
This warning will be changed to an error in the next release of Rubocop,
preventing us from upgrading automatically.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
