### PR TITLE
Add an export function for TRN Requests

### DIFF
--- a/app/controllers/support_interface/trn_request_csv_exports_controller.rb
+++ b/app/controllers/support_interface/trn_request_csv_exports_controller.rb
@@ -1,0 +1,25 @@
+module SupportInterface
+  class TrnRequestCsvExportsController < SupportInterfaceController
+    def create
+      @export_form =
+        SupportInterface::TrnRequestExportForm.new(
+          trn_request_export_form_params,
+        )
+
+      respond_to do |format|
+        format.csv do
+          send_data TrnRequest.to_csv(@export_form.scope),
+                    filename: @export_form.filename
+        end
+      end
+    end
+
+    private
+
+    def trn_request_export_form_params
+      params.require(:support_interface_trn_request_export_form).permit(
+        :time_period,
+      )
+    end
+  end
+end

--- a/app/controllers/support_interface/trn_requests_controller.rb
+++ b/app/controllers/support_interface/trn_requests_controller.rb
@@ -3,6 +3,7 @@ module SupportInterface
   class TrnRequestsController < SupportInterfaceController
     def index
       @trn_requests = TrnRequest.order(updated_at: :desc).limit(100)
+      @export_form = SupportInterface::TrnRequestExportForm.new
     end
   end
 end

--- a/app/forms/support_interface/trn_request_export_form.rb
+++ b/app/forms/support_interface/trn_request_export_form.rb
@@ -1,0 +1,50 @@
+require "csv"
+
+module SupportInterface
+  class TrnRequestExportForm
+    include ActiveModel::Model
+
+    attr_accessor :time_period
+
+    def filename
+      time_period_string = time_period.to_time&.strftime("%Y_%m_%d") || "all"
+
+      "#{time_period_string}_trn_requests.csv"
+    end
+
+    def months
+      @months ||=
+        begin
+          date = PerformanceStats::LAUNCH_DATE
+          months = []
+          while date < Time.current
+            months << [
+              date.beginning_of_month.strftime("%B %Y"),
+              date.beginning_of_month,
+            ]
+            date = date.advance(months: 1)
+          end
+          months << %w[All all]
+          months.reverse
+        end
+    end
+
+    def scope
+      @scope ||=
+        begin
+          scope = TrnRequest.since_launch
+          if time_period.present?
+            case time_period
+            when "all"
+              scope
+            else
+              start = time_period.to_time.beginning_of_month
+              created_at = [start..start.end_of_month]
+              scope = scope.where(created_at:)
+            end
+          end
+          scope
+        end
+    end
+  end
+end

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -42,6 +42,7 @@ class TrnRequest < ApplicationRecord
   has_many :account_unlock_events
 
   scope :with_zendesk_ticket, -> { where.not(zendesk_ticket_id: nil) }
+  scope :since_launch, -> { where(created_at: PerformanceStats::LAUNCH_DATE..) }
 
   def answers_checked=(value)
     return unless value
@@ -96,5 +97,17 @@ class TrnRequest < ApplicationRecord
 
   def itt_provider_name_for_dqt
     itt_provider_ukprn.present? ? nil : itt_provider_name
+  end
+
+  def self.to_csv(scope = since_launch)
+    attributes = %w[id trn email created_at updated_at]
+
+    CSV.generate(headers: true) do |csv|
+      csv << attributes.map(&:titleize)
+
+      scope.find_each do |trn_request|
+        csv << attributes.map { |attr| trn_request.send(attr) }
+      end
+    end
   end
 end

--- a/app/views/support_interface/trn_requests/index.html.erb
+++ b/app/views/support_interface/trn_requests/index.html.erb
@@ -1,88 +1,105 @@
 <% content_for :page_title, 'TRN Requests' %>
 
-<h1 class="govuk-heading-l">
-  TRN Requests
-  <span class="govuk-caption-l">
-    Ordered by last updated, showing <%= "#{[100, TrnRequest.count].min} of #{TrnRequest.count}" %> total
-  </span>
-</h1>
 
-<% @trn_requests.each do |trn_request| %>
-  <h2 class="govuk-heading-m">TRN Request #<%= trn_request.id %></h2>
-  <%= govuk_summary_list do |summary_list|
-    summary_list.row do |row|
-      row.key(text: 'Created at')
-      row.value(text: trn_request.created_at)
-    end
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      TRN Requests
+      <span class="govuk-caption-l">
+        Ordered by last updated, showing <%= "#{[100, TrnRequest.count].min} of #{TrnRequest.count}" %> total
+      </span>
+    </h1>
 
-    summary_list.row do |row|
-      row.key(text: 'Updated at')
-      row.value(text: trn_request.updated_at)
-    end
-
-    summary_list.row do |row|
-      row.key(text: 'Submitted at')
-      row.value do
-        if trn_request.checked_at
-          trn_request.checked_at.to_s
-        else
-          govuk_tag(colour: 'grey', text: 'Not yet submitted')
-        end
-      end
-    end
-
-    if trn_request.checked_at
-      summary_list.row do |row|
-        row.key(text: 'TRN')
-        row.value do
-          if trn_request.trn
-            govuk_tag(colour: 'green', text: 'Found 🎉')
-          else
-            govuk_tag(colour: 'yellow', text: 'Not found')
-          end
-        end
-      end
-
-      if !trn_request.zendesk_ticket_id && !trn_request.trn
+    <% @trn_requests.each do |trn_request| %>
+      <h2 class="govuk-heading-m">TRN Request #<%= trn_request.id %></h2>
+      <%= govuk_summary_list do |summary_list|
         summary_list.row do |row|
-          row.key(text: 'Zendesk ticket')
-          row.value do
-            govuk_tag(colour: 'grey', text: 'Not submitted')
-          end
+          row.key(text: 'Created at')
+          row.value(text: trn_request.created_at)
         end
-      end
 
-      if trn_request.zendesk_ticket_id
         summary_list.row do |row|
-          row.key(text: 'Zendesk ticket')
-          row.value do
-            tag.a "Ticket #{trn_request.zendesk_ticket_id}", class: 'govuk-link', href: "https://teachingregulationagency.zendesk.com/agent/tickets/#{trn_request.zendesk_ticket_id}"
-          end
+          row.key(text: 'Updated at')
+          row.value(text: trn_request.updated_at)
         end
 
-        unless trn_request.trn
-          summary_list.row do |row|
-            row.key(text: 'Actions')
-            row.value do
-              govuk_button_to("Sync from Zendesk", [:support_interface, trn_request, :zendesk_sync], secondary: true, class: 'govuk-!-margin-bottom-0')
+        summary_list.row do |row|
+          row.key(text: 'Submitted at')
+          row.value do
+            if trn_request.checked_at
+              trn_request.checked_at.to_s
+            else
+              govuk_tag(colour: 'grey', text: 'Not yet submitted')
             end
           end
         end
-      end
-    end
-  end %>
 
-  <% if Rails.env.production? %>
-    <h3 class="govuk-heading-s">Anonymised information</h3>
-  <% else %>
-    <h3 class="govuk-heading-s">
-      <%= govuk_tag(colour: 'blue', text: 'Development only') %>
-      Information
-    </h3>
-  <% end %>
+        if trn_request.checked_at
+          summary_list.row do |row|
+            row.key(text: 'TRN')
+            row.value do
+              if trn_request.trn
+                govuk_tag(colour: 'green', text: 'Found 🎉')
+              else
+                govuk_tag(colour: 'yellow', text: 'Not found')
+              end
+            end
+          end
 
-  <% if trn_request.trn_responses.any? %>
-    <%= render(TrnResponseComponent.new(trn_response: trn_request.trn_responses.last, anonymise: Rails.env.production?)) %>
-  <% end %>
-  <%= render(TrnDetailsComponent.new(trn_request: trn_request, anonymise: Rails.env.production?)) %>
-<% end %>
+          if !trn_request.zendesk_ticket_id && !trn_request.trn
+            summary_list.row do |row|
+              row.key(text: 'Zendesk ticket')
+              row.value do
+                govuk_tag(colour: 'grey', text: 'Not submitted')
+              end
+            end
+          end
+
+          if trn_request.zendesk_ticket_id
+            summary_list.row do |row|
+              row.key(text: 'Zendesk ticket')
+              row.value do
+                tag.a "Ticket #{trn_request.zendesk_ticket_id}", class: 'govuk-link', href: "https://teachingregulationagency.zendesk.com/agent/tickets/#{trn_request.zendesk_ticket_id}"
+              end
+            end
+
+            unless trn_request.trn
+              summary_list.row do |row|
+                row.key(text: 'Actions')
+                row.value do
+                  govuk_button_to("Sync from Zendesk", [:support_interface, trn_request, :zendesk_sync], secondary: true, class: 'govuk-!-margin-bottom-0')
+                end
+              end
+            end
+          end
+        end
+      end %>
+
+      <% if Rails.env.production? %>
+        <h3 class="govuk-heading-s">Anonymised information</h3>
+      <% else %>
+        <h3 class="govuk-heading-s">
+          <%= govuk_tag(colour: 'blue', text: 'Development only') %>
+          Information
+        </h3>
+      <% end %>
+
+      <% if trn_request.trn_responses.any? %>
+        <%= render(TrnResponseComponent.new(trn_response: trn_request.trn_responses.last, anonymise: Rails.env.production?)) %>
+      <% end %>
+      <%= render(TrnDetailsComponent.new(trn_request: trn_request, anonymise: Rails.env.production?)) %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Export TRN Requests</h2>
+    <p>
+      <%= form_with model: @export_form, url: support_interface_trn_requests_exports_path(format: :csv) do |f| %>
+        <%= f.govuk_collection_select :time_period, @export_form.months, :last, :first, include_blank: true, label: { text: "Which month do you want to export?" } %>
+        <%= f.govuk_submit "Export to CSV" %>
+      <% end %>
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   namespace :support_interface, path: "/support" do
     get "/", to: redirect("/support/trn-requests")
     get "/trn-requests", to: "trn_requests#index"
+    post "/trn-requests/exports", to: "trn_request_csv_exports#create"
 
     get "/features", to: "feature_flags#index"
     post "/features/:feature_name/activate",

--- a/spec/forms/trn_request_export_form_spec.rb
+++ b/spec/forms/trn_request_export_form_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe SupportInterface::TrnRequestExportForm, type: :model do
+  describe "#filename" do
+    subject do
+      described_class.new(
+        time_period: Time.zone.local(2022, 12, 1, 12, 0, 0),
+      ).filename
+    end
+
+    it { is_expected.to eq("2022_12_01_trn_requests.csv") }
+  end
+
+  describe "#months" do
+    subject { described_class.new(time_period: nil).months }
+
+    before { travel_to Time.zone.local(2022, 6, 18, 12, 0, 0) }
+
+    after { travel_back }
+
+    it "returns all months since the launch date" do
+      is_expected.to eq(
+        [
+          %w[All all],
+          ["June 2022", Time.zone.local(2022, 6, 1, 0, 0, 0)],
+          ["May 2022", Time.zone.local(2022, 5, 1, 0, 0, 0)],
+        ],
+      )
+    end
+  end
+
+  describe "#scope" do
+    subject { described_class.new(time_period:).scope.to_a }
+
+    let!(:prelaunch) do
+      create(:trn_request, created_at: Time.zone.local(2022, 5, 3, 12, 0, 0))
+    end
+    let!(:may) do
+      create(:trn_request, created_at: Time.zone.local(2022, 5, 4, 12, 0, 0))
+    end
+    let!(:june) do
+      create(:trn_request, created_at: Time.zone.local(2022, 6, 1, 12, 0, 0))
+    end
+
+    context "when time_period is 'all'" do
+      let(:time_period) { "all" }
+
+      it { is_expected.to eq([may, june]) }
+    end
+
+    context "when time_period is a date" do
+      let(:time_period) { Time.zone.local(2022, 6, 1, 0, 0, 0) }
+
+      it { is_expected.to eq([june]) }
+    end
+  end
+end

--- a/spec/system/support_interface/trn_request_exports_spec.rb
+++ b/spec/system/support_interface/trn_request_exports_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.feature "Trn Request exports", type: :system do
+  before do
+    travel_to Time.zone.local(2022, 11, 18, 12, 0, 0)
+    given_the_service_is_open
+  end
+
+  after do
+    travel_back
+    deactivate_feature_flags
+  end
+
+  scenario "Exporting TRN requests", download: true do
+    given_there_is_a_trn_request
+    and_i_am_authorized_as_a_support_user
+    and_i_am_on_the_trn_requests_page
+    when_i_select_the_time_period
+    and_i_click_the_export_button
+    then_the_exported_file_should_contain_the_trn_request
+  end
+
+  private
+
+  def and_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize("test", "test")
+  end
+
+  def and_i_am_on_the_trn_requests_page
+    visit support_interface_trn_requests_path
+  end
+
+  def and_i_click_the_export_button
+    click_on "Export to CSV"
+  end
+
+  def deactivate_feature_flags
+    FeatureFlag.deactivate(:service_open)
+  end
+
+  def given_the_service_is_open
+    FeatureFlag.activate(:service_open)
+  end
+
+  def given_there_is_a_trn_request
+    @trn_request =
+      create(:trn_request, email: "trn@example.com", id: 1, trn: "123456")
+  end
+
+  def then_the_exported_file_should_contain_the_trn_request
+    expect(page.response_headers["Content-Disposition"]).to eq(
+      "attachment; filename=\"2022_11_01_trn_requests.csv\"; " \
+        "filename*=UTF-8''2022_11_01_trn_requests.csv",
+    )
+    expect(page.response_headers["Content-Type"]).to eq("text/csv")
+    expect(download_content).to eq(
+      "Id,Trn,Email,Created At,Updated At\n" \
+        "1,123456,trn@example.com,2022-11-18 12:00:00 UTC,2022-11-18 12:00:00 UTC\n",
+    )
+  end
+
+  def when_i_select_the_time_period
+    select "November 2022",
+           from: "Which month do you want to export?",
+           visible: false
+  end
+end


### PR DESCRIPTION
We want to make it possible to export TRN Requests for audit purposes.

Using a similar approach to the Zendesk deletion export, this change
adds an export form to the bottom of the TRN Request view for support
staff.

The data can be exported in its entirety or grouped by month.

There is no attempt to automate this yet.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
