### PR TITLE
Add a CSV column representing account unlocking

### DIFF
--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -99,8 +99,12 @@ class TrnRequest < ApplicationRecord
     itt_provider_ukprn.present? ? nil : itt_provider_name
   end
 
+  def first_unlocked_at
+    account_unlock_events.order(created_at: :asc).first&.created_at
+  end
+
   def self.to_csv(scope = since_launch)
-    attributes = %w[id trn email created_at updated_at]
+    attributes = %w[id trn email first_unlocked_at created_at updated_at]
 
     CSV.generate(headers: true) do |csv|
       csv << attributes.map(&:titleize)

--- a/spec/factories/account_unlock_events.rb
+++ b/spec/factories/account_unlock_events.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :account_unlock_event do
+    trn_request
+  end
+end

--- a/spec/jobs/trn_request_export_job_spec.rb
+++ b/spec/jobs/trn_request_export_job_spec.rb
@@ -28,11 +28,12 @@ RSpec.describe TrnRequestExportJob, type: :job do
             trn_request.id,
             trn_request.trn,
             trn_request.email,
+            nil,
             trn_request.created_at,
             trn_request.updated_at,
           ].join(",")
           expect(TrnExportMailer).to have_received(:monthly_report).with(
-            "Id,Trn,Email,Created At,Updated At\n#{trn_request_row}\n",
+            "Id,Trn,Email,First Unlocked At,Created At,Updated At\n#{trn_request_row}\n",
           )
         end
       end

--- a/spec/system/support_interface/trn_request_exports_spec.rb
+++ b/spec/system/support_interface/trn_request_exports_spec.rb
@@ -54,8 +54,8 @@ RSpec.feature "Trn Request exports", type: :system do
     )
     expect(page.response_headers["Content-Type"]).to eq("text/csv")
     expect(download_content).to eq(
-      "Id,Trn,Email,Created At,Updated At\n" \
-        "1,123456,trn@example.com,2022-11-18 12:00:00 UTC,2022-11-18 12:00:00 UTC\n",
+      "Id,Trn,Email,First Unlocked At,Created At,Updated At\n" \
+        "1,123456,trn@example.com,,2022-11-18 12:00:00 UTC,2022-11-18 12:00:00 UTC\n",
     )
   end
 


### PR DESCRIPTION
The CSV of TRNs that we export is missing a data on whether the account
was also unlocked. This is a key part of the analysis the team are
currently wanting to do.

This change adds a `First Unlocked At` column to represent when the
unlock event was created for that particular request.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
