### PR TITLE
Remove references to the old support phone number

### DIFF
--- a/app/views/layouts/teacher_email.text.erb
+++ b/app/views/layouts/teacher_email.text.erb
@@ -1,8 +1,1 @@
 <%= yield %>
-
-# Get help
-
-Call the Teaching Regulation Agency, and have your National Insurance number ready:
-
-Telephone: <%= t('service.tel') %>
-Monday to Friday, 9am to 5pm (except public holidays)

--- a/app/views/pages/helpdesk_request_delayed.html.erb
+++ b/app/views/pages/helpdesk_request_delayed.html.erb
@@ -16,17 +16,6 @@
       Once we’ve fixed the technical problem, you’ll get a confirmation email with your request number.
     </p>
 
-    <h2 class="govuk-heading-m">If you need your TRN quickly</h2>
-    <p class="govuk-body">
-      Call the Teaching Regulation Agency and give the helpdesk 
-      your request number: <%= @trn_request.zendesk_ticket_id %>
-    </p>
-
-    <ul class="govuk-list">
-      <li>Telephone: <%= t('service.tel') %></li>
-      <li>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</li>
-    </ul>
-
     <h2 class="govuk-heading-m">Give feedback</h2>
     <p class="govuk-body">
       <a class="govuk-link" href="https://forms.gle/3LGJXe9EFaeQbFgP7">

--- a/app/views/pages/helpdesk_request_submitted.html.erb
+++ b/app/views/pages/helpdesk_request_submitted.html.erb
@@ -14,16 +14,6 @@
       We’re likely to get back to you in 2 working days, but it could take up to 5.
     </p>
 
-    <h2 class="govuk-heading-m">If you need your TRN quickly</h2>
-    <p class="govuk-body">
-      Call the Teaching Regulation Agency and give the helpdesk your request number: <%= @trn_request.zendesk_ticket_id %>
-    </p>
-
-    <ul class="govuk-list">
-      <li>Telephone: <%= t('service.tel') %></li>
-      <li>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</li>
-    </ul>
-
     <h2 class="govuk-heading-m">Give feedback</h2>
     <p class="govuk-body">
       <a class="govuk-link" href="https://forms.gle/3LGJXe9EFaeQbFgP7">What did you think of this service?</a> (takes 30 seconds)

--- a/app/views/pages/longer_than_normal.html.erb
+++ b/app/views/pages/longer_than_normal.html.erb
@@ -11,14 +11,6 @@
       If you give us all the information we need, you won’t get a response straight away. And if the information you give is
       incomplete, it might take more than five days to get back to you.
     </p>
-    <h2 class="govuk-heading-m">If you need your TRN urgently</h2>
-    <p class='govuk-body'>
-      Call the Teaching Regulation Agency, and have your National Insurance number ready:
-    </p>
-    <ul class="govuk-list">
-      <li>Telephone: <%= t('service.tel') %></li>
-      <li>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</li>
-    </ul>
     <%= govuk_button_link_to 'Continue', name_path %>
   </div>
 </div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -40,13 +40,6 @@
       The TRN has previously been known as a QTS, GTC, DfE, DfES and DCSF
       number.
     </p>
-
-    <h2 class="govuk-heading-m">Find a lost TRN by phone</h2>
-    <p class="govuk-body">Call the Teaching Regulation Agency, and have your National Insurance number ready:</p>
-    <ul class="govuk-list">
-      <li>Telephone: <%= t('service.tel') %></li>
-      <li>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</li>
-    </ul>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/teacher_mailer/delayed_information_received.erb
+++ b/app/views/teacher_mailer/delayed_information_received.erb
@@ -7,14 +7,3 @@ We’ve received the information you submitted, and you’ll get an email with y
 Otherwise, we’ll contact you for more information.
 
 We aim to respond in 5 working days.
-
-# If you need your TRN quickly
-
-Call the Teaching Regulation Agency and give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>.
-
-Telephone: <%= t('service.tel') %>
-Monday to Thursday, 9am to 5pm, Friday 9am to 4.30pm (except public holidays)
-
-# If you’ve already called our helpline
-
-Please ignore this message.

--- a/app/views/teacher_mailer/information_received.erb
+++ b/app/views/teacher_mailer/information_received.erb
@@ -5,10 +5,3 @@ We’ve received the information you submitted.
 You’ll get an email with your TRN if we find a match. Otherwise, we’ll contact you for more information.
 
 We aim to respond in 5 working days.
-
-# If you need your TRN quickly
-
-Call the Teaching Regulation Agency and give the helpdesk your ticket number: <%= @trn_request.zendesk_ticket_id %>.
-
-Telephone: <%= t('service.tel') %>
-Monday to Thursday, 9am to 5pm, Friday 9am to 4.30pm (except public holidays)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,6 @@ en:
   service:
     email: teaching.status@education.gov.uk
     name: Find a lost teacher reference number (TRN)
-    tel: 020 7593 5394
     url: https://find-a-lost-trn.education.gov.uk/
 
   notification_banner:

--- a/spec/system/active_sanctions_spec.rb
+++ b/spec/system/active_sanctions_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "TRN requests", type: :system do
 
     when_i_press_the_submit_button
     then_i_see_the_zendesk_confirmation_page
-    and_i_receive_an_email_with_the_zendesk_ticket_number
+    and_i_receive_an_email
   end
 
   def deactivate_feature_flags
@@ -91,7 +91,6 @@ RSpec.describe "TRN requests", type: :system do
       "We’ve received your request",
     )
     expect(page).to have_content("We’ve received your request")
-    expect(page).to have_content("give the helpdesk your request number: 42")
   end
 
   def then_i_see_the_check_answers_page
@@ -105,14 +104,11 @@ RSpec.describe "TRN requests", type: :system do
     expect(page).to have_content("5 May 1999")
   end
 
-  def and_i_receive_an_email_with_the_zendesk_ticket_number
+  def and_i_receive_an_email
     perform_enqueued_jobs(only: ActionMailer::MailDeliveryJob)
     open_email("test@example.com")
     expect(current_email.subject).to eq(
       "We’ve received the information you submitted",
-    )
-    expect(current_email.body).to include(
-      "give the helpdesk your ticket number: 42",
     )
   end
 end

--- a/spec/system/trn_requests_spec.rb
+++ b/spec/system/trn_requests_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "TRN requests", type: :system do
     when_i_choose_no_my_details_are_correct
     and_i_press_continue
     then_i_see_the_zendesk_confirmation_page
-    and_i_receive_an_email_with_the_zendesk_ticket_number
+    and_i_receive_an_email
 
     when_i_navigate_to_the_email_page
     then_i_see_the_email_page
@@ -420,7 +420,7 @@ RSpec.describe "TRN requests", type: :system do
     when_i_choose_no_my_details_are_correct
     and_i_press_continue
     then_i_see_the_zendesk_confirmation_page
-    and_i_receive_an_email_with_the_zendesk_ticket_number
+    and_i_receive_an_email
     and_a_job_to_check_zendesk_is_queued
   end
 
@@ -558,14 +558,11 @@ RSpec.describe "TRN requests", type: :system do
     expect(current_email.subject).to eq("Your TRN is 2921020")
   end
 
-  def and_i_receive_an_email_with_the_zendesk_ticket_number
+  def and_i_receive_an_email
     perform_enqueued_jobs(only: ActionMailer::MailDeliveryJob)
     open_email("kevin@kevin.com")
     expect(current_email.subject).to eq(
       "We’ve received the information you submitted",
-    )
-    expect(current_email.body).to include(
-      "give the helpdesk your ticket number: 42",
     )
   end
 
@@ -757,7 +754,6 @@ RSpec.describe "TRN requests", type: :system do
       "We’ve received your request",
     )
     expect(page).to have_content("We’ve received your request")
-    expect(page).to have_content("give the helpdesk your request number: 42")
   end
 
   def then_i_see_the_date_of_birth_page


### PR DESCRIPTION
The phone number we have is no longer in use and there's no replacement. This change removes all references to phone support. I've created a separate action to review this content as we may need to point people to the new support email address instead.