### PR TITLE
Disable deleting Zendesk tickets

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -6,10 +6,6 @@ zendesk_health_alert:
   cron: "0 10 * * *"
   class: "ZendeskHealthJob"
 
-zendesk_delete:
-  cron: "0 11 * * *"
-  class: "ScheduleZendeskTicketsForDeletionJob"
-
 trn_request_monthly:
   cron: "0 12 1 * *"
   class: "TrnRequestExportJob"


### PR DESCRIPTION
We are about to switch Zendesk instance and want to avoid deleting
tickets that are un-related to Find.

This change removes the schedule for deleting tickets but leaves the
functionality available in case we want to re-enable it.

There is a Trello ticket for investigating how we want to manage our
data retention policy on this alternative Zendesk instance.