### PR TITLE
Move Zendesk URL to a variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -9,3 +9,4 @@ IDENTITY_SHARED_SECRET_KEY=testkey
 IDENTITY_USER_TOKEN=testkey
 SUPPORT_PASSWORD=test
 SUPPORT_USERNAME=test
+ZENDESK_URL=https://teachingregulationagency.zendesk.com

--- a/app/views/support_interface/trn_requests/index.html.erb
+++ b/app/views/support_interface/trn_requests/index.html.erb
@@ -59,7 +59,7 @@
             summary_list.row do |row|
               row.key(text: 'Zendesk ticket')
               row.value do
-                tag.a "Ticket #{trn_request.zendesk_ticket_id}", class: 'govuk-link', href: "https://teachingregulationagency.zendesk.com/agent/tickets/#{trn_request.zendesk_ticket_id}"
+                tag.a "Ticket #{trn_request.zendesk_ticket_id}", class: 'govuk-link', href: "#{ENV["ZENDESK_URL"]}/agent/tickets/#{trn_request.zendesk_ticket_id}"
               end
             end
 

--- a/app/views/support_interface/zendesk/index.html.erb
+++ b/app/views/support_interface/zendesk/index.html.erb
@@ -64,7 +64,7 @@
           row.cell do
             tag.a("Ticket #{ticket.ticket_id}",
               class: 'govuk-link',
-              href: "https://teachingregulationagency.zendesk.com/agent/tickets/#{ticket.ticket_id}") +
+              href: "#{ENV["ZENDESK_URL"]}/agent/tickets/#{ticket.ticket_id}") +
               tag.span(ticket.group_name, class: 'govuk-caption-m')
           end
           row.cell do
@@ -124,7 +124,7 @@
           row.cell do
             tag.a("Ticket #{ticket.ticket_id}",
               class: 'govuk-link',
-              href: "https://teachingregulationagency.zendesk.com/agent/tickets/#{ticket.ticket_id}") +
+              href: "#{ENV["ZENDESK_URL"]}/agent/tickets/#{ticket.ticket_id}") +
               tag.span(ticket.group_name, class: 'govuk-caption-m')
           end
           row.cell do

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -51,13 +51,13 @@ class ExtendedDummyClient
               updated_at: (6.months + 1.day).ago,
               custom_fields: [
                 { id: 4_419_328_659_089, value: "Foo" },
-                { id: 4_562_126_876_049, value: "Bar" },
+                { id: 4_562_126_876_049, value: "Bar" }
               ],
               group: {
-                name: "Some group",
-              },
-            ),
-          ],
+                name: "Some group"
+              }
+            )
+          ]
         )
         collection.instance_variable_set(:@count, 1)
       end
@@ -95,13 +95,13 @@ module DummyTicketExtensions
       ZendeskAPI::Ticket::Comment.new(
         GDS_ZENDESK_CLIENT,
         id: 1,
-        body: "Example",
+        body: "Example"
       ),
       ZendeskAPI::Ticket::Comment.new(
         GDS_ZENDESK_CLIENT,
         id: 2,
-        body: "Your TRN is **2921020**",
-      ),
+        body: "Your TRN is **2921020**"
+      )
     ]
     ticket
   end
@@ -137,6 +137,6 @@ GDS_ZENDESK_CLIENT =
       username: ENV.fetch("ZENDESK_USER", nil),
       token: ENV.fetch("ZENDESK_TOKEN", nil),
       logger: Rails.logger,
-      url: "https://teachingregulationagency.zendesk.com/api/v2/",
+      url: [ENV.fetch("ZENDESK_URL", nil), "/api/v2"].join
     )
   end


### PR DESCRIPTION
We want to be able to control the Zendesk instance that the service
points to.

Currently it is hard-coded but it should be configurable via an
environment variable to make it easier to control.

https://trello.com/c/IQe0G60z/1130-change-the-zendesk-instance-tickets-are-created-in

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
