### PR TITLE
Fix building assets in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV GOVUK_NOTIFY_API_KEY=TestKey \
     REDIS_URL=redis://required-but-not-used \
     SECRET_KEY_BASE=TestKey \
     ZENDESK_TOKEN=TestToken \
+    ZENDESK_URL=https://required-but-not-used \
     ZENDESK_USER=TestUser \
     IDENTITY_SHARED_SECRET_KEY=testkey \
     IDENTITY_API_URL=http://localhost \


### PR DESCRIPTION
The Docker step to build the assets requires a ZENDESK_URL value but it
doesn't need to be "real" in order for the rake task to complete.