### PR TITLE
Domain migration prep and add Terrafile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ bin/fetch_config.rb
 .terraform
 .terraform/
 terraform/*token*
-terraform/*/vendor
+terraform/**/vendor/
 terraform/*/.terraform
 bin/terrafile
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dev:
 .PHONY: development_aks ## For AKS
 development_aks: aks ## Specify development aks environment
 	$(eval include global_config/development_aks.sh)
-	
+
 .PHONY: test
 test:
 	$(eval DEPLOY_ENV=test)
@@ -240,15 +240,15 @@ set-key-vault-names:
 	$(eval KEY_VAULT_APPLICATION_NAME=$(AZURE_RESOURCE_PREFIX)-$(SERVICE_SHORT)-$(CONFIG_SHORT)-app-kv)
 	$(eval KEY_VAULT_INFRASTRUCTURE_NAME=$(AZURE_RESOURCE_PREFIX)-$(SERVICE_SHORT)-$(CONFIG_SHORT)-inf-kv)
 
-
 domain-azure-resources: set-azure-account set-azure-template-tag set-azure-resource-group-tags ## deploy container to store terraform state for all dns resources -run validate first
 	$(if $(AUTO_APPROVE), , $(error can only run with AUTO_APPROVE))
 	az deployment sub create -l "UK South" --template-uri "https://raw.githubusercontent.com/DFE-Digital/tra-shared-services/${ARM_TEMPLATE_TAG}/azure/resourcedeploy.json" \
 		--name "${DNS_ZONE}domains-$(shell date +%Y%m%d%H%M%S)" --parameters "resourceGroupName=${RESOURCE_NAME_PREFIX}-${DNS_ZONE}domains-rg" 'tags=${RG_TAGS}' \
 			"tfStorageAccountName=${RESOURCE_NAME_PREFIX}${DNS_ZONE}domainstf" "tfStorageContainerName=${DNS_ZONE}domains-tf"  "keyVaultName=${RESOURCE_NAME_PREFIX}-${DNS_ZONE}domains-kv" ${WHAT_IF}
 
+domains-infra-init: bin/terrafile faltrn_domain set-azure-account ## make domains-infra-init -  terraform init for dns core resources, eg Main FrontDoor resource
+	./bin/terrafile -p terraform/domains/infrastructure/vendor/modules -f terraform/domains/infrastructure/config/zones_Terrafile
 
-domains-infra-init: faltrn_domain set-azure-account ## make domains-infra-init -  terraform init for dns core resources, eg Main FrontDoor resource
 	terraform -chdir=terraform/domains/infrastructure init -reconfigure -upgrade
 
 domains-infra-plan: domains-infra-init ## terraform plan for dns core resources
@@ -257,10 +257,11 @@ domains-infra-plan: domains-infra-init ## terraform plan for dns core resources
 domains-infra-apply: domains-infra-init ## terraform apply for dns core resources
 	terraform -chdir=terraform/domains/infrastructure apply -var-file config/zones.tfvars.json ${AUTO_APPROVE}
 
-
 ######################################
 
-domains-init: faltrn_domain set-azure-account ## terraform init for dns resources: make <env>  domains-init
+domains-init: bin/terrafile faltrn_domain set-azure-account ## terraform init for dns resources: make <env>  domains-init
+	./bin/terrafile -p terraform/domains/environment_domains/vendor/modules -f terraform/domains/environment_domains/config/${CONFIG}_Terrafile
+
 	terraform -chdir=terraform/domains/environment_domains init -upgrade -reconfigure -backend-config=key=$(or $(DOMAINS_TERRAFORM_BACKEND_KEY),faltrndomains_$(DEPLOY_ENV).tfstate)
 
 domains-plan: domains-init  ## terraform plan for dns resources, eg dev.<domain_name> dns records and frontdoor routing
@@ -271,7 +272,6 @@ domains-apply: domains-init ## terraform apply for dns resources
 
 domains-destroy: domains-init ## terraform destroy for dns resources
 	terraform -chdir=terraform/domains/environment_domains destroy -var-file config/$(DEPLOY_ENV).tfvars.json
-
 
 arm-deployment: set-resource-group-name set-storage-account-name set-azure-template-tag set-azure-account set-azure-resource-group-tags set-key-vault-names ## deploy container/kv to store terraform state for each environment
 	az deployment sub create --name "resourcedeploy-tsc-$(shell date +%Y%m%d%H%M%S)" \

--- a/terraform/domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/domains/environment_domains/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.45.0"
   hashes = [
     "h1:4BOYXFMiLk4ozEZHUhquRnE5urebcWvaCUV3uys646o=",
+    "h1:VQWxV5+qelZeUCjpdLvZ7iAom4RvG+fVVgK6ELvw/cs=",
     "h1:gQLNY1I5e9kcle1p/VYEWb0eteQ/t5kUfnqVu2/GBNY=",
     "zh:04c5dbb8845366ce5eb0dc2d55e151270cc2c0ace20993867fdae9af43b953ad",
     "zh:2589585da615ccae341400d45d672ee3fae413fdd88449b5befeff12a85a44b2",

--- a/terraform/domains/environment_domains/config/development.tfvars.json
+++ b/terraform/domains/environment_domains/config/development.tfvars.json
@@ -1,6 +1,7 @@
 {
   "domains": ["dev"],
-  "environment_short": "dev",
+  "cached_paths": ["/assets/*"],
+  "environment_short": "dv",
   "environment_tag": "dev",
   "origin_hostname": "find-a-lost-trn-development-web.test.teacherservices.cloud"
 }

--- a/terraform/domains/environment_domains/config/development_Terrafile
+++ b/terraform/domains/environment_domains/config/development_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"

--- a/terraform/domains/environment_domains/config/preproduction.tfvars.json
+++ b/terraform/domains/environment_domains/config/preproduction.tfvars.json
@@ -1,6 +1,7 @@
 {
   "domains": ["preprod"],
-  "environment_short": "preprod",
+  "cached_paths": ["/assets/*"],
+  "environment_short": "pp",
   "environment_tag": "pre-prod",
   "origin_hostname": "find-a-lost-trn-preproduction-web.test.teacherservices.cloud"
 }

--- a/terraform/domains/environment_domains/config/preproduction_Terrafile
+++ b/terraform/domains/environment_domains/config/preproduction_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -1,6 +1,19 @@
 {
-  "domains": ["www", "apex"],
+  "domains": ["apex"],
+  "cached_paths": ["/assets/*"],
   "environment_short": "pd",
   "environment_tag": "Prod",
-  "origin_hostname": "find-a-lost-trn-production-web.teacherservices.cloud"
+  "origin_hostname": "find-a-lost-trn-production.london.cloudapps.digital",
+  "null_host_header": true,
+  "hosted_zone": {
+    "find-a-lost-trn.education.gov.uk": {
+      "resource_group_name": "s189p01-faltrndomains-rg",
+      "cnames": {
+        "_443ce8e523e08d5e5f44703bcffa0875": {
+          "target": "_680e92e9fa66938e47a0348221196c28.mntkzmhvxg.acm-validations.aws.",
+          "ttl": 86400
+        }
+      }
+    }
+  }
 }

--- a/terraform/domains/environment_domains/config/production_Terrafile
+++ b/terraform/domains/environment_domains/config/production_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/domains/environment_domains/config/test.tfvars.json
+++ b/terraform/domains/environment_domains/config/test.tfvars.json
@@ -1,6 +1,7 @@
 {
   "domains": ["test"],
-  "environment_short": "test",
+  "cached_paths": ["/assets/*"],
+  "environment_short": "ts",
   "environment_tag": "test",
   "origin_hostname": "find-a-lost-trn-test-web.test.teacherservices.cloud"
 }

--- a/terraform/domains/environment_domains/config/test_Terrafile
+++ b/terraform/domains/environment_domains/config/test_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -1,11 +1,13 @@
 module "domains" {
-  source              = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains?ref=stable"
+  source              = "./vendor/modules/domains//domains/environment_domains"
   zone                = var.zone
   front_door_name     = var.front_door_name
   resource_group_name = var.resource_group_name
   domains             = var.domains
   environment         = var.environment_short
   host_name           = var.origin_hostname
+  null_host_header    = try(var.null_host_header, false)
+  cached_paths        = try(var.cached_paths, [])
 }
 
 data "azurerm_cdn_frontdoor_profile" "main" {
@@ -16,4 +18,10 @@ data "azurerm_cdn_frontdoor_profile" "main" {
 data "azurerm_dns_zone" "main" {
   name                = var.zone
   resource_group_name = var.resource_group_name
+}
+
+# Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.
+module "dns_records" {
+  source      = "./vendor/modules/domains//dns/records"
+  hosted_zone = var.hosted_zone
 }

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -38,3 +38,19 @@ variable "origin_hostname" {
 locals {
   hostname = "${var.domains[0]}.${var.zone}"
 }
+
+variable "hosted_zone" {
+  type    = map(any)
+  default = {}
+}
+
+variable "null_host_header" {
+  default     = false
+  description = "The origin_host_header for the azurerm_cdn_frontdoor_origin resource will be var.host_name (if false) or null (if true). If null then the host name from the incoming request will be used."
+}
+
+variable "cached_paths" {
+  type        = list(string)
+  default     = []
+  description = "List of path patterns such as /assets/* that front door will cache"
+}

--- a/terraform/domains/infrastructure/.terraform.lock.hcl
+++ b/terraform/domains/infrastructure/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.53.0"
   constraints = "3.53.0"
   hashes = [
+    "h1:NqV7ilkolM3jBsmAx5Bh6mA9zfUHCQh3hyjOPBUeWlo=",
     "h1:bK70LV1NldhodSm58cUpawKwdUL1A5AKKglAV2wZ/QY=",
     "zh:078ece8318ad7d6c1cd2e5f2044188e74af63921b93223c7f8d477539fa91888",
     "zh:1bdc98ff8c2d3f3e81a746762e03d39794b2f5c90dc478cdb23dcc3d3f9947b6",

--- a/terraform/domains/infrastructure/config/zones_Terrafile
+++ b/terraform/domains/infrastructure/config/zones_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/domains/infrastructure/main.tf
+++ b/terraform/domains/infrastructure/main.tf
@@ -1,5 +1,5 @@
 module "domains_infrastructure" {
-  source                 = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/infrastructure?ref=stable"
+  source                 = "./vendor/modules/domains//domains/infrastructure"
   hosted_zone            = var.hosted_zone
   tags                   = var.tags
   deploy_default_records = var.deploy_default_records


### PR DESCRIPTION
### Context

Manage the services domain configuration using Terraform and on the Azure platform

### Changes proposed in this pull request

Prepare the Terraform code and configs for the migration
Add Terrafile support to DNS management
Add or update relevant Makefile commands

Include a summary of the change.

### Guidance to review

Confirm configuration values are correct

## Next steps

- [ ] Get the _dnsauth record added to Route 53 so the apex domain certificate is validated.
- [ ] Test the domain following https://vninja.net/2020/02/06/macos-custom-dns-resolvers
- [ ] Agree migration date with service team
- [ ] Raise service request and then change to update the R53 CNAME record to an NS record

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
