### PR TITLE
Update origin hostnames for test environments

### DIFF
--- a/terraform/domains/environment_domains/config/development.tfvars.json
+++ b/terraform/domains/environment_domains/config/development.tfvars.json
@@ -3,5 +3,5 @@
   "cached_paths": ["/assets/*"],
   "environment_short": "dv",
   "environment_tag": "dev",
-  "origin_hostname": "find-a-lost-trn-development-web.test.teacherservices.cloud"
+  "origin_hostname": "find-a-lost-trn-development.test.teacherservices.cloud"
 }

--- a/terraform/domains/environment_domains/config/preproduction.tfvars.json
+++ b/terraform/domains/environment_domains/config/preproduction.tfvars.json
@@ -3,5 +3,5 @@
   "cached_paths": ["/assets/*"],
   "environment_short": "pp",
   "environment_tag": "pre-prod",
-  "origin_hostname": "find-a-lost-trn-preproduction-web.test.teacherservices.cloud"
+  "origin_hostname": "find-a-lost-trn-preproduction.test.teacherservices.cloud"
 }

--- a/terraform/domains/environment_domains/config/test.tfvars.json
+++ b/terraform/domains/environment_domains/config/test.tfvars.json
@@ -3,5 +3,5 @@
   "cached_paths": ["/assets/*"],
   "environment_short": "ts",
   "environment_tag": "test",
-  "origin_hostname": "find-a-lost-trn-test-web.test.teacherservices.cloud"
+  "origin_hostname": "find-a-lost-trn-test.test.teacherservices.cloud"
 }


### PR DESCRIPTION
### Context

Update origin hostnames for test environments


### Summary 

Remove "web" from the origin hostnames of the dev, test and preprod environments


### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
