### PR TITLE
Remove dev paas env from workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -152,7 +152,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [dev, test, preprod]
+        environment: [test, preprod]
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}

--- a/.github/workflows/database-copy.yml
+++ b/.github/workflows/database-copy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Restore DB
     strategy:
       matrix:
-        environment: [dev, test, preprod, production]
+        environment: [test, preprod, production]
       max-parallel: 1
     uses: ./.github/workflows/restore-paas-db-to-aks.yml
     with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,11 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Deploy environment ( dev, test, preprod or production )"
+        description: "Deploy environment ( test, preprod or production )"
         required: true
-        default: dev
+        default: test
         type: choice
         options:
-          - dev
           - test
           - preprod
           - production

--- a/.github/workflows/restore-paas-db-to-aks.yml
+++ b/.github/workflows/restore-paas-db-to-aks.yml
@@ -10,7 +10,6 @@ on:
       environment:
         type: choice
         options:
-          - dev
           - test
           - preprod
           - production
@@ -78,9 +77,6 @@ jobs:
         id: set_aks_env_name
         run: |
           case "${{ inputs.environment }}" in
-          dev)
-            echo "ENVIRONMENT_AKS=development_aks" >> $GITHUB_OUTPUT
-            ;;
           test)
             echo "ENVIRONMENT_AKS=test_aks" >> $GITHUB_OUTPUT
             ;;
@@ -124,11 +120,6 @@ jobs:
           production_cluster_name=s189p01-tsc-production-aks
 
           case "${ENVIRONMENT_NAME}" in
-          development_aks)
-            echo "cluster_rg=$test_cluster_rg" >> $GITHUB_ENV
-            echo "cluster_name=$test_cluster_name" >> $GITHUB_ENV
-            echo "app_name=find-a-lost-trn-development" >> $GITHUB_ENV
-            ;;
           test_aks)
             echo "cluster_rg=$test_cluster_rg" >> $GITHUB_ENV
             echo "cluster_name=$test_cluster_name" >> $GITHUB_ENV


### PR DESCRIPTION
### Context

Remove dev paas env from workflow after development_aks has been successfully migrated

### Changes proposed in this pull request

- Remove the dev paas env from the workflow and from the 
- Remove Dev from the scheduled DB copy

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
