### PR TITLE
Remove preprod paas env from workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -90,7 +90,6 @@ jobs:
   deploy_v2_nonprod:
     name: Deploy to ${{ matrix.environment }} environment
     runs-on: ubuntu-latest
-    continue-on-error: true
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency: deploy_${{ matrix.environment }}
     needs: [docker]
@@ -143,46 +142,6 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           arm-access-key: ${{ secrets.ARM_ACCESS_KEY }}
 
-  deploy_nonprod:
-    name: Deploy to ${{ matrix.environment }} environment
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    concurrency: deploy_${{ matrix.environment }}
-    needs: [docker]
-    strategy:
-      max-parallel: 1
-      matrix:
-        environment: [preprod]
-    environment:
-      name: ${{ matrix.environment }}
-      url: ${{ steps.deploy.outputs.environment_url }}
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Docker image tag
-        id: image
-        run: |
-          echo ::set-output name=tag::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA
-        env:
-          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
-        shell: bash
-
-      - uses: ./.github/workflows/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: ${{ matrix.environment }}
-          docker_image: ${{ steps.image.outputs.tag }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/${{ matrix.environment }}.tfvars.json
-      - uses: ./.github/workflows/actions/smoke-test
-        id: smoke-test
-        with:
-          environment: ${{ matrix.environment }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
   deploy_production:
     name: Deploy to production environment
     runs-on: ubuntu-latest
@@ -191,7 +150,7 @@ jobs:
       name: production
       url: ${{ steps.deploy.outputs.environment_url }}
     concurrency: deploy_production
-    needs: [docker, deploy_nonprod]
+    needs: [docker, deploy_v2_nonprod]
 
     outputs:
       environment_url: ${{ steps.deploy.outputs.environment_url }}

--- a/.github/workflows/database-copy.yml
+++ b/.github/workflows/database-copy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Restore DB
     strategy:
       matrix:
-        environment: [preprod, production]
+        environment: [production]
       max-parallel: 1
     uses: ./.github/workflows/restore-paas-db-to-aks.yml
     with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,9 @@ on:
       environment:
         description: "Deploy environment ( test, preprod or production )"
         required: true
-        default: preprod
+        default: production
         type: choice
         options:
-          - preprod
           - production
       sha:
         description: Commit sha to be deployed

--- a/.github/workflows/restore-paas-db-to-aks.yml
+++ b/.github/workflows/restore-paas-db-to-aks.yml
@@ -10,7 +10,6 @@ on:
       environment:
         type: choice
         options:
-          - preprod
           - production
 
 env:
@@ -76,9 +75,6 @@ jobs:
         id: set_aks_env_name
         run: |
           case "${{ inputs.environment }}" in
-          preprod)
-            echo "ENVIRONMENT_AKS=preproduction_aks" >> $GITHUB_OUTPUT
-            ;;
           production)
             echo "ENVIRONMENT_AKS=production_aks" >> $GITHUB_OUTPUT
             ;;
@@ -116,11 +112,6 @@ jobs:
           production_cluster_name=s189p01-tsc-production-aks
 
           case "${ENVIRONMENT_NAME}" in
-          preproduction_aks)
-            echo "cluster_rg=$test_cluster_rg" >> $GITHUB_ENV
-            echo "cluster_name=$test_cluster_name" >> $GITHUB_ENV
-            echo "app_name=find-a-lost-trn-preproduction" >> $GITHUB_ENV
-            ;;
           production_aks)
             echo "cluster_rg=$production_cluster_rg" >> $GITHUB_ENV
             echo "cluster_name=$production_cluster_name" >> $GITHUB_ENV


### PR DESCRIPTION
### Context

Remove preprod paas env from workflow after preproduction_aks has been successfully migrated

### Changes proposed in this pull request

Remove the preprod paas env from the workflow and from the
Remove preprod from the scheduled DB copy


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
