### PR TITLE
[775] Revert "Use 0 statuscake confirmations in production"

### DIFF
--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -16,7 +16,7 @@
       ],
       "contact_group": [282783],
       "ssl_domain": "https://find-a-lost-trn.education.gov.uk",
-      "confirmations": 0
+      "confirmations": 2
     }
   },
   "inf_vault_name": "s189p01-faltrn-pd-inf-kv",

--- a/terraform/aks/workspace_variables/production_aks_Terrafile
+++ b/terraform/aks/workspace_variables/production_aks_Terrafile
@@ -1,3 +1,3 @@
 aks:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "statuscake-confirmation"
+    version: "stable"


### PR DESCRIPTION
### Context
The front door DNSTimeout fix was rolled out. Reverting to default confirmations to eliminate false alarms.

### Guidance to review
Check default

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
