### PR TITLE
Add data_schema to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,6 +26,7 @@ bin/dev
 data
 db/*.sqlite3
 db/schema.rb
+db/data_schema.rb
 log
 public/assets
 storage


### PR DESCRIPTION
### Context
I'm getting this error when linting locally:

[error] No parser could be inferred for file "find-a-lost-trn/db/data_schema.rb".


### Changes proposed in this pull request

We don't need to lint this file anyway, so add it to the ignore list.


### Guidance to review


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
