### PR TITLE
Fix Rails >=7.1 / RedCarpet incompatibility bug

### DIFF
--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -2,8 +2,15 @@
 
 class MarkdownTemplate
   def self.call(template, source)
+    source ||= template.source
+
+    # Rails >= 7.1 does not work with the Redcarpet markdown renderer.
+    # There is an argument mismatch where a string is expected but an OutputBuffer is provided.
+    # This is a workaround to convert the buffer to a string.
     erb_handler = ActionView::Template.registered_template_handler(:erb)
-    compiled_source = erb_handler.call(template, source)
+    erb_handler.call(template, source)
+    compiled_source = ActionView::OutputBuffer.new( erb_handler.call( template, source ) )
+    compiled_source << '.to_s'
     "GovukMarkdown.render(begin;#{compiled_source};end).html_safe"
   end
 end


### PR DESCRIPTION
### Context

We have a Sentry error in production.
https://dfe-teacher-services.sentry.io/issues/4934931319/?alert_rule_id=14966789&alert_type=issue&notification_uuid=6b0d7b8f-e05c-4f5f-970a-74882b184111&project=6275068&referrer=slack
Rails >=7.1 isn't compatible with RedCarpet which underpins Govuk Markdown.
We've experienced this issue in other services eg. https://github.com/DFE-Digital/check-childrens-barred-list/commit/acf34e6b6e267c5853182a4b423d6ce5277c2bf3

### Changes proposed in this pull request

Add similar workaround for Rails 7.1 template handler for markdown.

### Guidance to review

Does `/privacy` work?

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
