### PR TITLE
Pin sidekiq < 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "puma", "~> 6.4"
 gem "rack-attack"
 gem "rails", "~> 7.1.3"
 gem "sentry-rails"
-gem "sidekiq"
+gem "sidekiq", "< 7" # v7 requires Redis 6.2 that Azure doesn't support yet
 gem "sidekiq-cron", "~> 1.10"
 gem "sprockets-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -585,7 +585,7 @@ DEPENDENCIES
   rubocop-govuk
   sentry-rails
   shoulda-matchers (~> 5.3)
-  sidekiq
+  sidekiq (< 7)
   sidekiq-cron (~> 1.10)
   solargraph
   solargraph-rails


### PR DESCRIPTION
### Context

We use Sidekiq. It uses Redis. Sidekiq 7 requires Redis >= 6.2 which Azure doesn't currently support. Dependabot keeps opening an upgrade PR and when we merge it the worker instances can't start.

### Changes proposed in this pull request

Pin the Sidekiq version to < 7

### Checklist

 - [x] Rebased main
 - [x] Cleaned commit history
 - [x] Tested by running locally
