### PR TITLE
Update webhook env var in SlackClient

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -9,6 +9,6 @@ IDENTITY_API_URL=https://preprod.teaching-identity.education.gov.uk/
 IDENTITY_SHARED_SECRET_KEY=testkey
 IDENTITY_USER_TOKEN=testkey
 REDIS_URL=redis://localhost:6379/1
-SLACK_WEBHOOK_URL=test
+SLACK_WEBHOOK=test
 SUPPORT_PASSWORD=test
 SUPPORT_USERNAME=test

--- a/app/services/slack_client.rb
+++ b/app/services/slack_client.rb
@@ -17,7 +17,7 @@ class SlackClient
   private
 
   def client
-    Faraday.new(url: ENV.fetch("SLACK_WEBHOOK_URL")) do |faraday|
+    Faraday.new(url: ENV.fetch("SLACK_WEBHOOK")) do |faraday|
       faraday.request :json
       faraday.response :json
       faraday.response :logger, nil, { bodies: true, headers: true }


### PR DESCRIPTION


### Context
This env var hasn't been set for the production app since the AKS migration, and is needed by SlackClient for reporting performance alerts and Zendesk health to Slack.



### Changes proposed in this pull request

Secrets for this service are now split into infra and app lists. The infra list contains a Slack webhook URL that is used when database backups fail. We need that same URL in the app list.

In addition to adding SLACK_WEBHOOK to the app secrets via the Azure Portal, this PR simply aligns the name of the env var between the two places in the codebase it is currently used.

### Guidance to review

I'll manually test SlackClient on a console once this is merged.

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
