### PR TITLE
Add app_key_vault variable block to terraform

### DIFF
--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -3,6 +3,11 @@ variable "app_environment" {
   description = "Environment name in full e.g development"
 }
 
+variable "app_key_vault" {
+  default     = null
+  description = "app kv name"
+}
+
 variable "file_environment" {
   type        = string
   description = "AKS environment name e.g dev"


### PR DESCRIPTION

### Context
Deploys are failing currently with an error message which suggests this block is missing.

### Changes proposed in this pull request

### Guidance to review


### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
