### PR TITLE
Update found TRN email

### DIFF
--- a/app/views/teacher_mailer/found_trn.erb
+++ b/app/views/teacher_mailer/found_trn.erb
@@ -12,7 +12,7 @@ We suggest you keep this email for future reference.
 
 You need to know your TRN to:
 
-* view your record with the Teaching Regulation Agency (TRA), check your record is accurate and download professional certificates in the Teacher self service portal https://teacherservices.education.gov.uk/SelfService/Login
+* [access your teaching qualifications](https://access-your-teaching-qualifications.education.gov.uk) to download your initial certificates, change your name on them or check details of your initial teacher training and induction
 * give to employers so they can complete mandatory teacher status checks
 * manage records of your contributions to the Teachers’ Pensions scheme
 * give to the Department for Education (DfE) when you have been awarded QTS so you can begin your early career teacher induction and access your early career framework induction training programme


### PR DESCRIPTION
### Context

The teacher self service portal has been decommissioned and replaced by the access your teaching qualifications service.


### Changes proposed in this pull request

Remove references to TSS and add AYTQ link from the TRN email.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
