### PR TITLE
Added required attributes to postgres and redis

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -1,37 +1,35 @@
 module "postgres" {
   source = "./vendor/modules/aks//aks/postgres"
 
-  namespace             = var.namespace
-  environment           = local.environment
-  azure_resource_prefix = var.azure_resource_prefix
-  service_name          = local.service_name
-  service_short         = var.service_short
-  config_short          = var.config_short
-
-  cluster_configuration_map = module.cluster_data.configuration_map
-
-  use_azure               = var.deploy_azure_backing_services
-  azure_enable_monitoring = var.enable_monitoring
-  azure_extensions        = ["plpgsql", "citext", "uuid-ossp"]
-  server_version          = "14"
-
-  azure_enable_backup_storage = var.azure_enable_backup_storage
+  namespace                      = var.namespace
+  environment                    = local.environment
+  azure_resource_prefix          = var.azure_resource_prefix
+  service_name                   = local.service_name
+  service_short                  = var.service_short
+  config_short                   = var.config_short
+  cluster_configuration_map      = module.cluster_data.configuration_map
+  use_azure                      = var.deploy_azure_backing_services
+  azure_enable_monitoring        = var.enable_monitoring
+  azure_extensions               = ["plpgsql", "citext", "uuid-ossp"]
+  server_version                 = "14"
+  azure_enable_backup_storage    = var.azure_enable_backup_storage
+  azure_sku_name                 = var.postgres_flexible_server_sku
+  azure_enable_high_availability = var.postgres_enable_high_availability
+  azure_maintenance_window       = var.azure_maintenance_window
 }
 
 module "redis" {
   count  = var.deploy_redis ? 1 : 0
   source = "./vendor/modules/aks//aks/redis"
 
-  namespace             = var.namespace
-  environment           = local.environment
-  azure_resource_prefix = var.azure_resource_prefix
-  service_name          = local.service_name
-  service_short         = var.service_short
-  config_short          = var.config_short
-
+  namespace                 = var.namespace
+  environment               = local.environment
+  azure_resource_prefix     = var.azure_resource_prefix
+  service_name              = local.service_name
+  service_short             = var.service_short
+  config_short              = var.config_short
   cluster_configuration_map = module.cluster_data.configuration_map
-
-  use_azure               = var.deploy_azure_backing_services
-  azure_enable_monitoring = var.enable_monitoring
-  azure_patch_schedule    = [{ "day_of_week" : "Sunday", "start_hour_utc" : 01 }]
+  use_azure                 = var.deploy_azure_backing_services
+  azure_enable_monitoring   = var.enable_monitoring
+  azure_patch_schedule      = [{ "day_of_week" : "Sunday", "start_hour_utc" : 01 }]
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -45,6 +45,15 @@ variable "enable_monitoring" {
   default     = false
   description = "Enable monitoring and alerting"
 }
+variable "postgres_enable_high_availability" {
+  default = false
+}
+variable "postgres_flexible_server_sku" {
+  default = "B_Standard_B1ms"
+}
+variable "azure_maintenance_window" {
+  default = null
+}
 
 variable "enable_postgres_ssl" {
   default     = true

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -8,6 +8,13 @@
   "config_short": "pd",
   "service_short": "faltrn",
   "app_key_vault": "s189p01-faltrn-pd-app-kv",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_enable_high_availability": true,
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 3,
+    "start_minute": 0
+  },
   "statuscake_alerts": {
     "alert": {
       "website_url": [


### PR DESCRIPTION
WHY: There is a required minimum standard setting for prod postgres and redis
HOW: By setting HA, Maintenance window and SKU

### Context
Added required attributes to postgres and redis in prod
<!-- Why are you making this change? -->

### Changes proposed in this pull request
 set HA, Maintenance window and SKU for prod. as required in guide

### Guidance to review
make production terraform-plan DOCKER_IMAGE=ghcr.io/dfe-digital/find-a-lost-trn:3a1e8be400670ce40862d900a30980301ffd7492

### Link to Trello card
https://trello.com/c/9krStzPr/1787-fix-find-a-lost-trn-prod-db