### PR TITLE
Statuscake SSL alert removed for preprod

### DIFF
--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/eppo/environment" {
   constraints = "1.3.5"
   hashes = [
     "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
+    "h1:pceowuRAKcjLd+g4noIJdX6CBIWavlM4BvRTsGfH0uQ=",
     "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
     "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
     "zh:12ca5162286b80b7f46bd013ae2007641132d201af12bc6adb872f9a0ff85b7a",
@@ -30,6 +31,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   hashes = [
     "h1:cmleWBjFp4eK0iQICvCKxTxECx8nvl0MAfth9mLzT70=",
     "h1:g2p1LQQy+Ih6gWzMQTmlb6v5s9iXP3EusXIwd63APg0=",
+    "h1:y6R1GCooPE9y9BpPuhqokyYJky5T8s0dOMgFsC+VL/0=",
     "zh:08463ceca4208419715b5816d120fe05f2abda9bea083cfe1818e25517483581",
     "zh:130760c5ab791bd114b3edbb79b95138a60cd97f1b72e4096b33a207b367d126",
     "zh:26403fc9be70b60fddf09b1510067763b2da57cf3b116d375b5bee048acad8d2",
@@ -50,6 +52,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.21.1"
   hashes = [
     "h1:2spGoBcGDQ/Csc23bddCfM21zyKx3PONoiqRgmuChnM=",
+    "h1:I1qWLUFmB0Z8+3CX+XzJtkgiAOYQ1nHlLN9lFcPf+zc=",
     "h1:gP8IU3gFfXYRfGZr5Qws9JryZsOGsluAVpiAoZW7eo0=",
     "zh:156a437d7edd6813e9cb7bdff16ebce28cec08b07ba1b0f5e9cec029a217bc27",
     "zh:1a21c255d8099e303560e252579c54e99b5f24f2efde772c7e39502c62472605",
@@ -70,6 +73,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.1"
   hashes = [
     "h1:8iqExjtAvirFTJkpm5YyYD+fC+DGV8NTJzKsE2c70VA=",
+    "h1:a+Goawwh6Qtg4/bRWzfDtIdrEFfPlnVy0y4LdUQY3nI=",
     "zh:2a0ec154e39911f19c8214acd6241e469157489fc56b6c739f45fbed5896a176",
     "zh:57f4e553224a5e849c99131f5e5294be3a7adcabe2d867d8a4fef8d0976e0e52",
     "zh:58f09948c608e601bd9d0a9e47dcb78e2b2c13b4bda4d8f097d09152ea9e91c5",
@@ -90,6 +94,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   constraints = "2.1.0"
   hashes = [
     "h1:GI/6fNXTYwAcpvo4iES2VbrLJaJg8Lp4TdiQBxyhgTo=",
+    "h1:H3gMqrYGiDktXysrY/2+3xL2npZhXmJTJHoEn7o9Kew=",
     "h1:eLBXGDSLG9/r5R/0GRBXgCY7rza0+u1YckytVU9GTos=",
     "zh:00cd46ce1502f0df61eb1f1aa6cac07399f20e48c89033dd53314b733762252d",
     "zh:0fddb98d450ae9ad8daa25b1fec5c1e8c6c6487560d52da57b0e71e2531025e9",

--- a/terraform/aks/statuscake.tf
+++ b/terraform/aks/statuscake.tf
@@ -10,7 +10,7 @@ module "statuscake" {
 }
 
 resource "statuscake_ssl_check" "domain-alert" {
-  for_each = var.statuscake_alerts
+  for_each = { for k, v in var.statuscake_alerts : k => v if can(v.ssl_domain) }
 
   check_interval   = 3600 # Check once per hour
   contact_groups   = each.value.contact_group

--- a/terraform/aks/workspace_variables/preproduction.tfvars.json
+++ b/terraform/aks/workspace_variables/preproduction.tfvars.json
@@ -13,8 +13,7 @@
         "https://preprod.find-a-lost-trn.education.gov.uk/health/all",
         "https://find-a-lost-trn-preproduction.test.teacherservices.cloud/health/all"
       ],
-      "contact_group": [288912],
-      "ssl_domain": "https://preprod.find-a-lost-trn.education.gov.uk"
+      "contact_group": [288912]
     }
   },
   "inf_vault_name": "s189t01-faltrn-pp-inf-kv",


### PR DESCRIPTION
### Context
 
Statuscake SSL alert removed for preprod

### Changes proposed in this pull request

Updated terraform code create  SSL alert if ssl_domain availabe.

### Guidance to review

Terraform Plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # statuscake_ssl_check.domain-alert["alert"] will be destroyed
  # (because key ["alert"] is not in for_each map)
  - resource "statuscake_ssl_check" "domain-alert" {
      - check_interval   = 3600 -> null
      - contact_groups   = [
          - "288912",
        ] -> null
      - follow_redirects = true -> null
      - id               = "315625" -> null
      - paused           = false -> null

      - alert_config {
          - alert_at    = [
              - 3,
              - 7,
              - 30,
            ] -> null
          - on_broken   = true -> null
          - on_expiry   = true -> null
          - on_mixed    = true -> null
          - on_reminder = true -> null
        }

      - monitored_resource {
          - address = "https://preprod.find-a-lost-trn.education.gov.uk" -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.
### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
