### PR TITLE
Correct expectation in smoke test

### DIFF
--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def then_i_see_the_email_page
-    expect(page).to have_content("Your email address")
+    expect(page).to have_content("What is your email address?")
   end
 
   def then_i_see_the_have_ni_page


### PR DESCRIPTION
### Context

Incorrect wording in smoke spec causing spec to fail. This update will bring the expecation in the test in line with the real case. 

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
