### PR TITLE
[2205] Use no-sandbox to stop smoke tests timeouts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,6 +548,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   x86_64-darwin-21
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,11 +16,15 @@ require "vcr"
 require "view_component/test_helpers"
 
 Capybara.register_driver(:cuprite) do |app|
+  browser_options = {}
+  browser_options['no-sandbox'] = nil if ENV['CI']
+
   Capybara::Cuprite::Driver.new(
     app,
     timeout: 10,
     process_timeout: 30,
     window_size: [1200, 800],
+    browser_options:
   )
 end
 Capybara.default_driver = :cuprite


### PR DESCRIPTION
### Context
Smoke test failures: https://github.com/DFE-Digital/find-a-lost-trn/actions/runs/12772372270

### Changes proposed in this pull request
Set capybara driver no-sandbox to true to avoid timeouts

### Guidance to review
- Set HOSTING_DOMAIN, SUPPORT_USERNAME, SUPPORT_PASSWORD
- Run: `bin/smoke`

### Link to Trello card
https://trello.com/c/WqTLwTdX

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
