### PR TITLE
Correcting healthcheck path

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -256,5 +256,5 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID   }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
           environment: ${{ matrix.domain_environment }}
-          healthcheck: healthcheck
+          healthcheck: health
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

The healthcheck path for this application is /health not /healthcheck

### Changes proposed in this pull request

healthcheck: health

### Guidance to review

https://find-a-lost-trn.education.gov.uk/health returns a 200
https://find-a-lost-trn.education.gov.uk/healthcheck returns a page not found

### Link to Trello card

https://trello.com/c/qyXB3RQA/1972-implement-ci-cd-for-domains-on-all-services

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
