### PR TITLE
Adding id-token permission to workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -10,6 +10,7 @@ permissions:
   packages: write
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   build-no-cache:


### PR DESCRIPTION
## Context
Fix Build No Cache workflow for FALTRN

## Changes proposed in this pull request
Updating id-token permission

## Guidance to review
Check workflow run
https://github.com/DFE-Digital/find-a-lost-trn/actions/runs/14033517772/job/39286255848

## Link to Trello card
https://trello.com/c/EDFsxSCM/2231-faltrn-plan-for-dr-test-april-2025

## Checklist

- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [x]  Tested by running locally