### PR TITLE
Add ingress rate limit

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -3,5 +3,16 @@
   "cached_paths": ["/assets/*"],
   "environment_short": "pd",
   "environment_tag": "Prod",
-  "origin_hostname": "find-a-lost-trn-production.teacherservices.cloud"
+  "origin_hostname": "find-a-lost-trn-production.teacherservices.cloud",
+  "rate_limit": [
+    {
+      "agent": "all",
+      "priority": 100,
+      "duration": 5,
+      "limit": 250,
+      "selector": "Host",
+      "operator": "GreaterThanOrEqual",
+      "match_values": "0"
+    }
+  ]
 }

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -8,4 +8,5 @@ module "domains" {
   host_name           = var.origin_hostname
   null_host_header    = try(var.null_host_header, false)
   cached_paths        = try(var.cached_paths, [])
+  rate_limit          = try(var.rate_limit, null)
 }

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -44,3 +44,16 @@ variable "cached_paths" {
   default     = []
   description = "List of path patterns such as /assets/* that front door will cache"
 }
+
+variable "rate_limit" {
+  type = list(object({
+    agent        = optional(string)
+    priority     = optional(number)
+    duration     = optional(number)
+    limit        = optional(number)
+    selector     = optional(string)
+    operator     = optional(string)
+    match_values = optional(string)
+  }))
+  default = null
+}


### PR DESCRIPTION
### Context

Configure rate limiting for production

### Changes proposed in this pull request

Add global rate limit per IP for 5 minute intervals
Value for global rate set from checking ingress logs for the last 4 weeks and is more than double any 10 minute period in that time.

### Guidance to review

make production domains-plan

### Link to Trello card

https://trello.com/c/rmljcE5W/2345-add-rate-limiting-for-services

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
