### PR TITLE
Rate limiting for nonprod

### DIFF
--- a/terraform/domains/environment_domains/config/development.tfvars.json
+++ b/terraform/domains/environment_domains/config/development.tfvars.json
@@ -3,5 +3,6 @@
   "cached_paths": ["/assets/*"],
   "environment_short": "dv",
   "environment_tag": "dev",
-  "origin_hostname": "find-a-lost-trn-development.test.teacherservices.cloud"
+  "origin_hostname": "find-a-lost-trn-development.test.teacherservices.cloud",
+  "rate_limit_max": 250
 }

--- a/terraform/domains/environment_domains/config/preproduction.tfvars.json
+++ b/terraform/domains/environment_domains/config/preproduction.tfvars.json
@@ -3,5 +3,6 @@
   "cached_paths": ["/assets/*"],
   "environment_short": "pp",
   "environment_tag": "pre-prod",
-  "origin_hostname": "find-a-lost-trn-preproduction.test.teacherservices.cloud"
+  "origin_hostname": "find-a-lost-trn-preproduction.test.teacherservices.cloud",
+  "rate_limit_max": 250
 }

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -4,15 +4,5 @@
   "environment_short": "pd",
   "environment_tag": "Prod",
   "origin_hostname": "find-a-lost-trn-production.teacherservices.cloud",
-  "rate_limit": [
-    {
-      "agent": "all",
-      "priority": 100,
-      "duration": 5,
-      "limit": 250,
-      "selector": "Host",
-      "operator": "GreaterThanOrEqual",
-      "match_values": "0"
-    }
-  ]
+  "rate_limit_max": 250
 }

--- a/terraform/domains/environment_domains/config/test.tfvars.json
+++ b/terraform/domains/environment_domains/config/test.tfvars.json
@@ -3,5 +3,6 @@
   "cached_paths": ["/assets/*"],
   "environment_short": "ts",
   "environment_tag": "test",
-  "origin_hostname": "find-a-lost-trn-test.test.teacherservices.cloud"
+  "origin_hostname": "find-a-lost-trn-test.test.teacherservices.cloud",
+  "rate_limit_max": 250
 }

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -9,4 +9,5 @@ module "domains" {
   null_host_header    = try(var.null_host_header, false)
   cached_paths        = try(var.cached_paths, [])
   rate_limit          = try(var.rate_limit, null)
+  rate_limit_max      = try(var.rate_limit_max, null)
 }

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -57,3 +57,8 @@ variable "rate_limit" {
   }))
   default = null
 }
+
+variable "rate_limit_max" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
### Context

Add front door rate limiting for nonprod envs

### Changes proposed in this pull request

Add rate limit max (250 reqs per IP over 5 minutes)
Change prod rate limiting to use the new format, but no change to the settings.

### Guidance to review

make env domains-plan

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
