### PR TITLE
Pin exact third party github action versions

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -55,7 +55,7 @@ runs:
         fi
 
     - name: Use Terraform ${{ env.TERRAFORM_VERSION }}
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # Pinned at v2.0.3
       with:
         terraform_version: ${{ env.TERRAFORM_VERSION }}
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
         with:
           message: |
             AKS review app deployed to https://find-a-lost-trn-review-pr-${{ github.event.pull_request.number }}.test.teacherservices.cloud
@@ -154,7 +154,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
         env:
           SLACK_COLOR: failure
           SLACK_TITLE: Failure deploying release to ${{ matrix.environment }}
@@ -204,7 +204,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
         env:
           SLACK_COLOR: failure
           SLACK_TITLE: Failure deploying release to production

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -47,7 +47,7 @@ jobs:
           snyk-token: ${{ secrets.SNYK_TOKEN }}
 
       - name: Notify slack on failure
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
         if: ${{ failure() }}
         with:
           SLACK_USERNAME: CI Deployment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # Pinned at v3.1.2
         with:
           terraform_version: 1.5.0
 


### PR DESCRIPTION
### Context

Github action tags can be changed and pointed at new versions of a repo, this can lead to supply chain attacks and evidence of this occuring on other projects outside DfE exists.

Pinning to exact git hashes ensures that the version of the action cannot be changed without us explicitly changing it.

### Changes proposed in this pull request

- Pin github action versions

### Guidance to review

- Check github actions run successfully

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
