### PR TITLE
Ensure only application models are checks in db integrity check

### DIFF
--- a/lib/ok_computer_checks/database_integrity_check.rb
+++ b/lib/ok_computer_checks/database_integrity_check.rb
@@ -12,7 +12,7 @@ module OkComputerChecks
     private
 
     def tables_missing_for_models?
-      ActiveRecord::Base.descendants.map(&method(:table_present_for_model?)).include?(false)
+      ApplicationRecord.descendants.map(&method(:table_present_for_model?)).include?(false)
     end
 
     def table_present_for_model?(model)


### PR DESCRIPTION
We only currently want to check these tables