### PR TITLE
Update copy

### DIFF
--- a/app/views/check_trn/new.html.erb
+++ b/app/views/check_trn/new.html.erb
@@ -7,7 +7,7 @@
   <p class="govuk-body">You will have a TRN if you:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>hold qualified teacher status (QTS) in England or Wales</li>
-    <li>hold early years teacher status (EYTS) in England</li>
+    <li>hold early years teacher status (EYTS) or early years professional status (EYPS) in England</li>
     <li>hold a national professional qualification (NPQ)</li>
     <li>are working towards QTS, EYTS or an NPQ</li>
     <li>contribute to the Teachers’ Pensions scheme in England or Wales</li>


### PR DESCRIPTION
### Context

The EYTFI Private beta will follow the AYTQ Customer Journey model in that citizens will require a TRN in order to access the service
Under the AYTQ Customer Journey model, if the user selects "No" to the "Do you have a TRN" question, and hits continue, they are taken to a dead end screen which advises them that they are unable to access the service.
On this page, the Citizen User is directed to Find a Lost TRN. It has been requested that the FLTRN pages are updated to refer that EYPS may also have a TRN and can use the service to find it

Update the Find a Lost TRN screen to refer to EYPS in all cases where it is currently used following the content design
While this has been requested for the EYTFI Private beta, it has been confirmed that this would be useful information to display on the information screen in all places it is used, as it may be useful for other services

### Changes proposed in this pull request

-FLTRN Screens have been updated with new content to refer to EYPS

### Link to Trello card

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/248

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
