### PR TITLE
Prevent request replay in the TRN submission endpoints

### DIFF
--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -56,6 +56,40 @@ module EnforceQuestionOrder
     )
   end
 
+  # Atomically claim this request for processing. Returns false if it was already
+  # claimed by a previous (replayed or double-submitted) request, so callers can
+  # short-circuit before repeating any side effect (emails, Zendesk tickets,
+  # Identity API submissions). The claim is persisted on the record rather than in
+  # the session because the session is cookie-based: a replayed request carries the
+  # original cookie and would not see a session flag set by the first request.
+  def claim_submission!
+    TrnRequest
+      .where(id: trn_request.id, submitted_at: nil)
+      .update_all(submitted_at: Time.current)
+      .positive?
+  end
+
+  # Release a claim made by a branch that produced no side effect (e.g. no TRN
+  # match), so the user can correct their answers and resubmit. Written with
+  # update_all to mirror claim_submission! — the in-memory record is unaware of
+  # the claim, so an attribute assignment would be a no-op.
+  def release_submission!
+    TrnRequest.where(id: trn_request.id).update_all(submitted_at: nil)
+  end
+
+  # Where to send a replayed or duplicate submission whose outcome already exists.
+  def redirect_to_completed_submission
+    if trn_request.from_get_an_identity? && session[:identity_redirect_url]
+      redirect_to session[:identity_redirect_url], allow_other_host: true
+    elsif trn_request.zendesk_ticket_id
+      redirect_to helpdesk_request_submitted_path
+    elsif trn_request.trn
+      redirect_to trn_found_path
+    else
+      redirect_to root_url
+    end
+  end
+
   # If you want to use this method in a view, add `helper_method :check_answers_back_path` to the controller
   # this module is included in
   def check_answers_back_path

--- a/app/controllers/concerns/enforce_question_order.rb
+++ b/app/controllers/concerns/enforce_question_order.rb
@@ -78,11 +78,18 @@ module EnforceQuestionOrder
   end
 
   # Where to send a replayed or duplicate submission whose outcome already exists.
+  # Each branch keys off persisted outcome state (or session state present in the
+  # original request), because a replay carries the pre-submission cookie and
+  # cannot see anything the first request's response wrote to the session. A
+  # raised Zendesk ticket is checked before the identity branch: a Get An Identity
+  # request that fell back to a ticket has both zendesk_ticket_id and
+  # from_get_an_identity? set, and belongs on the helpdesk page, not back at the
+  # identity host.
   def redirect_to_completed_submission
-    if trn_request.from_get_an_identity? && session[:identity_redirect_url]
-      redirect_to session[:identity_redirect_url], allow_other_host: true
-    elsif trn_request.zendesk_ticket_id
+    if trn_request.zendesk_ticket_id
       redirect_to helpdesk_request_submitted_path
+    elsif trn_request.from_get_an_identity? && session[:identity_redirect_url]
+      redirect_to session[:identity_redirect_url], allow_other_host: true
     elsif trn_request.trn
       redirect_to trn_found_path
     else

--- a/app/controllers/no_match_controller.rb
+++ b/app/controllers/no_match_controller.rb
@@ -24,7 +24,17 @@ class NoMatchController < ApplicationController
         redirect_to session[:identity_redirect_url], allow_other_host: true
         session[:identity_client_title] = nil
       else
-        create_zendesk_ticket
+        begin
+          create_zendesk_ticket
+        rescue ZendeskService::ConnectionError
+          # The connection error is raised before the ticket is created, so the
+          # side effect has not committed: release the claim to keep the
+          # submission retryable, then re-raise so the failure still surfaces.
+          # Deliberately narrow — releasing after a committed side effect (a sent
+          # Identity submission, or a created ticket) would let a replay repeat it.
+          release_submission!
+          raise
+        end
 
         redirect_to helpdesk_request_submitted_path
       end

--- a/app/controllers/no_match_controller.rb
+++ b/app/controllers/no_match_controller.rb
@@ -13,6 +13,8 @@ class NoMatchController < ApplicationController
     if @no_match_form.valid? && @no_match_form.try_again?
       redirect_to check_answers_path
     elsif @no_match_form.valid?
+      return redirect_to_completed_submission unless claim_submission!
+
       if trn_request.from_get_an_identity?
         # Send a request to Get An Identity API with no TRN found
         IdentityApi.submit_trn!(trn_request, session[:identity_journey_id])

--- a/app/controllers/trn_requests_controller.rb
+++ b/app/controllers/trn_requests_controller.rb
@@ -14,7 +14,9 @@ class TrnRequestsController < ApplicationController
   end
 
   def update
-    redirect_to root_url unless trn_request
+    return redirect_to root_url unless trn_request
+    return redirect_to_completed_submission unless claim_submission!
+
     session[:form_complete] = false
 
     update_answers_checked_on_trn_request
@@ -38,6 +40,7 @@ class TrnRequestsController < ApplicationController
         redirect_to trn_found_path
       end
     rescue DqtApi::NoResults
+      release_submission!
       redirect_to no_match_path
     rescue DqtApi::ApiError,
            Faraday::ConnectionFailed,

--- a/app/models/trn_request.rb
+++ b/app/models/trn_request.rb
@@ -24,6 +24,7 @@
 #  preferred_last_name     :string
 #  previous_first_name     :string(510)
 #  previous_last_name      :string(510)
+#  submitted_at            :datetime
 #  trn                     :string
 #  trn_from_user           :string
 #  created_at              :datetime         not null

--- a/db/migrate/20260630134004_add_submitted_at_to_trn_requests.rb
+++ b/db/migrate/20260630134004_add_submitted_at_to_trn_requests.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtToTrnRequests < ActiveRecord::Migration[7.2]
+  def change
+    add_column :trn_requests, :submitted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2022_10_19_115943) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_30_134004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -139,6 +139,7 @@ ActiveRecord::Schema[7.1].define(version: 2022_10_19_115943) do
     t.string "preferred_first_name"
     t.string "preferred_last_name"
     t.boolean "official_name_preferred"
+    t.datetime "submitted_at"
   end
 
   create_table "trn_responses", force: :cascade do |t|

--- a/spec/models/trn_request_spec.rb
+++ b/spec/models/trn_request_spec.rb
@@ -24,6 +24,7 @@
 #  preferred_last_name     :string
 #  previous_first_name     :string(510)
 #  previous_last_name      :string(510)
+#  submitted_at            :datetime
 #  trn                     :string
 #  trn_from_user           :string
 #  created_at              :datetime         not null

--- a/spec/requests/no_match_spec.rb
+++ b/spec/requests/no_match_spec.rb
@@ -41,6 +41,57 @@ RSpec.describe "NoMatch replay protection", type: :request do
     end
   end
 
+  context "when raising the support ticket fails transiently" do
+    let(:trn_request) { create(:trn_request, awarded_qts: false, trn: nil) }
+
+    before { stub_current_trn_request(trn_request) }
+
+    it "releases the claim so the ticket can be created on retry" do
+      allow(ZendeskService).to receive(:create_ticket!).and_raise(
+        ZendeskService::ConnectionError,
+      )
+      post no_match_path, params: params # transient failure, claim released
+
+      expect(trn_request.reload.submitted_at).to be_nil
+
+      allow(ZendeskService).to receive(:create_ticket!) # retry succeeds
+      post no_match_path, params: params
+
+      expect(ZendeskService).to have_received(:create_ticket!).twice
+    end
+  end
+
+  # If the Identity submission commits but a later line fails (here the redirect
+  # raises because identity_redirect_url is absent), the claim must be kept so a
+  # replay cannot resend the submission — the claim is only released for a
+  # connection error, which is raised before anything commits.
+  context "when the identity submission commits but the response then fails" do
+    let(:trn_request) do
+      create(
+        :trn_request,
+        :from_get_an_identity,
+        official_name_preferred: true,
+        awarded_qts: false,
+        trn_from_user: "1234567",
+      )
+    end
+
+    before do
+      stub_current_trn_request(trn_request)
+      allow(IdentityApi).to receive(:submit_trn!)
+      # No identity_redirect_url, so redirect_to raises after submit_trn! commits.
+      allow_any_instance_of(NoMatchController).to receive(:session)
+        .and_return({})
+    end
+
+    it "keeps the claim so the submission is not resent on replay" do
+      post no_match_path, params: params
+
+      expect(IdentityApi).to have_received(:submit_trn!).once
+      expect(trn_request.reload.submitted_at).not_to be_nil
+    end
+  end
+
   context "when an identity submission is replayed" do
     let(:trn_request) do
       create(

--- a/spec/requests/no_match_spec.rb
+++ b/spec/requests/no_match_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+# NoMatchController#create shares the same replayable side effects as
+# TrnRequestsController#update (Zendesk ticket + email, or an Identity API
+# submission). A replayed POST /no-match must not repeat them. See
+# EnforceQuestionOrder#claim_submission! for the persisted, cookie-independent
+# guard.
+RSpec.describe "NoMatch replay protection", type: :request do
+  before { FeatureFlag.activate(:service_open) }
+  after { FeatureFlag.deactivate(:service_open) }
+
+  let(:params) { { no_match_form: { try_again: "false" } } }
+
+  def stub_current_trn_request(trn_request)
+    allow_any_instance_of(NoMatchController).to receive(
+      :trn_request,
+    ).and_return(trn_request)
+  end
+
+  context "when submitting the details is replayed" do
+    let(:trn_request) { create(:trn_request, awarded_qts: false, trn: nil) }
+
+    before do
+      stub_current_trn_request(trn_request)
+      allow(ZendeskService).to receive(:create_ticket!)
+    end
+
+    it "creates a single Zendesk ticket" do
+      post no_match_path, params: params
+      post no_match_path, params: params
+
+      expect(ZendeskService).to have_received(:create_ticket!).once
+    end
+
+    it "sends the information received email only once" do
+      expect {
+        post no_match_path, params: params
+        post no_match_path, params: params
+      }.to have_enqueued_mail(TeacherMailer, :information_received).once
+    end
+  end
+
+  context "when an identity submission is replayed" do
+    let(:trn_request) do
+      create(
+        :trn_request,
+        :from_get_an_identity,
+        official_name_preferred: true,
+        awarded_qts: false,
+        trn_from_user: "1234567",
+        submitted_at: Time.current,
+      )
+    end
+
+    before do
+      stub_current_trn_request(trn_request)
+      allow(IdentityApi).to receive(:submit_trn!)
+    end
+
+    it "does not resubmit the TRN to Get An Identity" do
+      post no_match_path, params: params
+
+      expect(IdentityApi).not_to have_received(:submit_trn!)
+    end
+  end
+end

--- a/spec/requests/trn_requests_spec.rb
+++ b/spec/requests/trn_requests_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+# Guards against the request-replay issue flagged by the ITHC: a replayed (or
+# double-submitted) `PUT /trn-request` must not repeat any side effect — emails,
+# Zendesk tickets or Identity API submissions. The guard is persisted on the
+# record (`submitted_at`) rather than the session, because the cookie-based
+# session means a replayed request carries the original cookie and would not see
+# a session flag set by the first request.
+RSpec.describe "TrnRequests replay protection", type: :request do
+  before { FeatureFlag.activate(:service_open) }
+  after { FeatureFlag.deactivate(:service_open) }
+
+  let(:params) { { trn_request: { answers_checked: true } } }
+
+  def stub_current_trn_request(trn_request)
+    allow_any_instance_of(TrnRequestsController).to receive(
+      :trn_request,
+    ).and_return(trn_request)
+  end
+
+  context "when a successful TRN match is replayed" do
+    let(:trn_request) { create(:trn_request, :has_trn) }
+
+    before { stub_current_trn_request(trn_request) }
+
+    it "emails the found TRN only once" do
+      expect {
+        put trn_request_path, params: params
+        put trn_request_path, params: params
+      }.to have_enqueued_mail(TeacherMailer, :found_trn).once
+    end
+
+    it "redirects the replay to the TRN found page without reprocessing" do
+      put trn_request_path, params: params
+      put trn_request_path, params: params
+
+      expect(response).to redirect_to(trn_found_path)
+    end
+  end
+
+  context "when a request that raises a support ticket is replayed" do
+    let(:trn_request) do
+      create(:trn_request, awarded_qts: false, trn: nil)
+    end
+
+    before do
+      stub_current_trn_request(trn_request)
+      allow(DqtApi).to receive(:find_trn!).and_raise(DqtApi::TooManyResults)
+      allow(ZendeskService).to receive(:create_ticket!)
+    end
+
+    it "creates a single Zendesk ticket" do
+      put trn_request_path, params: params
+      put trn_request_path, params: params
+
+      expect(ZendeskService).to have_received(:create_ticket!).once
+    end
+
+    it "sends the information received email only once" do
+      expect {
+        put trn_request_path, params: params
+        put trn_request_path, params: params
+      }.to have_enqueued_mail(TeacherMailer, :information_received).once
+    end
+  end
+
+  context "when no TRN is found" do
+    let(:trn_request) do
+      create(:trn_request, awarded_qts: false, trn: nil)
+    end
+
+    before { stub_current_trn_request(trn_request) }
+
+    it "releases the claim so the user can correct and resubmit" do
+      allow(DqtApi).to receive(:find_trn!).and_raise(DqtApi::NoResults)
+      put trn_request_path, params: params
+
+      expect(response).to redirect_to(no_match_path)
+      expect(trn_request.reload.submitted_at).to be_nil
+    end
+
+    it "processes a corrected resubmission after a no match" do
+      allow(DqtApi).to receive(:find_trn!).and_raise(DqtApi::NoResults)
+      put trn_request_path, params: params
+
+      allow(DqtApi).to receive(:find_trn!).and_return(
+        "trn" => "1234567", "hasActiveSanctions" => false,
+      )
+      expect { put trn_request_path, params: params }.to have_enqueued_mail(
+        TeacherMailer,
+        :found_trn,
+      ).once
+    end
+  end
+
+  context "when an identity submission is replayed" do
+    let(:trn_request) do
+      create(
+        :trn_request,
+        :has_trn,
+        :from_get_an_identity,
+        official_name_preferred: true,
+        submitted_at: Time.current,
+      )
+    end
+
+    before do
+      stub_current_trn_request(trn_request)
+      allow(IdentityApi).to receive(:submit_trn!)
+    end
+
+    it "does not resubmit the TRN to Get An Identity" do
+      put trn_request_path, params: params
+
+      expect(IdentityApi).not_to have_received(:submit_trn!)
+    end
+  end
+end

--- a/spec/requests/trn_requests_spec.rb
+++ b/spec/requests/trn_requests_spec.rb
@@ -116,4 +116,35 @@ RSpec.describe "TrnRequests replay protection", type: :request do
       expect(IdentityApi).not_to have_received(:submit_trn!)
     end
   end
+
+  # A Get An Identity request can fall back to a Zendesk ticket (e.g. the DQT
+  # lookup raises TooManyResults), leaving both zendesk_ticket_id and
+  # from_get_an_identity? set. Its replay belongs on the helpdesk page, not back
+  # at the identity host, so the ticket outcome must take precedence over the
+  # identity redirect — even while session[:identity_redirect_url] is still set.
+  context "when an identity request that raised a ticket is replayed" do
+    let(:trn_request) do
+      create(
+        :trn_request,
+        :has_zendesk_ticket,
+        :from_get_an_identity,
+        official_name_preferred: true,
+        awarded_qts: false,
+        trn_from_user: "1234567",
+        submitted_at: Time.current,
+      )
+    end
+
+    before do
+      stub_current_trn_request(trn_request)
+      allow_any_instance_of(TrnRequestsController).to receive(:session)
+        .and_return({ identity_redirect_url: "https://identity.example/back" })
+    end
+
+    it "redirects the replay to the helpdesk page, not the identity host" do
+      put trn_request_path, params: params
+
+      expect(response).to redirect_to(helpdesk_request_submitted_path)
+    end
+  end
 end


### PR DESCRIPTION
### Context

The FaLTRN ITHC flagged that a **replayed request** to the check-answers submission
endpoint can email a user multiple times. The endpoint is `TrnRequestsController#update`.

Investigating the full action showed the duplicate email is one of **three** replayable
side effects — the action had no idempotency guard at all: the found-TRN email, the
`IdentityApi.submit_trn!` Get-An-Identity submission, and the `ZendeskService.create_ticket!`
support ticket (plus its `information_received` email). `NoMatchController#create` carries
the identical unguarded submit-and-ticket code, so it is fixed here too.

The requirement was phrased "once per **session**", but the session store is
`:cookie_store`: a replayed request carries the captured original cookie, so any session
flag written by the first request is absent from the replay. The guard must therefore be
persisted on the `TrnRequest` record, not in the session — "once per session" is "once per
`TrnRequest`", since each session owns one record.

### Changes proposed in this pull request

A single persisted **claim** marker (`submitted_at`) on `TrnRequest`, plus an atomic
claim/release guard in the shared `EnforceQuestionOrder` concern:

- `claim_submission!` does an atomic conditional `UPDATE ... WHERE submitted_at IS NULL`.
  The first request wins; any replay or near-simultaneous double-submit fails the claim and
  is short-circuited to the already-computed outcome via `redirect_to_completed_submission`,
  with no repeated side effect. This also closes the TOCTOU window where two concurrent
  requests could both create a Zendesk ticket.
- `release_submission!` clears the claim on branches that produced no side effect (a
  `NoResults` no-match, or a Zendesk connection error before the ticket committed), so the
  user can correct their answers and resubmit. It writes via `update_all` to mirror the
  claim, because the in-memory record is unaware of the claim and an attribute assignment
  would be a no-op.
- `redirect_to_completed_submission` routes a replay to its existing outcome, checking a
  raised Zendesk ticket **before** the identity branch: a Get-An-Identity request that fell
  back to a ticket has both `zendesk_ticket_id` and `from_get_an_identity?` set and belongs
  on the helpdesk page, not back at the identity host.

Delivered as four atomic commits so the two endpoints stay segmentable:

| Commit                                                   | Scope                                                                        |
|----------------------------------------------------------|------------------------------------------------------------------------------|
| Prevent request replay in `TrnRequestsController#update` | migration, `submitted_at`, concern guard, `update` wiring, request spec      |
| Prevent request replay in `NoMatchController#create`     | reuse the guard on the `/no-match` submit branch, request spec               |
| Release the submission claim when a no-match ticket fails | release + re-raise on `ZendeskService::ConnectionError`, request spec        |
| Route a replayed ticket submission to the helpdesk over identity | ticket-over-identity precedence in the redirect, request spec         |

**Side effects to note:** existing rows keep `submitted_at` NULL (= not yet submitted),
which is safe — their sessions are long gone. No index or backfill.

**Assumption:** the session store staying cookie-based is what makes the persisted guard
necessary; a server-side session store would allow a session flag instead.

### Guidance to review

Using browser DevTools:

1. Open DevTools → Network, tick Preserve log.
1. Complete a real journey to the check-answers page. Click the final submit — this is request #1 (the legitimate one; it produces the side effect).
1. Connect to the Review App console by running `PR_NUMBER=1292 make review console`
1. Note down the submitted_at for the latest TrnRequest record.
1. In the Network list find the PUT /trn-request (or POST /no-match for that endpoint). Right-click → Copy → Copy as cURL. That command bundles the Cookie header (session) and the form body (authenticity_token + trn_request[answers_checked]=true) exactly as sent.
1. Paste it into a terminal and run it. That run is request #2 — the replay.
1. Reload the latest TrnRequest record and confirm that the submitted_at has not changed. This confirms that the repeated request was a no-op.

### Link to Github ticket

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/310

### Checklist

- [x] Attach to Github ticket
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
