### PR TITLE
Refer to a GitHub issue in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,13 +15,13 @@
 <!-- How could someone else check this work? -->
 <!-- Which parts do you want more feedback on? -->
 
-### Link to Trello card
+### Link to GitHub issue
 
-<!-- http://trello.com/123-example-card -->
+<!-- https://github.com/DFE-Digital/find-a-lost-trn/issues/123 -->
 
 ### Checklist
 
-- [ ] Attach to Trello card
+- [ ] Attach to GitHub issue
 - [ ] Rebased main
 - [ ] Cleaned commit history
 - [ ] Tested by running locally


### PR DESCRIPTION
### Context

The service tracks work in GitHub issues, but the pull request template still pointed
contributors at a Trello card — a stale reference that doesn't match how the team works.

### Changes proposed in this pull request

Update `.github/pull_request_template.md` so its link section and checklist item refer to a
GitHub issue instead of a Trello card:

- `### Link to Trello card` → `### Link to GitHub issue`
- example comment now points at a `find-a-lost-trn/issues/` URL
- checklist item `Attach to Trello card` → `Attach to GitHub issue`

No behaviour change — documentation/template only.

### Guidance to review

Read the diff on `.github/pull_request_template.md`; this PR's own body uses the new
`### Link to GitHub issue` heading as a live example of the result.

### Link to GitHub issue

<!-- No tracking issue — small template correction. -->

### Checklist

- [ ] Attach to GitHub issue
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
