### PR TITLE
Resolve console namespace and app name from tfvars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,9 @@ get-cluster-credentials: set-azure-account ## make <config> get-cluster-credenti
 	kubelogin convert-kubeconfig -l $(if ${AAD_LOGIN_METHOD},${AAD_LOGIN_METHOD},azurecli)
 
 console: get-cluster-credentials
-	kubectl -n tra-${DEPLOY_ENV} exec -ti --tty deployment/find-a-lost-trn-${DEPLOY_ENV} -- /bin/sh -c 'cd /app && /usr/local/bin/bundle exec rails c'
+	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/aks/workspace_variables/$(CONFIG).tfvars.json))
+	$(eval APP_ENV=$(shell jq -r '.app_environment' terraform/aks/workspace_variables/$(CONFIG).tfvars.json)$(env))
+	kubectl -n $(NAMESPACE) exec -ti --tty deployment/find-a-lost-trn-$(APP_ENV) -- /bin/sh -c 'cd /app && /usr/local/bin/bundle exec rails c'
 
 maintenance-image-push:
 	$(if ${GITHUB_TOKEN},, $(error Provide a valid Github token with write:packages permissions as GITHUB_TOKEN variable))


### PR DESCRIPTION
### Context

`PR_NUMBER=xxxx make review console` failed with
`Error from server (Forbidden): deployments.apps "find-a-lost-trn-review" is forbidden`.

The `console` target derived both the kubectl namespace and the deployment name from
`DEPLOY_ENV` alone, so review sessions targeted `tra-review` / `find-a-lost-trn-review` —
a namespace that does not exist, with the `PR_NUMBER` suffix dropped entirely. The real
review app lives in `tra-development` as `find-a-lost-trn-review-pr-<PR_NUMBER>`.

### Changes proposed in this pull request

The `console` target now reads `namespace` and `app_environment` from the per-`CONFIG`
`terraform/aks/workspace_variables/<CONFIG>.tfvars.json` — the same authoritative source
CI reads via `jq` — and appends the existing `$(env)` suffix set by the `review` target.

Resolved targets after the change:

| Env (CONFIG)       | Namespace         | Deployment                       | vs. before         |
| ------------------ | ----------------- | -------------------------------- | ------------------ |
| development        | `tra-development` | `find-a-lost-trn-development`    | unchanged          |
| test               | `tra-test`        | `find-a-lost-trn-test`           | unchanged          |
| production         | `tra-production`  | `find-a-lost-trn-production`     | unchanged          |
| preproduction      | `tra-test`        | `find-a-lost-trn-preproduction`  | namespace fixed    |
| review (PR `xxxx`) | `tra-development` | `find-a-lost-trn-review-pr-xxxx` | both fixed         |

Side effect worth noting: this also corrects `preproduction`, whose namespace is `tra-test`
rather than the `tra-preproduction` that `DEPLOY_ENV` produced. `jq` is already a required
tool in the Makefile, so no new dependency. No change to the `review` target — it already
sets `env=-pr-$(PR_NUMBER)`.

### Guidance to review

- `make -n review console PR_NUMBER=<n>` prints the resolved `kubectl` line without connecting;
  confirm it references `-n tra-development` and `deployment/find-a-lost-trn-review-pr-<n>`.
- `make -n development console` (or test/production) still resolves to `tra-<env>` /
  `find-a-lost-trn-<env>` as before.
- End-to-end check needs an actually-deployed review app (a PR with the `deploy` label).

### Link to Trello card

<!-- none -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
